### PR TITLE
20172-Modify FileReference>>moveTo: to work across file systems / devices

### DIFF
--- a/src/FileSystem-Core.package/FileReference.class/instance/copyTo..st
+++ b/src/FileSystem-Core.package/FileReference.class/instance/copyTo..st
@@ -2,7 +2,4 @@ operations
 copyTo: aReference
 	self isDirectory
 		ifTrue: [ aReference ensureCreateDirectory ]
-		ifFalse: [ 
-			filesystem = aReference fileSystem
-				ifTrue: [ filesystem copy: path to: aReference resolve path ]
-				ifFalse: [ filesystem copy: path toReference: aReference ] ]
+		ifFalse: [ filesystem copy: path toReference: aReference ]

--- a/src/FileSystem-Core.package/FileReference.class/instance/moveTo..st
+++ b/src/FileSystem-Core.package/FileReference.class/instance/moveTo..st
@@ -3,7 +3,7 @@ moveTo: aReference
 	
 	| result |
 	result := self fileSystem 
-		rename: self path
-		to: aReference resolve path.
+		move: self path
+		to: aReference resolve.
 	result ifNotNil: [
-		self setFileSystem: filesystem path: aReference path ].		
+		self setFileSystem: result fileSystem path: result path ].		

--- a/src/FileSystem-Core.package/FileSystem.class/instance/copy.toReference..st
+++ b/src/FileSystem-Core.package/FileSystem.class/instance/copy.toReference..st
@@ -1,12 +1,6 @@
-private
-copy: aPath toReference: destRef
-	| inputStream path |
-	
-	path := self resolve: aPath.
-	
-	[
-	inputStream := self readStreamOn: path.
-	inputStream ifNil: [ store signalFileDoesNotExist: path ].
-	destRef fileSystem copyFrom: inputStream to: destRef path 
-	
-		] ensure: [ inputStream ifNotNil: [ inputStream close ]]
+public
+copy: aPath toReference: destinationReference
+
+	^self = destinationReference fileSystem
+		ifTrue: [ self copy: aPath to: destinationReference resolve path ]
+		ifFalse: [ self copy: aPath toRemote: destinationReference ]

--- a/src/FileSystem-Core.package/FileSystem.class/instance/copy.toRemote..st
+++ b/src/FileSystem-Core.package/FileSystem.class/instance/copy.toRemote..st
@@ -1,0 +1,8 @@
+public
+copy: aPath toRemote: destRef
+	| inputStream path |
+	path := self resolve: aPath.
+	[ inputStream := self readStreamOn: path.
+	inputStream ifNil: [ store signalFileDoesNotExist: path ].
+	destRef fileSystem copyFrom: inputStream to: destRef path ]
+		ensure: [ inputStream ifNotNil: [ inputStream close ] ]

--- a/src/FileSystem-Core.package/FileSystem.class/instance/copyAndDelete.to..st
+++ b/src/FileSystem-Core.package/FileSystem.class/instance/copyAndDelete.to..st
@@ -1,0 +1,14 @@
+public
+copyAndDelete: sourcePath to: destination
+	"Copy the file referenced as sourcePath to the destination referred as destPath.  
+	If there is no file at sourcePath, raise FileDoesNotExist.
+	If destPath is a file, raise FileExists.
+	If an error occurs during the operation, try and roll back to the original state."
+	
+	[
+		self copy: sourcePath toReference: destination.
+		self delete: sourcePath.
+	] on: Error do: [ :error |
+		destination delete.
+		error signal.
+	]

--- a/src/FileSystem-Core.package/FileSystem.class/instance/move.to..st
+++ b/src/FileSystem-Core.package/FileSystem.class/instance/move.to..st
@@ -1,0 +1,23 @@
+public
+move: sourcePath to: destination
+	"Move the file /directory referenced as sourcePath to the destination referred as destPath.  
+	If there is no file at sourcePath, raise FileDoesNotExist.
+	If destPath is a file, raise FileExists.
+	If destPath is a directory, move the sourcePath in to the directory"
+
+	| fullDestination |
+
+	destination isFile ifTrue: [ FileExists signalWith: destination ].
+	destination isDirectory
+		ifTrue: [ fullDestination := destination / sourcePath basename ]
+		ifFalse: [ fullDestination := destination ].
+	self = destination fileSystem ifTrue: 
+	[
+		"Ideally we would test whether the source and destination are on the same filesystem from the OSs perspective.
+		Since we can't do that, just try rename, and if that fails, copy and delete."
+		[ self rename: sourcePath to: fullDestination resolve path ]
+			on: Error
+			do: [ :error | self copyAndDelete: sourcePath to: fullDestination ].
+	] ifFalse:
+		[ self copyAndDelete: sourcePath to: fullDestination ].
+	^fullDestination

--- a/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/testCopyAndDelete.st
+++ b/src/FileSystem-Tests-Core.package/FileSystemTest.class/instance/testCopyAndDelete.st
@@ -1,0 +1,23 @@
+tests
+testCopyAndDelete
+	"Check that FileSystem>>copyAndDelete:to: works within a filesystem.
+	DiskFileSystemTest>>testMoveMemoryToDisk checks that #copyAndDelete:to: works across filesystems."
+	| folder testString f1 f1s f2 |
+	
+	folder := filesystem workingDirectory.
+	testString := 'To be copied and deleted'.
+
+	f1 := folder / 'f1'.
+	f1s := f1 writeStream.
+	[ f1s nextPutAll: testString ] ensure: [ f1s close ].
+	f2 := folder / 'f2'.
+	
+	"Cleanup after running"
+	self 
+		markForCleanup: f1;
+		markForCleanup: f2.	
+	
+	filesystem copyAndDelete: f1 to: f2.
+	self deny: f1 exists.
+	self assert: f2 exists.
+	self assert: f2 contents equals: testString.

--- a/src/FileSystem-Tests-Disk.package/DiskFileSystemTest.class/instance/testMoveMemoryToDisk.st
+++ b/src/FileSystem-Tests-Disk.package/DiskFileSystemTest.class/instance/testMoveMemoryToDisk.st
@@ -1,0 +1,22 @@
+tests
+testMoveMemoryToDisk
+	"Test moving a file from the memory filesystem to the disk filesystem.
+	This ensures that the copyAndDelete:to: is called correctly."
+	| memfs out testString old new |
+	[
+		memfs := FileSystem memory.
+		old := memfs / 'testMoveMemoryToDisk_old'.
+		out := old writeStream.
+		testString := 'To be moved to disk'.
+		[ out nextPutAll: testString ] ensure: [ out close ].
+		
+		new := FileLocator imageDirectory / 'testMoveMemoryToDisk_new'.
+		old moveTo: new.
+		
+		self deny: (memfs / 'testMoveMemoryToDisk_old') exists.
+		self assert: new exists.
+		self assert: new contents equals: testString.
+	] ensure: [ 
+		old ensureDelete.
+		new ensureDelete.
+	]


### PR DESCRIPTION
See https://pharo.fogbugz.com/f/cases/20172/FileReference-moveTo-fails-if-destination-is-on-different-device

FileReference>>moveTo: is currently a synonym for renameTo:.  This causes it to fail if the destination is on a different device / file system to the source.

This can easily be reproduced by running FileLocatorTest>>testMoveTo with the image on a different device to the home directory (e.g. on Ubuntu, put the image somewhere on /dev/shm).