### PR TITLE
20164-Cache the default working directory within a session

### DIFF
--- a/src/FileSystem-Disk.package/DiskStore.class/class/defaultWorkingDirectory.st
+++ b/src/FileSystem-Disk.package/DiskStore.class/class/defaultWorkingDirectory.st
@@ -1,0 +1,8 @@
+accessing
+defaultWorkingDirectory
+	"Ask the VM for the default working directory.
+	Clients should normally use the instance side method which caches this value."
+	| pathString |
+
+	pathString := Primitives decode: Primitives imageFile.
+	^(Path from: pathString delimiter: self delimiter) parent

--- a/src/FileSystem-Disk.package/DiskStore.class/class/reset.st
+++ b/src/FileSystem-Disk.package/DiskStore.class/class/reset.st
@@ -1,3 +1,4 @@
 current
 reset
+	DefaultWorkingDirectory := nil.
 	CurrentFS := nil

--- a/src/FileSystem-Disk.package/DiskStore.class/class/startUp..st
+++ b/src/FileSystem-Disk.package/DiskStore.class/class/startUp..st
@@ -2,4 +2,5 @@ system startup
 startUp: resuming
 	self checkVMVersion.
 	resuming 
-		ifTrue: [ self reset ]
+		ifTrue: [ self reset ].
+	DefaultWorkingDirectory := self defaultWorkingDirectory.

--- a/src/FileSystem-Disk.package/DiskStore.class/instance/defaultWorkingDirectory.st
+++ b/src/FileSystem-Disk.package/DiskStore.class/instance/defaultWorkingDirectory.st
@@ -1,5 +1,6 @@
 accessing
 defaultWorkingDirectory
-	| pathString |
-	pathString := Primitives decode: Primitives imageFile.
-	^ (self pathFromString: pathString) parent
+	"Answer the default working directory, which is defined as the directory where the image resides."
+
+	^ DefaultWorkingDirectory
+		ifNil: [ self class defaultWorkingDirectory ]

--- a/src/FileSystem-Disk.package/DiskStore.class/properties.json
+++ b/src/FileSystem-Disk.package/DiskStore.class/properties.json
@@ -6,6 +6,7 @@
 	"pools" : [ ],
 	"classvars" : [
 		"CurrentFS",
+		"DefaultWorkingDirectory",
 		"Primitives"
 	],
 	"instvars" : [


### PR DESCRIPTION
DiskStore>>defaultWorkingDirectory currently:

1. Calls a primitive to get the image path
2. Converts the resulting string to a byte array
3. Converts the byte array back to a string with ZnCharacterEncoder
4. Converts the string to a path and gets the parent

every time it is called.

As an example of how often it can be called: Using Iceberg to clone an
empty repository, add a small package and synchronise the repository
called #defaultWorkingDirectory around 500 times.  It is called so many
times because FileSystem>>resolve: leads to FileSystem>>resolvePath:
which resolves the supplied path against the working directory, and
#resolve: is called from many places.  (The number of calls to
#defaultWorkingDirectory can vary significantly based on the
environment, but you get the idea).

The value of defaultWorkingDirectory only changes on startup and when the image is saved to a different location.

Caching defaultWorkingDirectory in a class variable and managing the
cache through session startup and shutdown gives around a 1,000 times performance improvement in #defaultWorkingDirectory.