### PR TITLE
20189: FileReference>>= considers same file different

### DIFF
--- a/src/FileSystem-Core.package/FileReference.class/instance/^equals.st
+++ b/src/FileSystem-Core.package/FileReference.class/instance/^equals.st
@@ -1,5 +1,8 @@
 comparing
 = other
+	"Two FileReferences are considered equal if they refer to the same file / directory.
+	As paths can have multiple relative representations, compare the absolute paths."
+	"Perform the path comparison last as conversion to absolute paths is relatively expensive"
 	^ self species = other species
-		and: [self path = other path
-			and: [self fileSystem = other fileSystem]]
+		and: [self fileSystem = other fileSystem
+			and: [self absolutePath = other absolutePath]]

--- a/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEqualityRelativeVsAbsolute.st
+++ b/src/FileSystem-Tests-Core.package/FileReferenceTest.class/instance/testEqualityRelativeVsAbsolute.st
@@ -1,0 +1,8 @@
+tests
+testEqualityRelativeVsAbsolute
+
+	| f1 f2 |
+
+	f1 := FileLocator workingDirectory / 'pharo-local'.
+	f2 := f1 asAbsolute.
+	self assert: f1 equals: f2


### PR DESCRIPTION
FileReference>>= currently performs a simplistic path comparison to
determine if two FileReferences are the same.

This means that an absolute reference and a relative reference to the
same file will be flagged as different files.

The (soon to be supplied) Pull Request modifies FileReference>>= to
make the paths absolute as part of the comparison, causing the two
FileReferences to be considered equal.

As an example, in Pharo6:

| f1 f2 |

f1 := FileLocator workingDirectory / 'pharo-local'.
f2 := f1 asAbsolute.
f1 = f2
" false"

After this PR, the above answers true.