### PR TITLE
20198-inner-structure-access-does-not-work-on-multiple-architecture

### DIFF
--- a/src/UnifiedFFI.package/ExternalType.extension/instance/offsetReadFieldAt..st
+++ b/src/UnifiedFFI.package/ExternalType.extension/instance/offsetReadFieldAt..st
@@ -28,14 +28,7 @@ offsetReadFieldAt: offsetVariableName
 						nextPut: $)]]].
 
 	self isAtomic ifFalse: "structure type"
-		[^String streamContents:[:s|
-			s nextPutAll:'^';
-				print: referentClass;
-				nextPutAll:' fromHandle: (handle structAt: ';
-				nextPutAll: offsetVariableName;
-				nextPutAll:' length: ';
-				print: self byteSize;
-				nextPutAll:')']].
+		[^ self offsetReadStructFieldAt: offsetVariableName ].
 
 	"Atomic non-pointer types"
 	^String streamContents:

--- a/src/UnifiedFFI.package/ExternalType.extension/instance/offsetReadStructFieldAt..st
+++ b/src/UnifiedFFI.package/ExternalType.extension/instance/offsetReadStructFieldAt..st
@@ -1,0 +1,6 @@
+*UnifiedFFI
+offsetReadStructFieldAt: offsetVariableName
+	^ '^ {1} fromHandle: (handle structAt: {2} length: {1} byteSize)' 
+		format: { 
+			referentClass name.
+			offsetVariableName }

--- a/src/UnifiedFFI.package/ExternalType.extension/instance/offsetWriteFieldAt.with..st
+++ b/src/UnifiedFFI.package/ExternalType.extension/instance/offsetWriteFieldAt.with..st
@@ -17,15 +17,7 @@ offsetWriteFieldAt: offsetVariableName with: valueName
 				nextPutAll:' getHandle.']].
 
 	self isAtomic ifFalse:[
-		^String streamContents:[:s|
-			s nextPutAll:'handle structAt: ';
-				nextPutAll: offsetVariableName;
-				nextPutAll:' put: ';
-				nextPutAll: valueName;
-				nextPutAll:' getHandle';
-				nextPutAll:' length: ';
-				print: self byteSize;
-				nextPutAll:'.']].
+		^ self offsetWriteStructFieldAt: offsetVariableName with: valueName ].
 
 	^String streamContents:[:s|
 		s nextPutAll:'handle ';

--- a/src/UnifiedFFI.package/ExternalType.extension/instance/offsetWriteStructFieldAt.with..st
+++ b/src/UnifiedFFI.package/ExternalType.extension/instance/offsetWriteStructFieldAt.with..st
@@ -1,0 +1,7 @@
+*UnifiedFFI
+offsetWriteStructFieldAt: offsetVariableName with: valueName
+	^ 'handle structAt: {1} put: {2} getHandle length: {3} byteSize' 
+		format: {
+			offsetVariableName. 
+			valueName. 
+			referentClass name }

--- a/src/UnifiedFFI.package/FFICallbackType.class/instance/offsetWriteFieldAt.with..st
+++ b/src/UnifiedFFI.package/FFICallbackType.class/instance/offsetWriteFieldAt.with..st
@@ -1,4 +1,12 @@
 emitting code
 offsetWriteFieldAt: offsetVariableName with: valueName
+	| cr tab |
+	cr := String cr.
+	tab := String tab.
 	^ String streamContents: [ :stream | 
-		stream << 'handle pointerAt: ' << offsetVariableName << ' put: (ExternalAddress fromAddress: anObject thunk address)' ]
+		stream 
+			<< 'handle ' << cr 
+			<< tab << tab << 'pointerAt: ' << offsetVariableName << cr 
+			<< tab << tab << 'put: (anObject ' << cr 
+			<< tab << tab << tab << 'ifNotNil: [ ExternalAddress fromAddress: anObject thunk address ]' << cr
+			<< tab << tab << tab << 'ifNil: [ ExternalAddress null ])' ]

--- a/src/UnifiedFFI.package/FFIExternalStructure.class/class/structureAlignment.st
+++ b/src/UnifiedFFI.package/FFIExternalStructure.class/class/structureAlignment.st
@@ -1,4 +1,4 @@
 accessing
 structureAlignment
-	externalStructureAlignment ifNil: [ self compileFields: self fields withAccessors: false ].
+	externalStructureAlignment ifNil: [ self compileFields ].
 	^ externalStructureAlignment

--- a/src/UnifiedFFI.package/FFIExternalStructureReferenceHandle.class/instance/getHandle.st
+++ b/src/UnifiedFFI.package/FFIExternalStructureReferenceHandle.class/instance/getHandle.st
@@ -1,0 +1,3 @@
+accessing
+getHandle
+	^ handle

--- a/src/UnifiedFFI.package/FFIExternalStructureType.class/instance/offsetReadReferenceAt..st
+++ b/src/UnifiedFFI.package/FFIExternalStructureType.class/instance/offsetReadReferenceAt..st
@@ -1,11 +1,4 @@
 emitting code
 offsetReadReferenceAt: offsetVariableName
-	^ String streamContents:[ :stream|
-		stream 
-			nextPutAll:'^';
-			print: self objectClass;
-			nextPutAll:' fromHandle: (handle referenceStructAt: ';
-			nextPutAll: offsetVariableName;
-			nextPutAll:' length: ';
-			print: self externalTypeSize;
-			nextPutAll:')' ].
+	^ '^ {1} fromHandle: (handle referenceStructAt: {2} length: {1} byteSize)'
+		format: { self objectClass name. offsetVariableName }

--- a/src/UnifiedFFI.package/FFIExternalStructureType.class/instance/readReferenceAt..st
+++ b/src/UnifiedFFI.package/FFIExternalStructureType.class/instance/readReferenceAt..st
@@ -1,11 +1,6 @@
 emitting code
 readReferenceAt: byteOffset
-	^ String streamContents:[ :stream|
-		stream 
-			nextPutAll:'^';
-			print: self objectClass;
-			nextPutAll:' fromHandle: (handle referenceStructAt: ';
-			print: byteOffset;
-			nextPutAll:' length: ';
-			print: self externalTypeSize;
-			nextPutAll:')' ].
+	^ '^ {1} fromHandle: (handle referenceStructAt: {2} length: {1} byteSize)'
+		format: { 
+			self objectClass name.
+			byteOffset }

--- a/src/UnifiedFFI.package/FFISizeT.class/class/asExternalTypeOn..st
+++ b/src/UnifiedFFI.package/FFISizeT.class/class/asExternalTypeOn..st
@@ -1,5 +1,4 @@
 converting
 asExternalTypeOn: generator
-	self pointerSize = 4 ifTrue: [ ^ generator resolveType: #uint32 ].
-	self pointerSize = 8 ifTrue: [ ^ generator resolveType: #uint64 ].
-	self error: 'no clue'
+	"We resolve size_t to a uint/ulong which may be not the case always"
+	^ generator resolveType: #ulong

--- a/src/UnifiedFFI.package/FFISizeT.class/instance/basicHandle.at..st
+++ b/src/UnifiedFFI.package/FFISizeT.class/instance/basicHandle.at..st
@@ -1,4 +1,3 @@
 private
 basicHandle: aHandle at: index
-	self flag: #todo. "x64"
-	^ aHandle unsignedLongAt: index
+	^ aHandle platformUnsignedLongAt: index

--- a/src/UnifiedFFI.package/FFISizeT.class/instance/basicHandle.at.put..st
+++ b/src/UnifiedFFI.package/FFISizeT.class/instance/basicHandle.at.put..st
@@ -1,4 +1,3 @@
 private
 basicHandle: aHandle at: index put: value
-	self flag: #todo. "x64"
-	^ aHandle unsignedLongAt: index put: value
+	^ aHandle platformUnsignedLongAt: index put: value

--- a/src/UnifiedFFI.package/FFISizeT.class/instance/readFieldAt..st
+++ b/src/UnifiedFFI.package/FFISizeT.class/instance/readFieldAt..st
@@ -1,0 +1,7 @@
+emitting code
+readFieldAt: byteOffset
+	self isPointer ifTrue: [ 
+		^ self pointerReadFieldAt: byteOffset ].
+
+	^ String streamContents: [ :stream |
+		stream << '^handle platformUnsignedLongAt: ' << byteOffset asString ].

--- a/src/UnifiedFFI.package/FFISizeT.class/instance/writeFieldAt.with..st
+++ b/src/UnifiedFFI.package/FFISizeT.class/instance/writeFieldAt.with..st
@@ -1,0 +1,11 @@
+emitting code
+writeFieldAt: byteOffset with: valueName
+	self isPointer ifTrue: [ 
+		^ self externalTypeWithArity 
+			writeFieldAt: byteOffset
+			with: valueName ].
+
+	^ String streamContents: [ :stream |
+		stream 
+			<< '^handle platformUnsignedLongAt: ' << byteOffset asString
+			<< ' put: ' << valueName ]


### PR DESCRIPTION
fixed for 6.0, now porting it here