### PR TITLE
17848-SequenciableCollection-first-raise-an-Error-if-the-collection-if-too-small

### DIFF
--- a/src/Collections-Sequenceable.package/OrderedCollection.class/instance/postCopyFrom.to..st
+++ b/src/Collections-Sequenceable.package/OrderedCollection.class/instance/postCopyFrom.to..st
@@ -5,9 +5,9 @@ postCopyFrom: startIndex to: endIndex
 	endIndex < startIndex ifFalse: [
 		"Because actual size of the array may be greater than used size,
 		postCopyFrom:to: may fail to fail and answer an incorrect result
-		if this sanity check were not applied"
-		(startIndex between: 1 and: self size) ifFalse: [^self error: 'startIndex is out of bounds'].
-		(endIndex between: 1 and: self size) ifFalse: [^self error: 'endIndex is out of bounds']].
+		if this sanity check were not applied."
+		(startIndex between: 1 and: self size) ifFalse: [^SubscriptOutOfBounds signalFor: startIndex lowerBound: (1 min: self size) upperBound: self size in: self].
+		(endIndex between: 1 and: self size) ifFalse: [^SubscriptOutOfBounds signalFor: endIndex lowerBound: (1 min: self size) upperBound: self size in: self]].
 	
 	"Add a protection that lacks in Array>>postcopy"
 	array := array copyFrom: startIndex + firstIndex - 1 to: (endIndex max: startIndex - 1) + firstIndex - 1.

--- a/src/Collections-Tests.package/TSubCollectionAccess.trait/instance/testFirstNElements.st
+++ b/src/Collections-Tests.package/TSubCollectionAccess.trait/instance/testFirstNElements.st
@@ -1,12 +1,9 @@
 tests - subcollections access
 testFirstNElements
 	"self debug: #testFirstNElements"
+
 	| result |
 	result := self moreThan3Elements first: self moreThan3Elements size - 1.
-	1 
-		to: result size
-		do: [ :i | self assert: (result at: i) = (self moreThan3Elements at: i) ].
+	1 to: result size do: [ :i | self assert: (result at: i) = (self moreThan3Elements at: i) ].
 	self assert: result size = (self moreThan3Elements size - 1).
-	self 
-		should: [ self moreThan3Elements first: self moreThan3Elements size + 1 ]
-		raise: Error
+	self should: [ self moreThan3Elements first: self moreThan3Elements size + 1 ] raise: SubscriptOutOfBounds


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/17848/SequenciableCollection-first-raise-an-Error-if-the-collection-if-too-small