### PR TITLE
19396-Smalltalk-globals-classNamed-should-not-return-nil

### DIFF
--- a/src/System-Support.package/ClassNotFound.class/README.md
+++ b/src/System-Support.package/ClassNotFound.class/README.md
@@ -1,0 +1,8 @@
+I represent an error produced when asking globals SystemDictionary for a class that doesn't exist.
+
+Example:
+Smalltalk globals classNamed: #Number. "=> Number"
+Smalltalk  globals classNamed: #notExistedClass. "=> ClassNotFound error"
+
+Object environment classNamed: #Number. "=> Number"
+Object environment classNamed: #notExistedClass. "=> ClassNotFound error"

--- a/src/System-Support.package/ClassNotFound.class/properties.json
+++ b/src/System-Support.package/ClassNotFound.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "OleksandrZaytsev 5/7/2017 18:07",
+	"super" : "Error",
+	"category" : "System-Support",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ClassNotFound",
+	"type" : "normal"
+}

--- a/src/System-Support.package/SystemDictionary.class/instance/classOrTraitNamed..st
+++ b/src/System-Support.package/SystemDictionary.class/instance/classOrTraitNamed..st
@@ -16,9 +16,12 @@ classOrTraitNamed: aString
 				ifFalse: [ 
 					meta := false.
 					baseName := aString ] ].
-	^self at: baseName asSymbol ifPresent:
-            [ :global |
-               (global isBehavior or: [global isTrait])ifTrue:
-                       [ meta
-                               ifFalse: [ global ]
-                               ifTrue: [ global classSide ]]]
+	^self at: baseName asSymbol
+		ifPresent: [ :global |
+   			(global isBehavior or: [global isTrait])
+				ifTrue: [
+					meta
+						ifFalse: [ global ]
+						ifTrue: [ global classSide ] ] ]
+		ifAbsent: [ 
+			ClassNotFound signal ].

--- a/src/System-SupportTests.package/ClassQueryTest.class/instance/testClassNotFound.st
+++ b/src/System-SupportTests.package/ClassQueryTest.class/instance/testClassNotFound.st
@@ -1,0 +1,12 @@
+tests
+testClassNotFound
+	
+	| correctErrorRaised |
+	
+	correctErrorRaised := false.
+	
+	[ Smalltalk globals classNamed: #notExistedClass ]
+		on: ClassNotFound do: [
+			correctErrorRaised := true. ].
+		
+    self assert: correctErrorRaised.

--- a/src/System-SupportTests.package/ClassQueryTest.class/instance/testClassNotFound.st
+++ b/src/System-SupportTests.package/ClassQueryTest.class/instance/testClassNotFound.st
@@ -1,12 +1,4 @@
 tests
 testClassNotFound
 	
-	| correctErrorRaised |
-	
-	correctErrorRaised := false.
-	
-	[ Smalltalk globals classNamed: #notExistedClass ]
-		on: ClassNotFound do: [
-			correctErrorRaised := true. ].
-		
-    self assert: correctErrorRaised.
+     self should: [ Smalltalk globals classNamed: #notExistedClass ] raise: ClassNotFound


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/19396/Smalltalk-globals-classNamed-should-not-return-nil