### PR TITLE
20213-SpecDebugger-label-display-session-name

### DIFF
--- a/src/Spec-Debugger.package/SpecDebugger.class/instance/session..st
+++ b/src/Spec-Debugger.package/SpecDebugger.class/instance/session..st
@@ -2,4 +2,4 @@ accessing
 session: aSession
 
 	sessionHolder value: aSession.
-	self label: aSession asString
+	self label: aSession name asString


### PR DESCRIPTION
SpecDebugger could display the name of the debug session at Pharo 5. In Pharo 6, it was not the name of the debug session, but it became a display like "a Session". This Pull Request is to fix this bug.