### PR TITLE
20231-Latin9Environment-was-not-initialized-correctly-for-the-languages-and-was-mixing-up-with-Latin1Environment

### DIFF
--- a/src/Files.package/MultiByteFileStream.class/class/initialize.st
+++ b/src/Files.package/MultiByteFileStream.class/class/initialize.st
@@ -10,4 +10,4 @@ initialize
 	LookAheadCount := 2048.
 	
 	SessionManager default registerSystemClassNamed: self name.
-	self startUp.
+	self startUp: false.

--- a/src/Files.package/MultiByteFileStream.class/class/startUp..st
+++ b/src/Files.package/MultiByteFileStream.class/class/startUp..st
@@ -1,3 +1,3 @@
 system startup
-startUp
+startUp: resuming
 	self guessDefaultLineEndConvention.

--- a/src/Multilingual-Languages.package/Latin9Environment.class/class/supportedLanguages.st
+++ b/src/Multilingual-Languages.package/Latin9Environment.class/class/supportedLanguages.st
@@ -3,4 +3,4 @@ supportedLanguages
 	"Return the languages that this class supports. 
 	Any translations for those languages will use this class as their environment."
 	
-	^#('fr' 'es' 'ca' 'eu' 'pt' 'it' 'sq' 'rm' 'nl' 'de' 'da' 'sv' 'no' 'fi' 'fo' 'is' 'ga' 'gd' 'en' 'af' 'sw')
+	^#('hu' 'sl' 'hr' 'ro' 'cs' 'sk')


### PR DESCRIPTION
I have changed the  languages for the environments to match what there is in the Pharo6 image.Latin1 languages should be: #('fr' 'es' 'ca' 'eu' 'pt' 'it' 'sq' 'rm' 'nl' 'de' 'da' 'sv' 'no' 'fi' 'fo' 'is' 'ga' 'gd' 'en' 'af' 'sw')and Latin9 Languages: #('hu' 'sl' 'hr' 'ro' 'cs' 'sk')