### PR TITLE
20233 select only the best matching package managers  in MCPackageManager class>>managersForCategory:do:

### DIFF
--- a/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/setUp.st
+++ b/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/setUp.st
@@ -1,5 +1,11 @@
-as yet unclassified
+running
 setUp
 	super setUp.
 	package1 := (RPackage named: #A, UUID new asString36) register.
 	package2 := (RPackage named: package1 name, #'-SubPart') register.
+	mcPackage1 := MCPackage named: package1 name.
+	mcPackage2 := MCPackage named: package2 name.
+	"register MC packages"
+	MCPackageManager
+		forPackage: mcPackage1;
+		forPackage: mcPackage2

--- a/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/tearDown.st
+++ b/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/tearDown.st
@@ -1,6 +1,9 @@
-as yet unclassified
+running
 tearDown
 	super tearDown.
 	
 	package1 unregister.
 	package2 unregister.
+	MCPackageManager registry
+		removeKey: mcPackage1 ifAbsent: [ ];
+		removeKey: mcPackage2 ifAbsent: [ ] 

--- a/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/testManagersForCategoryDo.st
+++ b/src/Monticello-Tests.package/MCPackageManagerTest.class/instance/testManagersForCategoryDo.st
@@ -1,0 +1,28 @@
+running
+testManagersForCategoryDo
+	"Consider the following package structure:
+		Renraku
+		Renraku-Help
+
+		and a method extension with the protocol '*renraku'.
+		MCPackageManager>>methodModified: should only mark 'Renraku' as modified,
+		not 'Renraku-Help'"
+	| managers |
+	self assert: (MCPackageManager registry includesKey: mcPackage1).
+	self assert: (MCPackageManager registry includesKey: mcPackage2).
+	
+	managers := OrderedCollection new.
+	MCPackageManager
+		managersForCategory: mcPackage1 name
+		do: [ :manager | managers add: manager ].
+		
+	self assert: managers size equals: 1.
+	self assert: managers first package == mcPackage1.
+	
+	managers := OrderedCollection new.
+	MCPackageManager
+		managersForCategory: mcPackage2 name
+		do: [ :manager | managers add: manager ].
+		
+	self assert: managers size equals: 1.
+	self assert: managers first package == mcPackage2

--- a/src/Monticello-Tests.package/MCPackageManagerTest.class/properties.json
+++ b/src/Monticello-Tests.package/MCPackageManagerTest.class/properties.json
@@ -7,7 +7,9 @@
 	"classvars" : [ ],
 	"instvars" : [
 		"package2",
-		"package1"
+		"package1",
+		"mcPackage1",
+		"mcPackage2"
 	],
 	"name" : "MCPackageManagerTest",
 	"type" : "normal"

--- a/src/Monticello.package/MCPackageManager.class/class/bestMatchingManagerForCategory.do..st
+++ b/src/Monticello.package/MCPackageManager.class/class/bestMatchingManagerForCategory.do..st
@@ -1,0 +1,16 @@
+system changes
+bestMatchingManagerForCategory: aSystemCategory do: aBlock
+	| bestMatches bestMatchingManagerAndPackage |
+	bestMatches := OrderedCollection new.
+	self registry do: [ :mgr |
+		| candidatePackages bestMatchingPackage |
+		candidatePackages := mgr packageSet packages select: [ :package |
+			package name beginsWith: aSystemCategory ].
+		bestMatchingPackage := candidatePackages detectMin: [ :package |
+			package name size ].
+		bestMatchingPackage ifNotNil: [
+			bestMatches add: mgr -> bestMatchingPackage ] ].
+	bestMatchingManagerAndPackage := bestMatches detectMin: [ :managerAndPackage |
+			managerAndPackage value package name size ].
+	bestMatchingManagerAndPackage ifNotNil: [ :managerAndPackage |
+		aBlock value: managerAndPackage key ]

--- a/src/Monticello.package/MCPackageManager.class/class/bestMatchingManagerForCategory.do..st
+++ b/src/Monticello.package/MCPackageManager.class/class/bestMatchingManagerForCategory.do..st
@@ -11,6 +11,6 @@ bestMatchingManagerForCategory: aSystemCategory do: aBlock
 		bestMatchingPackage ifNotNil: [
 			bestMatches add: mgr -> bestMatchingPackage ] ].
 	bestMatchingManagerAndPackage := bestMatches detectMin: [ :managerAndPackage |
-			managerAndPackage value package name size ].
+			managerAndPackage value name size ].
 	bestMatchingManagerAndPackage ifNotNil: [ :managerAndPackage |
 		aBlock value: managerAndPackage key ]

--- a/src/Monticello.package/MCPackageManager.class/class/managersForCategory.do..st
+++ b/src/Monticello.package/MCPackageManager.class/class/managersForCategory.do..st
@@ -5,12 +5,12 @@ managersForCategory: aSystemCategory do: aBlock
 	foundOne := false.
 	cat := aSystemCategory ifNil:[^nil]. "yes this happens; for example in eToy projects"
 	"first ask PackageInfos, their package name might not match the category"
-	self registry do: [:mgr | 
-		(mgr packageSet packages anySatisfy:[:p | p name beginsWith: aSystemCategory])	ifTrue: [
+	self
+		bestMatchingManagerForCategory: aSystemCategory
+		do: [ :mgr |
 			aBlock value: mgr.
-			foundOne := true.
-		]
-	].
+			foundOne := true ].
+
    foundOne ifTrue: [^self].
 	["Loop over categories until we found a matching one"
 	self registry at: (MCPackage named: cat) ifPresent:[:mgr|


### PR DESCRIPTION
fixes https://pharo.fogbugz.com/f/cases/20233/MCPackageManager-class-managersForCategory-do-marks-too-many-packages-as-modified

* select only the best matching package managers  in MCPackageManager class>>managersForCategory:do: