### PR TITLE
20290 add build number to uploaded files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,10 @@ node('unix') {
 		if( env.BRANCH_NAME == "development" ){
 			stage("Upload to files.pharo.org"){
 				dir("bootstrap-cache"){
-					shell "BUILD_NUMBER=${env.BUILD_ID} bash bootstrap/scripts/prepare_for_upload.sh"
-					shell "bash bootstrap/scripts/upload_to_files.pharo.org.sh"
+				    shell "BUILD_NUMBER=${env.BUILD_ID} bash bootstrap/scripts/prepare_for_upload.sh"
+					sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
+						shell "bash bootstrap/scripts/upload_to_files.pharo.org.sh"
+					}
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,18 @@ node('unix') {
 			shell "BOOTSTRAP_ARCH=${architecture} bash ./bootstrap/scripts/build.sh -a ${architecture}"
 			stash includes: "bootstrap-cache/*.zip,bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
 	    }
+		
+		if( env.BRANCH_NAME == "development" ){
+			stage("Upload to files.pharo.org"){
+				dir("bootstrap-cache"){
+					shell "BUILD_NUMBER=${env.BUILD_ID} bash bootstrap/scripts/prepare_for_upload.sh"
+					shell "bash bootstrap/scripts/upload_to_files.pharo.org.sh"
+				}
+			}
+		}
+		
 		} finally {
+
 			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
 		}
 		

--- a/bootstrap/scripts/prepare_for_upload.sh
+++ b/bootstrap/scripts/prepare_for_upload.sh
@@ -13,6 +13,6 @@ for f in Pharo7.0-*.zip; do
 	#If it is not base image
 	if [[ "$f" != "FULL_IMAGE_NAME" ]]; then
 		IMAGE_KIND=$(echo "$f" | cut -d '-' -f 2)
-		mv "$f" Pharo${IMAGE_KIND}-7.0.0-arch.32bit.build.${BUILD_NUMBER}.sha.${HASH}.zip;
+		mv "$f" Pharo${IMAGE_KIND}-7.0.0-alpha.build.${BUILD_NUMBER}.sha.${HASH}.arch.32bit.zip;
 	fi
 done

--- a/bootstrap/scripts/prepare_for_upload.sh
+++ b/bootstrap/scripts/prepare_for_upload.sh
@@ -1,0 +1,18 @@
+#Get the hash of the built image
+HASH=$(find Pharo7.0-32bit-*.zip | head -n 1 | cut -d '-' -f 3 | cut -d '.' -f 1)
+FULL_IMAGE_NAME="Pharo7.0-32bit-${HASH}.zip"
+MINIMAL_IMAGE_NAME="Pharo7.0-metacello-32bit-${HASH}.zip"
+BUILD_NUMBER=${BUILD_NUMBER:-nobuildnumber}
+
+cp "${FULL_IMAGE_NAME}" latest.zip
+cp "${FULL_IMAGE_NAME}" latest-32.zip
+cp "${MINIMAL_IMAGE_NAME}" latest-minimal.zip
+cp "${MINIMAL_IMAGE_NAME}" latest-minimal-32.zip
+
+for f in Pharo7.0-*.zip; do
+	#If it is not base image
+	if [[ "$f" != "FULL_IMAGE_NAME" ]]; then
+		IMAGE_KIND=$(echo "$f" | cut -d '-' -f 2)
+		mv "$f" Pharo${IMAGE_KIND}-7.0.0-arch.32bit.sha.${HASH}.build.${BUILD_NUMBER}.zip;
+	fi
+done

--- a/bootstrap/scripts/prepare_for_upload.sh
+++ b/bootstrap/scripts/prepare_for_upload.sh
@@ -1,18 +1,33 @@
 #Get the hash of the built image
 HASH=$(find Pharo7.0-32bit-*.zip | head -n 1 | cut -d '-' -f 3 | cut -d '.' -f 1)
-FULL_IMAGE_NAME="Pharo7.0-32bit-${HASH}.zip"
-MINIMAL_IMAGE_NAME="Pharo7.0-metacello-32bit-${HASH}.zip"
+FULL_IMAGE_NAME32="Pharo7.0-32bit-${HASH}.zip"
+FULL_IMAGE_NAME64="Pharo7.0-64bit-${HASH}.zip"
+
+MINIMAL_IMAGE_NAME32="Pharo7.0-metacello-32bit-${HASH}.zip"
+MINIMAL_IMAGE_NAME64="Pharo7.0-metacello-64bit-${HASH}.zip"
 BUILD_NUMBER=${BUILD_NUMBER:-nobuildnumber}
 
-cp "${FULL_IMAGE_NAME}" latest.zip
-cp "${FULL_IMAGE_NAME}" latest-32.zip
-cp "${MINIMAL_IMAGE_NAME}" latest-minimal.zip
-cp "${MINIMAL_IMAGE_NAME}" latest-minimal-32.zip
+cp "${FULL_IMAGE_NAME32}" latest.zip
+cp "${FULL_IMAGE_NAME32}" latest-32.zip
+cp "${FULL_IMAGE_NAME64}" latest-64.zip
+cp "${MINIMAL_IMAGE_NAME32}" latest-minimal.zip
+cp "${MINIMAL_IMAGE_NAME32}" latest-minimal-32.zip
+cp "${MINIMAL_IMAGE_NAME64}" latest-minimal-64.zip
 
-for f in Pharo7.0-*.zip; do
+for f in Pharo7.0-32bit-*.zip; do
 	#If it is not base image
-	if [[ "$f" != "FULL_IMAGE_NAME" ]]; then
+	BITNESS=32bit
+	if [[ "$f" != "FULL_IMAGE_NAME32" ]]; then
 		IMAGE_KIND=$(echo "$f" | cut -d '-' -f 2)
-		mv "$f" Pharo${IMAGE_KIND}-7.0.0-alpha.build.${BUILD_NUMBER}.sha.${HASH}.arch.32bit.zip;
+		mv "$f" Pharo${IMAGE_KIND}-7.0.0-alpha.build.${BUILD_NUMBER}.sha.${HASH}.arch.${BITNESS}.zip;
+	fi
+done
+
+for f in Pharo7.0-64bit-*.zip; do
+	#If it is not base image
+	BITNESS=64bit
+	if [[ "$f" != "FULL_IMAGE_NAME64" ]]; then
+		IMAGE_KIND=$(echo "$f" | cut -d '-' -f 2)
+		mv "$f" Pharo${IMAGE_KIND}-7.0.0-alpha.build.${BUILD_NUMBER}.sha.${HASH}.arch.${BITNESS}.zip;
 	fi
 done

--- a/bootstrap/scripts/prepare_for_upload.sh
+++ b/bootstrap/scripts/prepare_for_upload.sh
@@ -13,6 +13,6 @@ for f in Pharo7.0-*.zip; do
 	#If it is not base image
 	if [[ "$f" != "FULL_IMAGE_NAME" ]]; then
 		IMAGE_KIND=$(echo "$f" | cut -d '-' -f 2)
-		mv "$f" Pharo${IMAGE_KIND}-7.0.0-arch.32bit.sha.${HASH}.build.${BUILD_NUMBER}.zip;
+		mv "$f" Pharo${IMAGE_KIND}-7.0.0-arch.32bit.build.${BUILD_NUMBER}.sha.${HASH}.zip;
 	fi
 done

--- a/bootstrap/scripts/upload_to_files.pharo.org.sh
+++ b/bootstrap/scripts/upload_to_files.pharo.org.sh
@@ -4,4 +4,4 @@ set -ex
 
 destDir="/appli/files.pharo.org/image/70/"
 echo "Uploading Images to pharo.files.org/$destDir"
-scp *.zip files.pharo.org:$destDir
+scp -o StrictHostKeyChecking=no -v *.zip files.pharo.org:$destDir

--- a/bootstrap/scripts/upload_to_files.pharo.org.sh
+++ b/bootstrap/scripts/upload_to_files.pharo.org.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+set -ex
+
+destDir="/appli/files.pharo.org/image/70/"
+echo "Uploading Images to pharo.files.org/$destDir"
+scp *.zip files.pharo.org:$destDir


### PR DESCRIPTION
This PR adds a script that will prepare built archives with the a name convention using semantic versionning:

Pharo${IMAGE_KIND}-7.0.0-arch.32bit.sha.${HASH}.build.${BUILD_NUMBER}.zip

Where:
 - IMAGE_KIND is the built product (core image, image with monticello, image with metacello, full image...)
 - HASH is the commit hash
 - BUILD_NUMBER is the build number set by jenkins, or "nobuildnumber" if not available