### PR TITLE
20297 avoid deadlocks in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,18 @@ node('unix') {
 
 			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
 		}
-		
+	}
+}
+
+//Testing step
+def architectures = ['32']//, '64']
+for (arch in architectures) {
+// Need to bind the label variable before the closure - can't do 'for (label in labels)'
+def architecture = arch
+
+	builders[architecture] = {
+	dir(architecture) {
+
 		// platforms for Jenkins node types we will build on
 		def platforms = ['unix', 'osx', 'windows']
 		def testers = [:]
@@ -90,9 +101,6 @@ node('unix') {
 		}
 	} // end build block
 	
-	} // end for architectures
+} // end for architectures
 	
-	parallel builders
-	cleanWs()
-	
-} // end node
+parallel builders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ node('unix') {
 
 		} finally {
 			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
+			cleanWs()
 		}
 		}
 	}
@@ -70,14 +71,12 @@ node('unix') {
 }
 
 //Testing step
+def testers = [:]
 def architectures = ['32']//, '64']
+def platforms = ['unix', 'osx', 'windows']
 for (arch in architectures) {
 	// Need to bind the label variable before the closure - can't do 'for (label in labels)'
 	def architecture = arch
-	
-	// platforms for Jenkins node types we will build on
-	def platforms = ['unix', 'osx', 'windows']
-	def testers = [:]
 	for (platf in platforms) {
 		// Need to bind the label variable before the closure - can't do 'for (label in labels)'
 		def platform = platf
@@ -90,10 +89,10 @@ for (arch in architectures) {
 				} finally {
 					archiveArtifacts allowEmptyArchive: true, artifacts: '*.xml', fingerprint: true
 					junit allowEmptyResults: true, testResults: '*.xml'
+					cleanWs()
 				}
 			}}
 		}
 	}
 }
-
 parallel testers

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,19 +38,19 @@ node('unix') {
 			stash includes: "bootstrap-cache/*.zip,bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
 	    }
 		
-	    if (architecture == "32"){
-			  stage ("Convert Image - 32->64") {
-				  dir("conversion"){
-	          shell "cp ../bootstrap-cache/*.zip ."
-	          shell "bash ../bootstrap/scripts/transform_32_into_64.sh"
-	          shell "mv *-64bit-*.zip ../bootstrap-cache"
-	        }
-		   }
-	   }
+	    if (architecture == "32") {
+			stage ("Convert Image - 32->64") {
+				dir("conversion") {
+					shell "cp ../bootstrap-cache/*.zip ."
+					shell "bash ../bootstrap/scripts/transform_32_into_64.sh"
+					shell "mv *-64bit-*.zip ../bootstrap-cache"
+				}
+			}
+		}
 		
-		if( env.BRANCH_NAME == "development" ){
-			stage("Upload to files.pharo.org"){
-				dir("bootstrap-cache"){
+		if( env.BRANCH_NAME == "development" ) {
+			stage("Upload to files.pharo.org") {
+				dir("bootstrap-cache") {
 				    shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh"
 					sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
 						shell "bash ../bootstrap/scripts/upload_to_files.pharo.org.sh"
@@ -58,11 +58,12 @@ node('unix') {
 				}
 			}
 		}
-		
-		} finally {
 
+		} finally {
 			archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
 		}
+		}
+	}
 	}
 }
 


### PR DESCRIPTION
Right now, every time a job tries to build and run the tests, a main job that makes the bootstrap spawns three jobs to run the tests. The main job then waits for its children to finish, occupying a place in an executor.

That means that running many jobs concurrently could cause a deadlock because child jobs will spawn but they will never be executed because all executors are taken.

https://pharo.fogbugz.com/f/cases/20297/Avoid-deadlocks-in-jenkins

This pull request tries to make the bootstrap step not wait for the tests.