### PR TITLE
20305 pharo system repository should have a name

### DIFF
--- a/bootstrap/scripts/04-configure-resulting-image/fixPackageVersions.st
+++ b/bootstrap/scripts/04-configure-resulting-image/fixPackageVersions.st
@@ -14,8 +14,11 @@
 		location: FileLocator image parent parent;
 		subdirectory: 'src';
 		createRepository.].
+
+repo name: 'pharo'.
 repo beSystemRepository.
 repo register.
+
 "get loaded commit"
 commit := repo branch lastCommit.
 "set loaded commit as reference"


### PR DESCRIPTION
Right now, the pharo repository that is by default in an image says 'no name'. We should set the correct name, as proposed by Esteban:

repo name: ‘pharo’.

https://pharo.fogbugz.com/f/cases/20305/Pharo-system-repository-should-have-a-name