### PR TITLE
20256-Latin1TextConverter-should-know-mone-encoding-names

### DIFF
--- a/src/Multilingual-TextConversion.package/CP1250TextConverter.class/class/initialize.st
+++ b/src/Multilingual-TextConversion.package/CP1250TextConverter.class/class/initialize.st
@@ -1,3 +1,3 @@
-as yet unclassified
+initialization
 initialize
 	self initializeTables

--- a/src/Multilingual-TextConversion.package/Latin1TextConverter.class/class/encodingNames.st
+++ b/src/Multilingual-TextConversion.package/Latin1TextConverter.class/class/encodingNames.st
@@ -1,4 +1,3 @@
 accessing
-encodingNames 
-
-	^ #('latin-1' 'latin1' 'iso-8859-1') copy.
+encodingNames
+	^ #('latin-1' 'latin1' 'iso-8859-1' 'iso88591') copy

--- a/src/Multilingual-TextConversion.package/MacRomanTextConverter.class/class/initialize.st
+++ b/src/Multilingual-TextConversion.package/MacRomanTextConverter.class/class/initialize.st
@@ -1,3 +1,3 @@
-as yet unclassified
+initialization
 initialize
 	self initializeTables

--- a/src/Multilingual-TextConversion.package/TextConverter.class/class/encodingNames.st
+++ b/src/Multilingual-TextConversion.package/TextConverter.class/class/encodingNames.st
@@ -1,4 +1,4 @@
-utilities
+accessing
 encodingNames 
 
 	^ #() copy.


### PR DESCRIPTION
Add 'iso88591' to the encoding names of Latin1TextConverters + recategorize some methods.

Issue related: https://pharo.fogbugz.com/f/cases/20256/Latin1TextConverter-should-know-mone-encoding-names

case 20256