### PR TITLE
20248-DarkTheme-disabledTextColor-is-too-close-of-textColor

### DIFF
--- a/src/Polymorph-Widgets.package/Pharo3DarkTheme.class/instance/disabledColor.st
+++ b/src/Polymorph-Widgets.package/Pharo3DarkTheme.class/instance/disabledColor.st
@@ -1,3 +1,3 @@
 accessing colors
 disabledColor 
-	^ Color veryLightGray muchLighter
+	^ Color gray lighter


### PR DESCRIPTION
Change the disable color from the dark theme because it is too close from the basic color.This resolve case 20248 : https://pharo.fogbugz.com/f/cases/20248/DarkTheme-disabledTextColor-is-too-close-of-textColor