### PR TITLE
20247-Refactor-the-MostUsedTools-of-the-world-menu-to-cut-dependencies-and-use-priorities

### DIFF
--- a/src/GT-Playground.package/GTPlayground.class/class/menuCommandOn..st
+++ b/src/GT-Playground.package/GTPlayground.class/class/menuCommandOn..st
@@ -1,0 +1,9 @@
+world menu
+menuCommandOn: aBuilder
+	<worldMenu>
+	(aBuilder item: Smalltalk tools workspace title asSymbol)
+		parent: #MostUsedTools;
+		action: [ Smalltalk tools openWorkspace ];
+		order: 0.3;
+		keyText: 'o, w';
+		icon: Smalltalk tools workspace taskbarIcon

--- a/src/GT-Spotter.package/GTSpotter.class/class/menuCommandOn..st
+++ b/src/GT-Spotter.package/GTSpotter.class/class/menuCommandOn..st
@@ -1,0 +1,9 @@
+world menu
+menuCommandOn: aBuilder
+	<worldMenu>
+	(aBuilder item: #Spotter)
+		action: [ GTSpotterGlobalShortcut openGlobalSpotter ];
+		keyText: 'Shift + Enter';
+		order: 0.7;
+		parent: #MostUsedTools;
+		iconName: #smallFindIcon

--- a/src/MonticelloGUI.package/MCWorkingCopyBrowser.class/class/menuCommandOn..st
+++ b/src/MonticelloGUI.package/MCWorkingCopyBrowser.class/class/menuCommandOn..st
@@ -1,0 +1,9 @@
+world menu
+menuCommandOn: aBuilder
+	<worldMenu>
+	(aBuilder item: #'Monticello Browser')
+		parent: #MostUsedTools;
+		action: [ Smalltalk tools openMonticelloBrowser ];
+		order: 0.9;
+		keyText: 'o, p';
+		icon: Smalltalk tools monticelloBrowser taskbarIcon

--- a/src/Morphic-Core.package/WorldState.class/class/mostUsedToolsOn..st
+++ b/src/Morphic-Core.package/WorldState.class/class/mostUsedToolsOn..st
@@ -3,30 +3,4 @@ mostUsedToolsOn: aBuilder
 	<worldMenu>
 	(aBuilder group: #MostUsedTools)
 		withSeparatorAfter;
-		order: 0;
-		with: [ (aBuilder item: #'System Browser')
-				action: [ Smalltalk tools openClassBrowser ];
-				keyText: 'o, b';
-				icon: Smalltalk tools browser taskbarIcon.
-			(aBuilder item: Smalltalk tools workspace title asSymbol)
-				action: [ Smalltalk tools openWorkspace ];
-				keyText: 'o, w';
-				icon: Smalltalk tools workspace taskbarIcon.
-			Smalltalk globals
-				at: #TestRunner
-				ifPresent: [ :class | 
-					(aBuilder item: #'Test Runner')
-						action: [ Smalltalk tools openTestRunner ];
-						keyText: 'o, u';
-						icon: class taskbarIcon ].
-			Smalltalk globals
-				at: #GTSpotter
-				ifPresent: [ :class | 
-					(aBuilder item: #Spotter)
-						action: [ GTSpotterGlobalShortcut openGlobalSpotter ];
-						keyText: 'Shift + Enter';
-						iconName: #smallFindIcon ].
-			(aBuilder item: #'Monticello Browser')
-				action: [ Smalltalk tools openMonticelloBrowser ];
-				keyText: 'o, p';
-				icon: Smalltalk tools monticelloBrowser taskbarIcon ]
+		order: 0

--- a/src/Nautilus.package/Nautilus.class/class/menuCommandOn..st
+++ b/src/Nautilus.package/Nautilus.class/class/menuCommandOn..st
@@ -1,0 +1,9 @@
+world menu
+menuCommandOn: aBuilder
+	<worldMenu>
+	(aBuilder item: #'System Browser')
+		parent: #MostUsedTools;
+		action: [ Smalltalk tools openClassBrowser ];
+		order: 0.1;
+		keyText: 'o, b';
+		icon: Smalltalk tools browser taskbarIcon

--- a/src/SUnit-UI.package/TestRunner.class/class/menuCommandOn..st
+++ b/src/SUnit-UI.package/TestRunner.class/class/menuCommandOn..st
@@ -1,0 +1,9 @@
+world menu
+menuCommandOn: aBuilder
+	<worldMenu>
+	(aBuilder item: #'Test Runner')
+		parent: #MostUsedTools;
+		action: [ Smalltalk tools openTestRunner ];
+		order: 0.5;
+		keyText: 'o, u';
+		icon: self taskbarIcon


### PR DESCRIPTION
Split WorldState class>>mostUsedTools: to let each tool define its own entry on the menu. This commit also add #order: to the different items. This is helpful when we want to add some items as Iceberg.See case 20247 : https://pharo.fogbugz.com/f/cases/20247/Refactor-the-MostUsedTools-of-the-world-menu-to-cut-dependencies-and-use-priorities