### PR TITLE
20314-Extracting-zip-update-the-label-of-the-progress-bar-but-does-not-increment-it

### DIFF
--- a/src/Compression.package/ZipArchive.class/instance/extractAllTo..st
+++ b/src/Compression.package/ZipArchive.class/instance/extractAllTo..st
@@ -1,8 +1,8 @@
 archive operations
-extractAllTo: aDirectory 
+extractAllTo: aDirectory
 	"Extract all elements to the given directory"
-	UIManager default informUserDuring: 
-		[ :bar | 
-		self 
-			extractAllTo: aDirectory
-			informing: bar ]
+
+	UIManager default
+		informUserDuring: [ :bar | 
+			bar max: self members size.
+			self extractAllTo: aDirectory informing: bar ]

--- a/src/Compression.package/ZipArchive.class/instance/extractAllTo.informing.overwrite..st
+++ b/src/Compression.package/ZipArchive.class/instance/extractAllTo.informing.overwrite..st
@@ -1,27 +1,42 @@
 archive operations
 extractAllTo: aDirectory informing: bar overwrite: allOverwrite
 	"Extract all elements to the given directory"
-	| overwriteAll |
+
+	| overwriteAll lastUpdate barValue shouldUpdateInfos |
 	overwriteAll := allOverwrite.
-	self members do:[:entry| | dir |
-		entry isDirectory ifTrue:[
-			bar ifNotNil: [bar label: 'Creating ', entry fileName].
-			dir := (entry fileName findTokens:'/') 
-					inject: aDirectory into:[:base :part| base / part].
+	lastUpdate := 0.
+	barValue := 0.
+	self members
+		select: #isDirectory
+		thenDo: [ :entry | 
+			| dir |
+			(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
+				ifTrue: [ lastUpdate := Time millisecondClockValue ].
+			bar isNotNil & shouldUpdateInfos
+				ifTrue: [ bar label: 'Creating ' , entry fileName ].
+			dir := (entry fileName findTokens: '/') inject: aDirectory into: [ :base :part | base / part ].
 			dir ensureCreateDirectory.
-		].
-	].
-	self members do:[:entry| | response |
-		entry isDirectory ifFalse:[
-			bar ifNotNil: [bar label: 'Extracting ', entry fileName].
+			barValue := barValue + 1.
+			bar isNotNil & shouldUpdateInfos
+				ifTrue: [ bar value: barValue ] ].
+	self members
+		select: [ :entry | entry isDirectory not ]
+		thenDo: [ :entry | 
+			| response |
+			(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
+				ifTrue: [ lastUpdate := Time millisecondClockValue ].
+			bar isNotNil & shouldUpdateInfos
+				ifTrue: [ bar label: 'Extracting ' , entry fileName ].
 			response := entry extractInDirectory: aDirectory overwrite: overwriteAll.
-			response == #retryWithOverwrite ifTrue:[
-				overwriteAll := true.
-				response := entry extractInDirectory: aDirectory overwrite: overwriteAll.
-			].
-			response == #abort ifTrue:[^self].
-			response == #failed ifTrue:[
-				(self confirm: 'Failed to extract ', entry fileName, '. Proceed?') ifFalse:[^self].
-			].
-		].
-	].
+			response == #retryWithOverwrite
+				ifTrue: [ overwriteAll := true.
+					response := entry extractInDirectory: aDirectory overwrite: overwriteAll ].
+			response == #abort
+				ifTrue: [ ^ self ].
+			response == #failed
+				ifTrue: [ (self confirm: 'Failed to extract ' , entry fileName , '. Proceed?')
+						ifFalse: [ ^ self ] ].
+			barValue := barValue + 1.
+			bar isNotNil & shouldUpdateInfos
+				ifTrue: [ bar value: barValue.
+					lastUpdate := Time millisecondClockValue ] ]


### PR DESCRIPTION
This PR will increment the progress bar of ZipArchive unzip. This incrementation will be done each 100ms to not lose perfs. Also, I change the update of the progress bar label to be done only each 100ms. I tried on a zip with only small files and it improved the perf by around 5-6%. See case 20314 : https://pharo.fogbugz.com/f/cases/20314/Extracting-zip-update-the-label-of-the-progress-bar-but-does-not-increment-it