### PR TITLE
20191-index-inst-var-should-move-from-Slot-to-IndexedSlot

### DIFF
--- a/src/Slot.package/IndexedSlot.class/properties.json
+++ b/src/Slot.package/IndexedSlot.class/properties.json
@@ -1,11 +1,13 @@
 {
-	"commentStamp" : "MarcusDenker 1/22/2015 17:41",
+	"commentStamp" : "CyrilFerlicot 8/15/2017 1:20",
 	"super" : "Slot",
 	"category" : "Slot-Variables",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [ ],
+	"instvars" : [ 
+		"index"
+	],
 	"name" : "IndexedSlot",
 	"type" : "normal"
 }

--- a/src/Slot.package/Slot.class/properties.json
+++ b/src/Slot.package/Slot.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "JurajKubelka 3/4/2015 20:09",
+	"commentStamp" : "CyrilFerlicot 8/15/2017 1:20",
 	"super" : "Object",
 	"category" : "Slot-Variables",
 	"classinstvars" : [
@@ -10,7 +10,6 @@
 		"Properties"
 	],
 	"instvars" : [
-		"index",
 		"name"
 	],
 	"name" : "Slot",


### PR DESCRIPTION
Push down index variable from slot to indexed slots. See case 20191 https://pharo.fogbugz.com/f/cases/20191/index-inst-var-should-move-from-Slot-to-IndexedSlot

Be careful to the tests. Since it is hard to do this change in the image (it breaks the image), I did it by hand. 