### PR TITLE
Matrix: Trivial typo fix in method comment

### DIFF
--- a/src/Collections-Unordered.package/Matrix.class/class/rows.columns.element..st
+++ b/src/Collections-Unordered.package/Matrix.class/class/rows.columns.element..st
@@ -1,6 +1,6 @@
 instance creation
 rows: rowNumber columns: columnNumber element: element
-	"Create a Matrix of rowNUmber rows and columnNumber columns filled with element."
+	"Create a Matrix of rowNumber rows and columnNumber columns filled with element."
 	^ self 
 		rows: rowNumber 
 		columns: columnNumber


### PR DESCRIPTION
It is rowNumber and not rowNUmber.