### PR TITLE
18172-Rubric-line-numbers-are-not-dark-theme-friendly

### DIFF
--- a/src/Rubric.package/RubAbstractTextArea.class/class/lineNumbersTextColor.st
+++ b/src/Rubric.package/RubAbstractTextArea.class/class/lineNumbersTextColor.st
@@ -1,3 +1,3 @@
 settings
 lineNumbersTextColor
-	^ LineNumbersTextColor ifNil: [ LineNumbersTextColor := Color gray muchDarker] 
+	^ LineNumbersTextColor ifNil: [ LineNumbersTextColor := Smalltalk ui theme lineNumberColor ]


### PR DESCRIPTION
Use #lineNumberColor in rubric because current line number color is not dark theme friendly.Case 18172 : https://pharo.fogbugz.com/f/cases/18172/Rubric-line-numbers-are-not-dark-theme-friendly