### PR TITLE
20337-ported fallback for strings when primitive 105 fails from Squeak

### DIFF
--- a/src/Collections-Native.package/ByteArray.class/instance/replaceFrom.to.with.startingAt..st
+++ b/src/Collections-Native.package/ByteArray.class/instance/replaceFrom.to.with.startingAt..st
@@ -2,4 +2,13 @@ private
 replaceFrom: start to: stop with: replacement startingAt: repStart 
 	"Primitive. This destructively replaces elements from start to stop in the receiver starting at index, repStart, in the collection, replacement. Answer the receiver. Range checks are performed in the primitive only. Optional. See Object documentation whatIsAPrimitive."
 	<primitive: 105>
-	super replaceFrom: start to: stop with: replacement startingAt: repStart
+	replacement isString
+		ifFalse:
+			[super replaceFrom: start to: stop with: replacement startingAt: repStart]
+		ifTrue:
+			[ "use String>>byteAt: to mimic prim 105"
+			| index repOff |
+			repOff := repStart - start.
+			index := start - 1.
+			[(index := index + 1) <= stop]
+				whileTrue: [self at: index put: (replacement byteAt: repOff + index)]]

--- a/src/Collections-Tests.package/ByteArrayTest.class/instance/testFallbackReplaceFromToWithForString.st
+++ b/src/Collections-Tests.package/ByteArrayTest.class/instance/testFallbackReplaceFromToWithForString.st
@@ -1,0 +1,16 @@
+tests
+testFallbackReplaceFromToWithForString
+	| testString byteArray stringByteSize |
+	testString := 'Test string'.
+	stringByteSize := 'Test string' byteSize.
+	byteArray := ByteArray new: stringByteSize.
+	
+	self
+		shouldnt: [
+			byteArray
+				replaceFrom: 1
+				to: stringByteSize
+				with: testString
+				startingAt: 1 ]
+		raise: Exception
+		description: 'Primitive 105 should be optional for ByteArray'

--- a/src/Collections-Tests.package/ByteArrayTest.class/instance/testFallbackReplaceFromToWithForWideString.st
+++ b/src/Collections-Tests.package/ByteArrayTest.class/instance/testFallbackReplaceFromToWithForWideString.st
@@ -1,0 +1,16 @@
+tests
+testFallbackReplaceFromToWithForWideString
+	| testString byteArray stringByteSize |
+	testString := 'Test string' asWideString.
+	stringByteSize := 'Test string' byteSize.
+	byteArray := ByteArray new: stringByteSize.
+	
+	self
+		shouldnt: [
+			byteArray
+				replaceFrom: 1
+				to: stringByteSize
+				with: testString
+				startingAt: 1 ]
+		raise: Exception
+		description: 'Primitive 105 should be optional for ByteArray'


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20337/Squeak-has-a-fix-for-storing-wide-strings-into-a-ByteArray