### PR TITLE
20348-testWideStringClassName-needs-to-be-unmarked-as-expected-failure

### DIFF
--- a/src/FuelTests.package/FLBasicSerializationTest.class/instance/expectedFailures.st
+++ b/src/FuelTests.package/FLBasicSerializationTest.class/instance/expectedFailures.st
@@ -1,3 +1,3 @@
 failures
 expectedFailures
-	^ #(testConsiderCustomWideSymbolGlobal testWideStringGlobal testWideStringClassName)
+	^ #(testConsiderCustomWideSymbolGlobal testWideStringGlobal)

--- a/src/FuelTests.package/monticello.meta/categories.st
+++ b/src/FuelTests.package/monticello.meta/categories.st
@@ -1,5 +1,5 @@
 SystemOrganization addCategory: #FuelTests!
-SystemOrganization addCategory: 'FuelTests-Collections'!
-SystemOrganization addCategory: 'FuelTests-Mocks'!
-SystemOrganization addCategory: 'FuelTests-StreamStrategies'!
-SystemOrganization addCategory: 'FuelTests-Streams'!
+SystemOrganization addCategory: #'FuelTests-Collections'!
+SystemOrganization addCategory: #'FuelTests-Mocks'!
+SystemOrganization addCategory: #'FuelTests-StreamStrategies'!
+SystemOrganization addCategory: #'FuelTests-Streams'!


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20348/testWideStringClassName-needs-to-be-unmarked-as-expected-failuredo not expect failure from testWideStringClassName