### PR TITLE
20351-Obsolete-subclasses-not-initialized-in-the-bootstrapped-image

### DIFF
--- a/src/PharoBootstrap-Initialization.package/PharoBootstrapInitialization.class/class/initializeCommandLineHandlerAndErrorHandling.st
+++ b/src/PharoBootstrap-Initialization.package/PharoBootstrapInitialization.class/class/initializeCommandLineHandlerAndErrorHandling.st
@@ -37,7 +37,7 @@ initializeCommandLineHandlerAndErrorHandling
 	Slot initialize.
 	TraitBehavior initialize.
 	RPackage initialize.
-	Behavior initializeClassProperties.
+	Behavior initialize.
 
 	UIManager classVarNamed: 'Default' put: NonInteractiveUIManager new.
 	UIManager default activate.


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20351/Obsolete-subclasses-not-initialized-in-the-bootstrapped-image