### PR TITLE
20357-New-warning-text-color-is-not-readable-on-white-theme

### DIFF
--- a/src/Polymorph-Widgets.package/UITheme.class/instance/warningBackgroundColor.st
+++ b/src/Polymorph-Widgets.package/UITheme.class/instance/warningBackgroundColor.st
@@ -1,3 +1,3 @@
 accessing colors
 warningBackgroundColor
-	^ self warningTextColor darker darker
+	^ Color yellow

--- a/src/Polymorph-Widgets.package/UITheme.class/instance/warningTextColor.st
+++ b/src/Polymorph-Widgets.package/UITheme.class/instance/warningTextColor.st
@@ -1,3 +1,3 @@
 accessing colors
 warningTextColor
-	^ Color yellow
+	^ Color yellow muchDarker


### PR DESCRIPTION
When I added the warningTextColor I did not test it enough. Now that I try to use it with Iceberg I see that it is not good. This will make it more readable.Case 20357 :  https://pharo.fogbugz.com/f/cases/20357/New-warning-text-color-is-not-readable-on-white-theme