### PR TITLE
20360-Enable-Include-system-repositories-by-default-for-Iceberg-in-Pharo-7

### DIFF
--- a/src/BaselineOfIDE.package/BaselineOfIDE.class/instance/loadIceberg.st
+++ b/src/BaselineOfIDE.package/BaselineOfIDE.class/instance/loadIceberg.st
@@ -6,3 +6,4 @@ loadIceberg
 		repository: 'github://pharo-vcs/iceberg:v0.5.7';
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
+	(Smalltalk classNamed: #Iceberg) showSystemRepositories: true.


### PR DESCRIPTION
Enable "Include system repositories by default" for Iceberg in Pharo 7
case 20360https://pharo.fogbugz.com/f/cases/20360/Enable-Include-system-repositories-by-default-for-Iceberg-in-Pharo-7