### PR TITLE
20412-Unstable-Semaphore-tests

### DIFF
--- a/src/Kernel-Tests.package/SemaphoreTest.class/instance/testMutualExclusion.st
+++ b/src/Kernel-Tests.package/SemaphoreTest.class/instance/testMutualExclusion.st
@@ -9,9 +9,12 @@ testMutualExclusion
 		steps add: #startProcess1.
 		lock critical: [
 			steps add: #startCritical1.
-			Processor yield.
+			"waiting next process run"
+			[steps includes: #startProcess2] whileFalse: [Processor yield].
 			steps add: #endCritical1 ] ] fork.
 	[
+		"Waiting first process run"
+		[steps includes: #startProcess1] whileFalse: [Processor yield].
 		steps add: #startProcess2.
 		lock critical: [ 
 			steps add: #startCritical2.
@@ -20,4 +23,4 @@ testMutualExclusion
 	
 	[ steps size = 6 ] whileFalse: [ Processor yield ].
 
-	self assert: (steps hasEqualElements: #(startProcess1 startCritical1 startProcess2 endCritical1 startCritical2 endCritical2)).
+	self assert: (steps hasEqualElements: #(startProcess1 startCritical1 startProcess2 endCritical1 startCritical2 endCritical2))


### PR DESCRIPTION
fix to ensure first process running first and second process running at the middle of first critical section