### PR TITLE
Yield the CPU longer

### DIFF
--- a/src/Kernel.package/ProcessorScheduler.class/class/idleProcess.st
+++ b/src/Kernel.package/ProcessorScheduler.class/class/idleProcess.st
@@ -3,4 +3,4 @@ idleProcess
 	"A default background process which is invisible."
 
 	[true] whileTrue:
-		[self relinquishProcessorForMicroseconds: 1000]
+		[self relinquishProcessorForMicroseconds: 50000]


### PR DESCRIPTION
The work of the idle process is to run when no other smalltalk process is
runnable. And the process will use a primitive to yield execution for a given
amount of microseconds. The VM will either pick the closest delay to expire
or the timeout provided and yield execution. It will resume earlier in case of
I/O.

Pick 50ms as this is the time WorldState will update in server mode. In the
future we can increase it to minutes.