### PR TITLE
20426-Better-pin-messages

### DIFF
--- a/src/Kernel.package/Object.class/instance/inPinned.st
+++ b/src/Kernel.package/Object.class/instance/inPinned.st
@@ -1,0 +1,7 @@
+pinning
+inPinned
+	self
+		deprecated: 'Please use #isPinnedInMemory instead'
+		transformWith: '`@receiver isPinned' -> '`@receiver isPinnedInMemory'.
+		
+	^self isPinnedInMemory

--- a/src/Kernel.package/Object.class/instance/isPinned.st
+++ b/src/Kernel.package/Object.class/instance/isPinned.st
@@ -1,5 +1,5 @@
 pinning
-inPinned
+isPinned
 	self
 		deprecated: 'Please use #isPinnedInMemory instead'
 		transformWith: '`@receiver isPinned' -> '`@receiver isPinnedInMemory'.

--- a/src/Kernel.package/Object.class/instance/isPinnedInMemory.st
+++ b/src/Kernel.package/Object.class/instance/isPinnedInMemory.st
@@ -1,5 +1,5 @@
 pinning
-isPinned
+isPinnedInMemory
 	"Answer if the receiver is pinned.  The VM's garbage collector routinely moves
 	 objects as it reclaims and compacts memory.  But it can also pin an object so
 	 that it will not be moved, which can make it easier to pass objects out through

--- a/src/Kernel.package/Object.class/instance/pin.st
+++ b/src/Kernel.package/Object.class/instance/pin.st
@@ -1,7 +1,7 @@
 pinning
 pin
-	"The VM's garbage collector routinely moves objects as it reclaims and compacts
-	 memory. But it can also pin an object so that it will not be moved, which can make
-	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
-	 This method ensures an object is pinned, and answers whether it was already pinned."
-	^self setPinned: true
+	self
+		deprecated: 'Please use #pinInMemory instead'
+		transformWith: '`@receiver pin' -> '`@receiver pinInMemory'.
+		
+	self pinInMemory

--- a/src/Kernel.package/Object.class/instance/pinInMemory.st
+++ b/src/Kernel.package/Object.class/instance/pinInMemory.st
@@ -1,0 +1,7 @@
+pinning
+pinInMemory
+	"The VM's garbage collector routinely moves objects as it reclaims and compacts
+	 memory. But it can also pin an object so that it will not be moved, which can make
+	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
+	 This method ensures an object is pinned, and answers whether it was already pinned."
+	^self setPinnedInMemory: true

--- a/src/Kernel.package/Object.class/instance/setPinned..st
+++ b/src/Kernel.package/Object.class/instance/setPinned..st
@@ -1,8 +1,7 @@
-private
+pinning
 setPinned: aBoolean
-	"The VM's garbage collector routinely moves objects as it reclaims and compacts
-	 memory. But it can also pin an object so that it will not be moved, which can make
-	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
-	 This primitive either pins or unpins an object, and answers if it was already pinned."
-	<primitive: 184 error: ec>
-	^self primitiveFailed
+	self
+		deprecated: 'Please use #setPinnedInMemory: instead'
+		transformWith: '`@receiver setPinned: `@statements' -> '`@receiver setPinnedInMemory: `@statements'.
+		
+	self setPinnedInMemory: aBoolean

--- a/src/Kernel.package/Object.class/instance/setPinnedInMemory..st
+++ b/src/Kernel.package/Object.class/instance/setPinnedInMemory..st
@@ -1,0 +1,8 @@
+pinning
+setPinnedInMemory: aBoolean
+	"The VM's garbage collector routinely moves objects as it reclaims and compacts
+	 memory. But it can also pin an object so that it will not be moved, which can make
+	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
+	 This primitive either pins or unpins an object, and answers if it was already pinned."
+	<primitive: 184 error: ec>
+	^self primitiveFailed

--- a/src/Kernel.package/Object.class/instance/unpin.st
+++ b/src/Kernel.package/Object.class/instance/unpin.st
@@ -1,7 +1,7 @@
 pinning
 unpin
-	"The VM's garbage collector routinely moves objects as it reclaims and compacts
-	 memory. But it can also pin an object so that it will not be moved, which can make
-	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
-	 This method ensures an object is unpinned, and answers whether it was pinned."
-	^self setPinned: false
+	self
+		deprecated: 'Please use #unpinInMemory instead'
+		transformWith: '`@receiver unpin' -> '`@receiver unpinInMemory'.
+		
+	self unpinInMemory

--- a/src/Kernel.package/Object.class/instance/unpinInMemory.st
+++ b/src/Kernel.package/Object.class/instance/unpinInMemory.st
@@ -1,0 +1,7 @@
+pinning
+unpinInMemory
+	"The VM's garbage collector routinely moves objects as it reclaims and compacts
+	 memory. But it can also pin an object so that it will not be moved, which can make
+	 it easier to pass objects out through the FFI.  Objects are unpinnned when created.
+	 This method ensures an object is unpinned, and answers whether it was pinned."
+	^self setPinnedInMemory: false

--- a/src/UnifiedFFI-Tests.package/FFICallbackTests.class/instance/testCqsortWithByteArray.st
+++ b/src/UnifiedFFI-Tests.package/FFICallbackTests.class/instance/testCqsortWithByteArray.st
@@ -11,7 +11,7 @@ testCqsortWithByteArray
 	expected := (1.0 to: 10.0 by: 0.5) asArray.
 	
 	values := FFIExternalArray newType: 'double' size: unsorted size.
-	values getHandle pin.
+	values getHandle pinInMemory.
 	unsorted withIndexDo: [ :each :index | values at: index put: each ].
 	callback := FFICallback
 		signature:  #(int (const void *arg1, const void *arg2))


### PR DESCRIPTION
pinning messages are renamed with suffix ~InMemory.
Old messages are deprecated with auto transformation