### PR TITLE
20428-ClassTest-Kernel-Tests-is-dependent-on-System-Changes

### DIFF
--- a/src/System-Changes.package/Class.extension/instance/removeFromChanges.st
+++ b/src/System-Changes.package/Class.extension/instance/removeFromChanges.st
@@ -2,4 +2,5 @@
 removeFromChanges
 	"References to the receiver, a class, and its metaclass should no longer be included in the system ChangeSet."
 
-	ChangeSet current removeClassAndMetaClassChanges: self
+	self class environment at: #ChangeSet ifPresent: [ :changeSet |
+		changeSet current removeClassAndMetaClassChanges: self ].

--- a/src/System-Changes.package/TClass.extension/instance/removeFromChanges.st
+++ b/src/System-Changes.package/TClass.extension/instance/removeFromChanges.st
@@ -2,4 +2,5 @@
 removeFromChanges
 	"References to the receiver, a class, and its metaclass should no longer be included in the system ChangeSet."
 
-	ChangeSet current removeClassAndMetaClassChanges: self
+	self class environment at: #ChangeSet ifPresent: [ :changeSet |
+		changeSet current removeClassAndMetaClassChanges: self ].

--- a/src/System-Changes.package/Trait.extension/instance/removeFromChanges.st
+++ b/src/System-Changes.package/Trait.extension/instance/removeFromChanges.st
@@ -2,4 +2,5 @@
 removeFromChanges
 	"References to the receiver, a class, and its metaclass should no longer be included in the system ChangeSet."
 
-	ChangeSet current removeClassAndMetaClassChanges: self
+	self class environment at: #ChangeSet ifPresent: [ :changeSet |
+		changeSet current removeClassAndMetaClassChanges: self ].


### PR DESCRIPTION
safer version of removeFromChangeshttps://pharo.fogbugz.com/f/cases/20428/ClassTest-Kernel-Tests-is-dependent-on-System-Changes