### PR TITLE
20429-ContextTesttestSetUp-is-dependent-on-Opal

### DIFF
--- a/src/Kernel-Tests.package/ContextTest.class/instance/testSetUp.st
+++ b/src/Kernel-Tests.package/ContextTest.class/instance/testSetUp.st
@@ -6,5 +6,5 @@ testSetUp
 	self assert: aMethodContext home = aMethodContext.
 	self assert: aMethodContext receiver = aReceiver.
 	self assert: (aMethodContext method isKindOf: CompiledMethod).
-	self assert: aMethodContext method = aCompiledMethod.
+	self assert: aMethodContext method = aCompiledMethod. 
 	self assert: aMethodContext client printString = 'ContextTest>>#testSetUp'.

--- a/src/Kernel-Tests.package/ContextTest.class/instance/testSetUp.st
+++ b/src/Kernel-Tests.package/ContextTest.class/instance/testSetUp.st
@@ -7,5 +7,4 @@ testSetUp
 	self assert: aMethodContext receiver = aReceiver.
 	self assert: (aMethodContext method isKindOf: CompiledMethod).
 	self assert: aMethodContext method = aCompiledMethod.
-	self assert: aMethodContext methodNode selector = #rightCenter.
 	self assert: aMethodContext client printString = 'ContextTest>>#testSetUp'.


### PR DESCRIPTION
remove usage of methodNode in ContextTest>>#testSetUphttps://pharo.fogbugz.com/f/cases/20429/ContextTest-testSetUp-is-dependent-on-Opal