### PR TITLE
20415-Restore-the-extra-morphic-worlds-properly-on-startup

### DIFF
--- a/src/Morphic-Core.package/WorldMorph.class/class/shutDown.st
+++ b/src/Morphic-Core.package/WorldMorph.class/class/shutDown.st
@@ -1,3 +1,4 @@
 system startup
 shutDown
-	World ifNotNil: [:world | world triggerEvent: #aboutToLeaveWorld ]
+	World ifNotNil: [:world | world triggerEvent: #aboutToLeaveWorld ].
+	self extraWorldList do: [:world | world triggerEvent: #aboutToLeaveWorld ].

--- a/src/Morphic-Core.package/WorldMorph.class/class/startUp.st
+++ b/src/Morphic-Core.package/WorldMorph.class/class/startUp.st
@@ -1,3 +1,4 @@
 system startup
 startUp
-	World ifNotNil: [:world | world restoreMorphicDisplay]
+	World ifNotNil: [:world | world restoreMorphicDisplay].
+	self extraWorldList do: #restoreMorphicDisplay.

--- a/src/Morphic-Core.package/monticello.meta/categories.st
+++ b/src/Morphic-Core.package/monticello.meta/categories.st
@@ -1,7 +1,7 @@
 SystemOrganization addCategory: #'Morphic-Core'!
-SystemOrganization addCategory: 'Morphic-Core-Announcements'!
-SystemOrganization addCategory: 'Morphic-Core-Borders'!
-SystemOrganization addCategory: 'Morphic-Core-Events'!
-SystemOrganization addCategory: 'Morphic-Core-Kernel'!
-SystemOrganization addCategory: 'Morphic-Core-Support'!
-SystemOrganization addCategory: 'Morphic-Core-Worlds'!
+SystemOrganization addCategory: #'Morphic-Core-Announcements'!
+SystemOrganization addCategory: #'Morphic-Core-Borders'!
+SystemOrganization addCategory: #'Morphic-Core-Events'!
+SystemOrganization addCategory: #'Morphic-Core-Kernel'!
+SystemOrganization addCategory: #'Morphic-Core-Support'!
+SystemOrganization addCategory: #'Morphic-Core-Worlds'!


### PR DESCRIPTION
The attached changeset contains the changes for shutting down and starting the extra morphic worlds. This fixes rendering issues when starting an image that had extra morphic worlds open.
https://pharo.fogbugz.com/f/cases/20415/Restore-the-extra-morphic-worlds-properly-on-startup