### PR TITLE
20416-Add-the-notion-of-a-Cursor-owner

### DIFF
--- a/src/Graphics-Display Objects.package/Cursor.class/class/currentCursor..st
+++ b/src/Graphics-Display Objects.package/Cursor.class/class/currentCursor..st
@@ -2,5 +2,13 @@ current cursor
 currentCursor: aCursor 
 	"Make the instance of cursor, aCursor, be the current cursor. Display it."
 
+	ActiveHand ifNotNil: [
+		ActiveHand world currentCursor: aCursor.
+		ActiveHand world isCursorOwner ifTrue: [
+			aCursor beCursor
+		].
+		^ self
+	].
+
 	CurrentCursor := aCursor.
 	aCursor beCursor

--- a/src/Graphics-Display Objects.package/Cursor.class/class/currentCursor.st
+++ b/src/Graphics-Display Objects.package/Cursor.class/class/currentCursor.st
@@ -2,4 +2,4 @@ current cursor
 currentCursor
 	"Answer the instance of Cursor that is the one currently displayed."
 
-	^CurrentCursor
+	^ ActiveHand ifNotNil: [ActiveHand world currentCursor] ifNil: [ CurrentCursor ]

--- a/src/Graphics-Display Objects.package/Cursor.class/instance/beCursor.st
+++ b/src/Graphics-Display Objects.package/Cursor.class/instance/beCursor.st
@@ -1,8 +1,4 @@
 primitives
 beCursor
-	"Primitive. Tell the interpreter to use the receiver as the current cursor 
-	image. Fail if the receiver does not match the size expected by the 
-	hardware. Essential. See Object documentation whatIsAPrimitive."
-
-	<primitive: 101>
-	self primitiveFailed
+	"TODO: This is the place for redirecting the be cursor primitive into OSWindow"
+	self primitiveBeCursor

--- a/src/Graphics-Display Objects.package/Cursor.class/instance/beCursorWithMask..st
+++ b/src/Graphics-Display Objects.package/Cursor.class/instance/beCursorWithMask..st
@@ -1,12 +1,4 @@
 primitives
 beCursorWithMask: maskForm
-	"Primitive. Tell the interpreter to use the receiver as the current cursor image with the given mask Form. Both the receiver and the mask should have extent 16@16 and a depth of one. The mask and cursor bits are combined as follow:
-			mask	cursor	effect
-			 0		  0		transparent (underlying pixel shows through)
-			 1		  1		opaque black
-			 1		  0		opaque white
-			 0		  1		invert the underlying pixel"
-"Essential. See Object documentation whatIsAPrimitive."
-
-	<primitive: 101>
-	self primitiveFailed
+	"TODO: This is the place for redirecting the be cursor primitive into OSWindow"
+	self primitiveBeCursorWithMask: maskForm

--- a/src/Graphics-Display Objects.package/Cursor.class/instance/primitiveBeCursor.st
+++ b/src/Graphics-Display Objects.package/Cursor.class/instance/primitiveBeCursor.st
@@ -1,0 +1,8 @@
+primitives
+primitiveBeCursor
+	"Primitive. Tell the interpreter to use the receiver as the current cursor 
+	image. Fail if the receiver does not match the size expected by the 
+	hardware. Essential. See Object documentation whatIsAPrimitive."
+
+	<primitive: 101>
+	self primitiveFailed

--- a/src/Graphics-Display Objects.package/Cursor.class/instance/primitiveBeCursorWithMask..st
+++ b/src/Graphics-Display Objects.package/Cursor.class/instance/primitiveBeCursorWithMask..st
@@ -1,0 +1,12 @@
+primitives
+primitiveBeCursorWithMask: maskForm
+	"Primitive. Tell the interpreter to use the receiver as the current cursor image with the given mask Form. Both the receiver and the mask should have extent 16@16 and a depth of one. The mask and cursor bits are combined as follow:
+			mask	cursor	effect
+			 0		  0		transparent (underlying pixel shows through)
+			 1		  1		opaque black
+			 1		  0		opaque white
+			 0		  1		invert the underlying pixel"
+"Essential. See Object documentation whatIsAPrimitive."
+
+	<primitive: 101>
+	self primitiveFailed

--- a/src/Morphic-Core.package/HandMorph.class/instance/processEventsFromQueue..st
+++ b/src/Morphic-Core.package/HandMorph.class/instance/processEventsFromQueue..st
@@ -12,7 +12,11 @@ processEventsFromQueue: anEventQueue
 	[anEventQueue isNotNil and: [(evtBuf := anEventQueue nextEvent) isNotNil]] whileTrue: 
 			[evt := nil.	"for unknown event types"
 			type := evtBuf first.
-			type = EventTypeMouse ifTrue: [recentModifiers := evtBuf sixth. evt := self generateMouseEvent: evtBuf].
+			type = EventTypeMouse ifTrue: [
+				self world beCursorOwner.
+				recentModifiers := evtBuf sixth.
+				evt := self generateMouseEvent: evtBuf
+			].
 			type = EventTypeKeyboard 
 				ifTrue: [recentModifiers := evtBuf fifth. evt := self generateKeyboardEvent: evtBuf].
 			type = EventTypeDragDropFiles 

--- a/src/Morphic-Core.package/PasteUpMorph.class/instance/currentCursor..st
+++ b/src/Morphic-Core.package/PasteUpMorph.class/instance/currentCursor..st
@@ -1,0 +1,3 @@
+cursor
+currentCursor: aCursor
+	^ worldState currentCursor: aCursor

--- a/src/Morphic-Core.package/PasteUpMorph.class/instance/currentCursor.st
+++ b/src/Morphic-Core.package/PasteUpMorph.class/instance/currentCursor.st
@@ -1,0 +1,3 @@
+cursor
+currentCursor
+	^ worldState currentCursor

--- a/src/Morphic-Core.package/PasteUpMorph.class/instance/isCursorOwner.st
+++ b/src/Morphic-Core.package/PasteUpMorph.class/instance/isCursorOwner.st
@@ -1,0 +1,3 @@
+cursor
+isCursorOwner
+	^ false

--- a/src/Morphic-Core.package/WorldMorph.class/class/cursorOwnerWorld..st
+++ b/src/Morphic-Core.package/WorldMorph.class/class/cursorOwnerWorld..st
@@ -1,0 +1,6 @@
+extra worlds
+cursorOwnerWorld: aWorld
+	CursorOwnerWorld ~~ aWorld ifTrue: [ 
+		CursorOwnerWorld := aWorld.
+		(CursorOwnerWorld currentCursor ifNil: [Cursor normal]) beCursor
+	]

--- a/src/Morphic-Core.package/WorldMorph.class/class/cursorOwnerWorld.st
+++ b/src/Morphic-Core.package/WorldMorph.class/class/cursorOwnerWorld.st
@@ -1,0 +1,3 @@
+extra worlds
+cursorOwnerWorld
+	^ CursorOwnerWorld ifNil: [ World ]

--- a/src/Morphic-Core.package/WorldMorph.class/class/removeExtraWorld..st
+++ b/src/Morphic-Core.package/WorldMorph.class/class/removeExtraWorld..st
@@ -1,3 +1,5 @@
 extra worlds
 removeExtraWorld: aWorld
-	ExtraWorldList := self extraWorldList copyWithout: aWorld
+	ExtraWorldList := self extraWorldList copyWithout: aWorld.
+	CursorOwnerWorld == aWorld ifTrue: [ CursorOwnerWorld := nil. ]
+	

--- a/src/Morphic-Core.package/WorldMorph.class/instance/beCursorOwner.st
+++ b/src/Morphic-Core.package/WorldMorph.class/instance/beCursorOwner.st
@@ -1,0 +1,3 @@
+cursor
+beCursorOwner
+	self class cursorOwnerWorld: self

--- a/src/Morphic-Core.package/WorldMorph.class/instance/isCursorOwner.st
+++ b/src/Morphic-Core.package/WorldMorph.class/instance/isCursorOwner.st
@@ -1,0 +1,3 @@
+cursor
+isCursorOwner
+	^ self class cursorOwnerWorld == self

--- a/src/Morphic-Core.package/WorldMorph.class/properties.json
+++ b/src/Morphic-Core.package/WorldMorph.class/properties.json
@@ -5,6 +5,7 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [
+		"CursorOwnerWorld",
 		"ExtraWorldList"
 	],
 	"instvars" : [

--- a/src/Morphic-Core.package/WorldState.class/instance/currentCursor..st
+++ b/src/Morphic-Core.package/WorldState.class/instance/currentCursor..st
@@ -1,0 +1,3 @@
+accessing
+currentCursor: anObject
+	currentCursor := anObject

--- a/src/Morphic-Core.package/WorldState.class/instance/currentCursor.st
+++ b/src/Morphic-Core.package/WorldState.class/instance/currentCursor.st
@@ -1,0 +1,3 @@
+accessing
+currentCursor
+	^ currentCursor

--- a/src/Morphic-Core.package/WorldState.class/properties.json
+++ b/src/Morphic-Core.package/WorldState.class/properties.json
@@ -28,7 +28,8 @@
 		"alarms",
 		"lastAlarmTime",
 		"menuBuilder",
-		"activeHand"
+		"activeHand",
+		"currentCursor"
 	],
 	"name" : "WorldState",
 	"type" : "normal"

--- a/src/OSWindow-Core.package/OSWindowMorphicEventHandler.class/instance/visitMouseMoveEvent..st
+++ b/src/OSWindow-Core.package/OSWindowMorphicEventHandler.class/instance/visitMouseMoveEvent..st
@@ -2,7 +2,8 @@ visiting
 visitMouseMoveEvent: anEvent
 	| oldPos |
 	oldPos := morphicWorld activeHand ifNil: [ 0@0 ] ifNotNil: [:hand | hand position ].
-
+	morphicWorld beCursorOwner.
+	
 	^ MouseMoveEvent basicNew
 		setType: #mouseMove 
 		startPoint: oldPos

--- a/src/OSWindow-Core.package/monticello.meta/categories.st
+++ b/src/OSWindow-Core.package/monticello.meta/categories.st
@@ -1,7 +1,7 @@
 SystemOrganization addCategory: #'OSWindow-Core'!
-SystemOrganization addCategory: 'OSWindow-Core-Events'!
-SystemOrganization addCategory: 'OSWindow-Core-Events-Touch'!
-SystemOrganization addCategory: 'OSWindow-Core-Extras'!
-SystemOrganization addCategory: 'OSWindow-Core-Gestures'!
-SystemOrganization addCategory: 'OSWindow-Core-Morphic'!
-SystemOrganization addCategory: 'OSWindow-Core-OpenGL'!
+SystemOrganization addCategory: #'OSWindow-Core-Events'!
+SystemOrganization addCategory: #'OSWindow-Core-Events-Touch'!
+SystemOrganization addCategory: #'OSWindow-Core-Extras'!
+SystemOrganization addCategory: #'OSWindow-Core-Gestures'!
+SystemOrganization addCategory: #'OSWindow-Core-Morphic'!
+SystemOrganization addCategory: #'OSWindow-Core-OpenGL'!


### PR DESCRIPTION
Because the current cursor is associated to all the windows of an application in some platforms, we need to add the notion of a cursor owner window. The attached hack solves the rotating cursor bug that happens when opening multiple morphic worlds by calling "OSWindowWorldMorph new". After applying this patch, it is necessary to modify a single method in OSWindow, whose modification is attached.https://pharo.fogbugz.com/f/cases/20416/Add-the-notion-of-a-Cursor-owner