### PR TITLE
20444 FFIExternalStructurePlatformTests cleanup (is32/64bit)

### DIFF
--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is32bit.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is32bit.st
@@ -1,0 +1,4 @@
+private - testing
+is32bit
+	^ Smalltalk vm is32bit 
+		

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is32bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is32bits.st
@@ -1,5 +1,0 @@
-testing
-is32bits
-	^ Smalltalk vm wordSize = 4
-	
-		

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is64bit.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is64bit.st
@@ -1,0 +1,3 @@
+private - testing
+is64bit
+	^ Smalltalk vm is64bit 

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is64bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/is64bits.st
@@ -1,3 +1,0 @@
-testing
-is64bits
-	^ Smalltalk vm wordSize = 8

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectOffsets32bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectOffsets32bits.st
@@ -1,6 +1,6 @@
 tests
 testStructureHasCorrectOffsets32bits
-	self is32bits ifFalse: [ ^ self skip ].
+	self is32bit ifFalse: [ ^ self skip ].
 	
 	FFITestStructureByPlatform compiledSpec. "Ensure fields are initialized"
 	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_LONG) equals: 1.

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectOffsets64bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectOffsets64bits.st
@@ -1,6 +1,6 @@
 tests
 testStructureHasCorrectOffsets64bits
-	self is64bits ifFalse: [ ^ self skip ].
+	self is64bit ifFalse: [ ^ self skip ].
 	
 	FFITestStructureByPlatform compiledSpec. "Ensure fields are initialized"
 	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_LONG) equals: 1.

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectSize32bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectSize32bits.st
@@ -1,6 +1,6 @@
 tests
 testStructureHasCorrectSize32bits
-	self is32bits ifFalse: [ ^ self skip ].
+	self is32bit ifFalse: [ ^ self skip ].
 	
 	self 
 		assert: (FFIExternalType sizeOf: FFITestStructureByPlatform) 

--- a/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectSize64bits.st
+++ b/src/UnifiedFFI-Tests.package/FFIExternalStructurePlatformTests.class/instance/testStructureHasCorrectSize64bits.st
@@ -1,6 +1,6 @@
 tests
 testStructureHasCorrectSize64bits
-	self is64bits ifFalse: [ ^ self skip ].
+	self is64bit ifFalse: [ ^ self skip ].
 	
 	self 
 		assert: (FFIExternalType sizeOf: FFITestStructureByPlatform) 


### PR DESCRIPTION
- use singular instead of plural
- use Smalltalk vm methods instead of checking the wordsize themself
- categorize methods

see https://pharo.fogbugz.com/f/cases/20444/FFIExternalStructurePlatformTests-cleanup-is32-64bit