### PR TITLE
20087-ComposableModelnewList-should-use-FastTable

### DIFF
--- a/src/Spec-Core.package/ComposableModel.class/instance/newList.st
+++ b/src/Spec-Core.package/ComposableModel.class/instance/newList.st
@@ -1,3 +1,3 @@
 widgets
 newList
-	^ self instantiate: ListModel
+	^ self instantiate: FastTableModel


### PR DESCRIPTION
Implements fix suggested in Issue 20087.  All Spec tests are green, and 
ExternalBrowser (which uses #newList) retains its appearance and 
functionality.

If it is true that FastTable is fully-compatible with ListModel, the 
class comment should be updated to say this!