### PR TITLE
20471-Tests-for-Unicode-Categories-are-missing

### DIFF
--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/README.md
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/README.md
@@ -1,0 +1,2 @@
+Tests for the AsciiCharSet class.  The invariant is that AsciiCharSet is  a subset of Unicode, and therefore all of the methods defined there should
+have behaviour consisetent with Unicode.

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/classUnderTest.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/classUnderTest.st
@@ -1,0 +1,3 @@
+helper
+classUnderTest
+	^ AsciiCharset

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsCasedLetter.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsCasedLetter.st
@@ -1,0 +1,11 @@
+generated tests
+testIsCasedLetter
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isCasedLetter: ch) equals: (charset isCasedLetter: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsClosePunctuation.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsClosePunctuation.st
@@ -1,0 +1,11 @@
+generated tests
+testIsClosePunctuation
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isClosePunctuation: ch) equals: (charset isClosePunctuation: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsConnectorPunctuation.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsConnectorPunctuation.st
@@ -1,0 +1,11 @@
+generated tests
+testIsConnectorPunctuation
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isConnectorPunctuation: ch) equals: (charset isConnectorPunctuation: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsControlOther.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsControlOther.st
@@ -1,0 +1,11 @@
+generated tests
+testIsControlOther
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isControlOther: ch) equals: (charset isControlOther: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsCurrencySymbol.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsCurrencySymbol.st
@@ -1,0 +1,11 @@
+generated tests
+testIsCurrencySymbol
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isCurrencySymbol: ch) equals: (charset isCurrencySymbol: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDashPunctuation.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDashPunctuation.st
@@ -1,0 +1,11 @@
+generated tests
+testIsDashPunctuation
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isDashPunctuation: ch) equals: (charset isDashPunctuation: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDecimalDigit.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDecimalDigit.st
@@ -1,0 +1,11 @@
+generated tests
+testIsDecimalDigit
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isDecimalDigit: ch) equals: (charset isDecimalDigit: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDigit.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsDigit.st
@@ -1,0 +1,11 @@
+generated tests
+testIsDigit
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isDigit: ch) equals: (charset isDigit: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsEnclosingMark.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsEnclosingMark.st
@@ -1,0 +1,11 @@
+generated tests
+testIsEnclosingMark
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isEnclosingMark: ch) equals: (charset isEnclosingMark: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsFinalQuote.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsFinalQuote.st
@@ -1,0 +1,11 @@
+generated tests
+testIsFinalQuote
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isFinalQuote: ch) equals: (charset isFinalQuote: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsFormatOther.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsFormatOther.st
@@ -1,0 +1,11 @@
+generated tests
+testIsFormatOther
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isFormatOther: ch) equals: (charset isFormatOther: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsInitialQuote.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsInitialQuote.st
@@ -1,0 +1,11 @@
+generated tests
+testIsInitialQuote
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isInitialQuote: ch) equals: (charset isInitialQuote: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetter.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetter.st
@@ -1,0 +1,11 @@
+generated tests
+testIsLetter
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isLetter: ch) equals: (charset isLetter: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetterModifier.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetterModifier.st
@@ -1,0 +1,11 @@
+generated tests
+testIsLetterModifier
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isLetterModifier: ch) equals: (charset isLetterModifier: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetterNumber.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLetterNumber.st
@@ -1,0 +1,11 @@
+generated tests
+testIsLetterNumber
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isLetterNumber: ch) equals: (charset isLetterNumber: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLineSeparator.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLineSeparator.st
@@ -1,0 +1,11 @@
+generated tests
+testIsLineSeparator
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isLineSeparator: ch) equals: (charset isLineSeparator: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLowercase.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsLowercase.st
@@ -1,0 +1,11 @@
+generated tests
+testIsLowercase
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isLowercase: ch) equals: (charset isLowercase: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsMathSymbol.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsMathSymbol.st
@@ -1,0 +1,11 @@
+generated tests
+testIsMathSymbol
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isMathSymbol: ch) equals: (charset isMathSymbol: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsModifierSymbol.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsModifierSymbol.st
@@ -1,0 +1,11 @@
+generated tests
+testIsModifierSymbol
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isModifierSymbol: ch) equals: (charset isModifierSymbol: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsNonspacingMark.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsNonspacingMark.st
@@ -1,0 +1,11 @@
+generated tests
+testIsNonspacingMark
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isNonspacingMark: ch) equals: (charset isNonspacingMark: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOpenPunctuation.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOpenPunctuation.st
@@ -1,0 +1,11 @@
+generated tests
+testIsOpenPunctuation
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isOpenPunctuation: ch) equals: (charset isOpenPunctuation: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherLetter.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherLetter.st
@@ -1,0 +1,11 @@
+generated tests
+testIsOtherLetter
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isOtherLetter: ch) equals: (charset isOtherLetter: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherNumber.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherNumber.st
@@ -1,0 +1,11 @@
+generated tests
+testIsOtherNumber
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isOtherNumber: ch) equals: (charset isOtherNumber: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherPunctuation.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherPunctuation.st
@@ -1,0 +1,11 @@
+generated tests
+testIsOtherPunctuation
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isOtherPunctuation: ch) equals: (charset isOtherPunctuation: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherSymbol.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsOtherSymbol.st
@@ -1,0 +1,11 @@
+generated tests
+testIsOtherSymbol
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isOtherSymbol: ch) equals: (charset isOtherSymbol: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsParagraphSeparator.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsParagraphSeparator.st
@@ -1,0 +1,11 @@
+generated tests
+testIsParagraphSeparator
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isParagraphSeparator: ch) equals: (charset isParagraphSeparator: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsPrivateOther.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsPrivateOther.st
@@ -1,0 +1,11 @@
+generated tests
+testIsPrivateOther
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isPrivateOther: ch) equals: (charset isPrivateOther: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSpaceSeparator.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSpaceSeparator.st
@@ -1,0 +1,11 @@
+generated tests
+testIsSpaceSeparator
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isSpaceSeparator: ch) equals: (charset isSpaceSeparator: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSpacingCombiningMark.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSpacingCombiningMark.st
@@ -1,0 +1,11 @@
+generated tests
+testIsSpacingCombiningMark
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isSpacingCombiningMark: ch) equals: (charset isSpacingCombiningMark: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSurrogateOther.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsSurrogateOther.st
@@ -1,0 +1,11 @@
+generated tests
+testIsSurrogateOther
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isSurrogateOther: ch) equals: (charset isSurrogateOther: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsTitlecaseLetter.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsTitlecaseLetter.st
@@ -1,0 +1,11 @@
+generated tests
+testIsTitlecaseLetter
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isTitlecaseLetter: ch) equals: (charset isTitlecaseLetter: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsUppercase.st
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/instance/testIsUppercase.st
@@ -1,0 +1,11 @@
+generated tests
+testIsUppercase
+
+	"Exhaustively check that the charset under test behaves like Unicode"
+
+	| charset |
+	charset := self classUnderTest.
+	0 to: charset maxValue do: [ :asciiValue | 
+		| ch |
+		ch := Character value: asciiValue.
+		self assert: (Unicode isUppercase: ch) equals: (charset isUppercase: ch) ]

--- a/src/Kernel-Tests.package/AsciiCharsetTest.class/properties.json
+++ b/src/Kernel-Tests.package/AsciiCharsetTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "AndrewBlack 10/9/2017 14:35",
+	"super" : "TestCase",
+	"category" : "Kernel-Tests-Charset",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "AsciiCharsetTest",
+	"type" : "normal"
+}

--- a/src/Kernel-Tests.package/Latin1CharsetTest.class/README.md
+++ b/src/Kernel-Tests.package/Latin1CharsetTest.class/README.md
@@ -1,0 +1,4 @@
+Tests for the Latin1Charset class.  The invariant is that Latin1Charset is  a subset of Unicode, and therefore all of the methods defined there should
+have behaviour consisetent with Unicode.
+
+There may appeaer to be no tests here; that's because this class inherits all of  its tests from AsciiCharset.

--- a/src/Kernel-Tests.package/Latin1CharsetTest.class/instance/classUnderTest.st
+++ b/src/Kernel-Tests.package/Latin1CharsetTest.class/instance/classUnderTest.st
@@ -1,0 +1,3 @@
+helper
+classUnderTest
+	^ Latin1

--- a/src/Kernel-Tests.package/Latin1CharsetTest.class/properties.json
+++ b/src/Kernel-Tests.package/Latin1CharsetTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "AndrewBlack 10/9/2017 15:50",
+	"super" : "AsciiCharsetTest",
+	"category" : "Kernel-Tests-Charset",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "Latin1CharsetTest",
+	"type" : "normal"
+}

--- a/src/Kernel-Tests.package/UnicodeTest.class/README.md
+++ b/src/Kernel-Tests.package/UnicodeTest.class/README.md
@@ -1,0 +1,4 @@
+Tests the character classification methods against the generalCategory table.  
+
+Note that the correctness of the table is not checked. 
+It probebably should be, but that is another task. 

--- a/src/Kernel-Tests.package/UnicodeTest.class/class/resources.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/class/resources.st
@@ -1,0 +1,3 @@
+accessing
+resources
+	^ { UnicodeTestRNG }

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/aRandomSelectionOfCharactersDo..st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/aRandomSelectionOfCharactersDo..st
@@ -1,0 +1,3 @@
+helper
+aRandomSelectionOfCharactersDo: aBlock
+	self aRandomSelectionOfCodePointsDo: [ :cp | aBlock value: (Character codePoint: cp) ]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/aRandomSelectionOfCodePointsDo..st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/aRandomSelectionOfCodePointsDo..st
@@ -1,0 +1,4 @@
+helper
+aRandomSelectionOfCodePointsDo: aBlock
+	0 to: 255 do: [ :cp | aBlock value: cp].
+	500 timesRepeat: [ aBlock value: (unicodeGenerator randomCodePointAtOrAbove: 256) ].

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/checkCorrespondanceOf.and..st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/checkCorrespondanceOf.and..st
@@ -1,0 +1,9 @@
+helper
+checkCorrespondanceOf: aSelector and: aCategoryTag 
+	| cat methodAnswer catFromTable |
+	cat := Unicode classPool at: aCategoryTag.
+	self aRandomSelectionOfCodePointsDo: [ :cp |
+		methodAnswer := Unicode perform: aSelector with: (Character codePoint: cp).
+		catFromTable := Unicode generalCategory at: cp + 1.
+		self assert: methodAnswer equals: (catFromTable = cat)
+	]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/checkCorrespondanceOf.and..st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/checkCorrespondanceOf.and..st
@@ -4,6 +4,9 @@ checkCorrespondanceOf: aSelector and: aCategoryTag
 	cat := Unicode classPool at: aCategoryTag.
 	self aRandomSelectionOfCodePointsDo: [ :cp |
 		methodAnswer := Unicode perform: aSelector with: (Character codePoint: cp).
-		catFromTable := Unicode generalCategory at: cp + 1.
+		catFromTable := self unicodeCategoryTableLookup: cp.
+		(methodAnswer = (catFromTable = cat)) ifFalse: [ 
+			Transcript show: aSelector; show: 'and category '; show: aCategoryTag ;
+			show: 'disagree at U+'; show: cp asHexString ; cr ].
 		self assert: methodAnswer equals: (catFromTable = cat)
 	]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/setUp.st
@@ -1,0 +1,3 @@
+helper
+setUp
+	unicodeGenerator := UnicodeTestRNG current

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/setUp.st
@@ -1,3 +1,3 @@
-helper
+running
 setUp
 	unicodeGenerator := UnicodeTestRNG current

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsCasedLetter.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsCasedLetter.st
@@ -1,0 +1,5 @@
+tests-categorization
+testIsCasedLetter
+	"The Cased letter category, LC, is empty"
+	self aRandomSelectionOfCharactersDo: [ :ch | 
+		self deny: (Unicode isCasedLetter: ch) ]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsClosePunctuation.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsClosePunctuation.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsClosePunctuation
+	self checkCorrespondanceOf: #isClosePunctuation: and: #Pe

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsConnectorPunctuation.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsConnectorPunctuation.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsConnectorPunctuation
+	self checkCorrespondanceOf: #isConnectorPunctuation: and: #Pc

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsControlOther.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsControlOther.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsControlOther
+	self checkCorrespondanceOf: #isControlOther: and: #Cc

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsCurrencySymbol.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsCurrencySymbol.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsCurrencySymbol
+	self checkCorrespondanceOf: #isCurrencySymbol: and: #Sc

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDashPunctuation.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDashPunctuation.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsDashPunctuation
+	self checkCorrespondanceOf: #isDashPunctuation: and: #Pd

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDecimalDigit.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDecimalDigit.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsDecimalDigit
+	self checkCorrespondanceOf: #isDecimalDigit: and: #Nd

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDigit.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsDigit.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsDigit
+	self checkCorrespondanceOf: #isDigit: and: #Nd

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsEnclosingMark.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsEnclosingMark.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsEnclosingMark
+	self checkCorrespondanceOf: #isEnclosingMark: and: #Me

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsFinalQuote.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsFinalQuote.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsFinalQuote
+	self checkCorrespondanceOf: #isFinalQuote: and: #Pf

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsFormatOther.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsFormatOther.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsFormatOther
+	self checkCorrespondanceOf: #isFormatOther: and: #Cf

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsInitialQuote.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsInitialQuote.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsInitialQuote
+	self checkCorrespondanceOf: #isInitialQuote: and: #Pi

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetter.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetter.st
@@ -1,0 +1,8 @@
+tests-categorization
+testIsLetter
+	| letterCategories methodAnswer catFromTable |
+	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode classPool at: c ].
+	self aRandomSelectionOfCodePointsDo: [ :cp | 
+			methodAnswer := Unicode isLetter: (Character codePoint: cp).
+			catFromTable := self unicodeCategoryTableLookup: cp.
+			self assert: methodAnswer equals: (letterCategories includes: catFromTable) ]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetterModifier.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetterModifier.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsLetterModifier
+	self checkCorrespondanceOf: #isLetterModifier: and: #Lm

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetterNumber.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLetterNumber.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsLetterNumber
+	self checkCorrespondanceOf: #isLetterNumber: and: #Nl

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLineSeparator.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLineSeparator.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsLineSeparator
+	self checkCorrespondanceOf: #isLineSeparator: and: #Zl

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLowercase.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsLowercase.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsLowercase
+	self checkCorrespondanceOf: #isLowercase: and: #Ll

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsMathSymbol.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsMathSymbol.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsMathSymbol
+	self checkCorrespondanceOf: #isMathSymbol: and: #Sm

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsModifierSymbol.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsModifierSymbol.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsModifierSymbol
+	self checkCorrespondanceOf: #isModifierSymbol: and: #Sk

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsNonspacingMark.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsNonspacingMark.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsNonspacingMark
+	self checkCorrespondanceOf: #isNonspacingMark: and: #Mn

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOpenPunctuation.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOpenPunctuation.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsOpenPunctuation
+	self checkCorrespondanceOf: #isOpenPunctuation: and: #Ps

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherLetter.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherLetter.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsOtherLetter
+	self checkCorrespondanceOf: #isOtherLetter: and: #Lo

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherNumber.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherNumber.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsOtherNumber
+	self checkCorrespondanceOf: #isOtherNumber: and: #No

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherPunctuation.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherPunctuation.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsOtherPunctuation
+	self checkCorrespondanceOf: #isOtherPunctuation: and: #Po

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherSymbol.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsOtherSymbol.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsOtherSymbol
+	self checkCorrespondanceOf: #isOtherSymbol: and: #So

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsParagraphSeparator.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsParagraphSeparator.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsParagraphSeparator
+	self checkCorrespondanceOf: #isParagraphSeparator: and: #Zp

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsPrivateOther.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsPrivateOther.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsPrivateOther
+	self checkCorrespondanceOf: #isPrivateOther: and: #Co

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSpaceSeparator.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSpaceSeparator.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsSpaceSeparator
+	self checkCorrespondanceOf: #isSpaceSeparator: and: #Zs

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSpacingCombiningMark.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSpacingCombiningMark.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsSpacingCombiningMark
+	self checkCorrespondanceOf: #isSpacingCombiningMark: and: #Mc

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSurrogateOther.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsSurrogateOther.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsSurrogateOther
+	self checkCorrespondanceOf: #isSurrogateOther: and: #Cs

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsTitlecaseLetter.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsTitlecaseLetter.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsTitlecaseLetter
+	self checkCorrespondanceOf: #isTitlecaseLetter: and: #Lt

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsUppercase.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testIsUppercase.st
@@ -1,0 +1,3 @@
+tests-categorization
+testIsUppercase
+	self checkCorrespondanceOf: #isUppercase: and: #Lu

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testNonCharacterNegative.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testNonCharacterNegative.st
@@ -1,0 +1,5 @@
+tests-categorization
+testNonCharacterNegative
+	self aRandomSelectionOfCharactersDo: [  :ch |
+		self deny: (Unicode isNonCharacter: ch) 
+	]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testNonCharacterPositive.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testNonCharacterPositive.st
@@ -1,0 +1,8 @@
+tests-categorization
+testNonCharacterPositive
+	| nonCps |
+	nonCps := (16rFDD0 to: 16rFDEF) asSet. 
+	nonCps addAll: (16r0FFFE to: 16r10FFFE by: 16r10000).
+	nonCps addAll: (16r0FFFF to: 16r10FFFF by: 16r10000).
+	self assert: nonCps size equals: 66.		"defined that way by the standard"
+	nonCps do: [ :each | self assert: (Unicode isNonCharacter: (Character codePoint: each)) ]

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/testRNG.st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/testRNG.st
@@ -1,0 +1,7 @@
+helper
+testRNG
+	| chars uniqueCount |
+	chars := (1 to: 100)
+		collect: [ :_ | unicodeGenerator randomCharacter].
+	uniqueCount := chars asSet size.
+	self assert: uniqueCount = 100 description: (100 - uniqueCount) asString , ' duplicates'

--- a/src/Kernel-Tests.package/UnicodeTest.class/instance/unicodeCategoryTableLookup..st
+++ b/src/Kernel-Tests.package/UnicodeTest.class/instance/unicodeCategoryTableLookup..st
@@ -1,0 +1,8 @@
+helper
+unicodeCategoryTableLookup: codePoint
+	| index table |
+	index := codePoint + 1.
+	table := Unicode generalCategory.
+	^ index > table size
+		ifTrue: [ -1 ]
+		ifFalse: [ table at: index ]

--- a/src/Kernel-Tests.package/UnicodeTest.class/properties.json
+++ b/src/Kernel-Tests.package/UnicodeTest.class/properties.json
@@ -1,0 +1,15 @@
+{
+	"commentStamp" : "AndrewBlack 10/9/2017 17:46",
+	"super" : "TestCase",
+	"category" : "Kernel-Tests-Charset",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"rng",
+		"nonCharacters",
+		"unicodeGenerator"
+	],
+	"name" : "UnicodeTest",
+	"type" : "normal"
+}

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/README.md
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/README.md
@@ -1,0 +1,1 @@
+The random number generator used by the UnicodeTest

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/generator.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/generator.st
@@ -1,0 +1,3 @@
+private
+generator
+	^ generator

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/next.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/next.st
@@ -1,0 +1,3 @@
+private
+next
+	^ generator next

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/nonCharacters.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/nonCharacters.st
@@ -1,0 +1,8 @@
+private
+nonCharacters
+	nonCharacters
+		ifNil: [ nonCharacters := (16rFDD0 to: 16rFDEF) asOrderedCollection
+				, #(16rFFFE 16rFFFF 16r1FFFE 16r1FFFF 16r0002FFFE 16r0002FFFF 16r0003FFFE 16r0003FFFF)
+				, (16r4FFFE to: 16rFFFFE by: 16r10000) , (16r4FFFF to: 16rFFFFF by: 16r10000)
+				, #(16r0010FFFE 16r0010FFFF) ].
+	^ nonCharacters

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacter.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacter.st
@@ -1,0 +1,3 @@
+running
+randomCharacter
+	^ self randomCharacterBetween: 0 and: Unicode maxValue  

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacterAtOrAbove..st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacterAtOrAbove..st
@@ -1,0 +1,3 @@
+running
+randomCharacterAtOrAbove: lower
+	^ self randomCharacterBetween: lower and: Unicode maxValue  

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacterBetween.and..st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCharacterBetween.and..st
@@ -1,0 +1,3 @@
+running
+randomCharacterBetween: lower and: upper
+	^ Character codePoint: (self randomCodePointBetween: lower and: upper) 

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePoint.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePoint.st
@@ -1,0 +1,3 @@
+running
+randomCodePoint
+	^ self randomCodePointBetween: 0 and: Unicode maxValue  

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointAtOrAbove..st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointAtOrAbove..st
@@ -1,0 +1,3 @@
+running
+randomCodePointAtOrAbove: lower
+	^ self randomCodePointBetween: lower and: Unicode maxValue  

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointBetween.and..st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointBetween.and..st
@@ -1,0 +1,7 @@
+running
+randomCodePointBetween: lower and: upper
+	| max span codePoint |
+	max := upper min: 16rE01EF.
+	span := max - lower + 1.
+	[self nonCharacters includes: (codePoint := (self generator next * span) floor + lower) ] whileTrue.
+	^ codePoint

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointBetween.and..st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/randomCodePointBetween.and..st
@@ -3,5 +3,8 @@ randomCodePointBetween: lower and: upper
 	| max span codePoint |
 	max := upper min: 16rE01EF.
 	span := max - lower + 1.
-	[self nonCharacters includes: (codePoint := (self generator next * span) floor + lower) ] whileTrue.
+	[
+		codePoint := (self generator next * span) floor + lower.
+		Unicode isNonCharacter: (Character codePoint: codePoint) 
+	] whileTrue.
 	^ codePoint

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/setUp.st
@@ -1,4 +1,3 @@
-initialization
+running
 setUp
-	Transcript show: self className ; show: ' setUp'; cr.
 	generator := Random seed: 14159265.

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/setUp.st
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/instance/setUp.st
@@ -1,0 +1,4 @@
+initialization
+setUp
+	Transcript show: self className ; show: ' setUp'; cr.
+	generator := Random seed: 14159265.

--- a/src/Kernel-Tests.package/UnicodeTestRNG.class/properties.json
+++ b/src/Kernel-Tests.package/UnicodeTestRNG.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"commentStamp" : "AndrewBlack 10/9/2017 17:52",
+	"super" : "TestResource",
+	"category" : "Kernel-Tests-Charset",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"generator",
+		"nonCharacters"
+	],
+	"name" : "UnicodeTestRNG",
+	"type" : "normal"
+}

--- a/src/Kernel-Tests.package/monticello.meta/categories.st
+++ b/src/Kernel-Tests.package/monticello.meta/categories.st
@@ -1,4 +1,5 @@
 SystemOrganization addCategory: #'Kernel-Tests'!
+SystemOrganization addCategory: #'Kernel-Tests-Charset'!
 SystemOrganization addCategory: #'Kernel-Tests-Chronology'!
 SystemOrganization addCategory: #'Kernel-Tests-Classes'!
 SystemOrganization addCategory: #'Kernel-Tests-Exception'!

--- a/src/Kernel.package/AsciiCharset.class/README.md
+++ b/src/Kernel.package/AsciiCharset.class/README.md
@@ -1,1 +1,4 @@
-Notify to abort a task
+This class defines the attributes of the ASCII character set.  It's here to be used while boostrapping the image; eventually, it will be replaced by the
+Unicode character set.
+
+Character objects delegate behaviour to one of the  character sets AsciiCharSet, Latin1, or Unicode. 

--- a/src/Kernel.package/AsciiCharset.class/class/isCasedLetter..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isCasedLetter..st
@@ -1,0 +1,4 @@
+character classification
+isCasedLetter: char
+	"There are no ASCII Characters in this Category"
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isClosePunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isClosePunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isClosePunctuation: char
+	^ ')]}' includes: char

--- a/src/Kernel.package/AsciiCharset.class/class/isConnectorPunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isConnectorPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isConnectorPunctuation: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isConnectorPunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isConnectorPunctuation..st
@@ -1,3 +1,3 @@
 character classification
 isConnectorPunctuation: char
-	^ false
+	^ char = $_

--- a/src/Kernel.package/AsciiCharset.class/class/isControlOther..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isControlOther..st
@@ -1,0 +1,6 @@
+character classification
+isControlOther: char 
+	| code |
+	code := char charCode.
+	code <= 16r1F ifTrue: [ ^ true ].
+	^ code = Character delete

--- a/src/Kernel.package/AsciiCharset.class/class/isControlOther..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isControlOther..st
@@ -1,6 +1,4 @@
 character classification
-isControlOther: char 
-	| code |
-	code := char charCode.
-	code <= 16r1F ifTrue: [ ^ true ].
-	^ code = Character delete
+isControlOther: char
+	char charCode <= 16r1F ifTrue: [ ^ true ].
+	^ char = Character delete 

--- a/src/Kernel.package/AsciiCharset.class/class/isCurrencySymbol..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isCurrencySymbol..st
@@ -1,0 +1,3 @@
+character classification
+isCurrencySymbol: char
+	^ char = $$

--- a/src/Kernel.package/AsciiCharset.class/class/isDashPunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isDashPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isDashPunctuation: char
+	^ char = $-

--- a/src/Kernel.package/AsciiCharset.class/class/isDecimalDigit..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isDecimalDigit..st
@@ -1,0 +1,3 @@
+character classification
+isDecimalDigit: char
+	^ self isDigit: char

--- a/src/Kernel.package/AsciiCharset.class/class/isDigit..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isDigit..st
@@ -1,4 +1,4 @@
-casing
+character classification
 isDigit: aCharacter
 
 	^ aCharacter between: $0 and: $9

--- a/src/Kernel.package/AsciiCharset.class/class/isEnclosingMark..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isEnclosingMark..st
@@ -1,0 +1,3 @@
+character classification
+isEnclosingMark: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isFinalQuote..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isFinalQuote..st
@@ -1,0 +1,3 @@
+character classification
+isFinalQuote: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isFormatOther..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isFormatOther..st
@@ -1,0 +1,3 @@
+character classification
+isFormatOther: char 
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isInitialQuote..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isInitialQuote..st
@@ -1,0 +1,3 @@
+character classification
+isInitialQuote: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isLetter..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isLetter..st
@@ -1,4 +1,4 @@
-casing
+character classification
 isLetter: aCharacter
 
 	^ (aCharacter between: $a and: $z)

--- a/src/Kernel.package/AsciiCharset.class/class/isLetterModifier..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isLetterModifier..st
@@ -1,0 +1,3 @@
+character classification
+isLetterModifier: char 
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isLetterNumber..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isLetterNumber..st
@@ -1,0 +1,3 @@
+character classification
+isLetterNumber: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isLineSeparator..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isLineSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isLineSeparator: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isLowercase..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isLowercase..st
@@ -1,4 +1,4 @@
-casing
+character classification
 isLowercase: aCharacter
 
 	^ (aCharacter between: $a and: $z)

--- a/src/Kernel.package/AsciiCharset.class/class/isMathSymbol..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isMathSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isMathSymbol: char
+	^ '+<=>|~' includes: char

--- a/src/Kernel.package/AsciiCharset.class/class/isModifierSymbol..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isModifierSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isModifierSymbol: char
+	^ '^`' includes: char

--- a/src/Kernel.package/AsciiCharset.class/class/isNonspacingMark..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isNonspacingMark..st
@@ -1,0 +1,3 @@
+character classification
+isNonspacingMark: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isOpenPunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isOpenPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isOpenPunctuation: char
+	^ '([{' includes: char

--- a/src/Kernel.package/AsciiCharset.class/class/isOtherLetter..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isOtherLetter..st
@@ -1,0 +1,3 @@
+character classification
+isOtherLetter: char 
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isOtherNumber..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isOtherNumber..st
@@ -1,0 +1,3 @@
+character classification
+isOtherNumber: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isOtherPunctuation..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isOtherPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isOtherPunctuation: char
+	^ '!"#%&''*,./:;?@\' includes: char

--- a/src/Kernel.package/AsciiCharset.class/class/isOtherSymbol..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isOtherSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isOtherSymbol: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isParagraphSeparator..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isParagraphSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isParagraphSeparator: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isPrivateOther..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isPrivateOther..st
@@ -1,0 +1,3 @@
+character classification
+isPrivateOther: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isSpaceSeparator..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isSpaceSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isSpaceSeparator: char
+	^ char = Character space

--- a/src/Kernel.package/AsciiCharset.class/class/isSpacingCombiningMark..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isSpacingCombiningMark..st
@@ -1,0 +1,3 @@
+character classification
+isSpacingCombiningMark: char
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isSurrogateOther..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isSurrogateOther..st
@@ -1,0 +1,3 @@
+character classification
+isSurrogateOther: char 
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isTitlecaseLetter..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isTitlecaseLetter..st
@@ -1,0 +1,3 @@
+character classification
+isTitlecaseLetter: char 
+	^ false

--- a/src/Kernel.package/AsciiCharset.class/class/isUppercase..st
+++ b/src/Kernel.package/AsciiCharset.class/class/isUppercase..st
@@ -1,4 +1,4 @@
-casing
+character classification
 isUppercase: aCharacter
 
 	^ (aCharacter between: $A and: $Z)

--- a/src/Kernel.package/AsciiCharset.class/class/maxValue.st
+++ b/src/Kernel.package/AsciiCharset.class/class/maxValue.st
@@ -1,0 +1,5 @@
+sizing
+maxValue
+	"The maximum value of a character in this character set"
+
+	^ 127

--- a/src/Kernel.package/AsciiCharset.class/class/toLowercase..st
+++ b/src/Kernel.package/AsciiCharset.class/class/toLowercase..st
@@ -1,9 +1,9 @@
 casing
 toLowercase: aCharacter
-	"(AsciiCharset new toLowercase: $A) >>> $a.
-	(AsciiCharset new toLowercase: $a) >>> $a.
-	(AsciiCharset new toLowercase: $!) >>> $!"
+	"(AsciiCharset toLowercase: $A) >>> $a.
+	 (AsciiCharset  toLowercase: $a) >>> $a.
+	 (AsciiCharset  toLowercase: $!) >>> $!"
+
 	(aCharacter between: $A and: $Z)
 		ifFalse: [ ^ aCharacter ].
-	
-	^ Character value: (aCharacter asciiValue + $a asInteger - $A asInteger )
+	^ Character value: aCharacter asciiValue + $a asInteger - $A asInteger

--- a/src/Kernel.package/AsciiCharset.class/class/ucsTable.st
+++ b/src/Kernel.package/AsciiCharset.class/class/ucsTable.st
@@ -1,0 +1,3 @@
+character classification
+ucsTable
+	^ Latin1 ucsTable 

--- a/src/Kernel.package/AsciiCharset.class/properties.json
+++ b/src/Kernel.package/AsciiCharset.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "GuillermoPolito 19/07/2017 17:02",
+	"commentStamp" : "AndrewBlack 10/9/2017 14:20",
 	"super" : "Object",
 	"category" : "Kernel-BasicObjects",
 	"classinstvars" : [ ],

--- a/src/Kernel.package/Character.class/instance/isCasedLetter.st
+++ b/src/Kernel.package/Character.class/instance/isCasedLetter.st
@@ -1,0 +1,3 @@
+testing
+isCasedLetter
+^ self characterSet isCasedLetter: self

--- a/src/Kernel.package/Character.class/instance/isClosePunctuation.st
+++ b/src/Kernel.package/Character.class/instance/isClosePunctuation.st
@@ -1,0 +1,3 @@
+testing
+isClosePunctuation
+^ self characterSet isClosePunctuation: self

--- a/src/Kernel.package/Character.class/instance/isConnectorPunctuation.st
+++ b/src/Kernel.package/Character.class/instance/isConnectorPunctuation.st
@@ -1,0 +1,3 @@
+testing
+isConnectorPunctuation
+^ self characterSet isConnectorPunctuation: self

--- a/src/Kernel.package/Character.class/instance/isControlOther.st
+++ b/src/Kernel.package/Character.class/instance/isControlOther.st
@@ -1,0 +1,4 @@
+testing
+isControlOther
+
+	^ self characterSet isControlOther: self.

--- a/src/Kernel.package/Character.class/instance/isCurrencySymbol.st
+++ b/src/Kernel.package/Character.class/instance/isCurrencySymbol.st
@@ -1,0 +1,3 @@
+testing
+isCurrencySymbol
+^ self characterSet isCurrencySymbol: self

--- a/src/Kernel.package/Character.class/instance/isDashPunctuation.st
+++ b/src/Kernel.package/Character.class/instance/isDashPunctuation.st
@@ -1,0 +1,3 @@
+testing
+isDashPunctuation
+^ self characterSet isDashPunctuation: self

--- a/src/Kernel.package/Character.class/instance/isDecimalDigit.st
+++ b/src/Kernel.package/Character.class/instance/isDecimalDigit.st
@@ -1,0 +1,3 @@
+testing
+isDecimalDigit
+^ self characterSet isDecimalDigit: self

--- a/src/Kernel.package/Character.class/instance/isEnclosingMark.st
+++ b/src/Kernel.package/Character.class/instance/isEnclosingMark.st
@@ -1,0 +1,3 @@
+testing
+isEnclosingMark
+^ self characterSet isEnclosingMark: self

--- a/src/Kernel.package/Character.class/instance/isFinalQuote.st
+++ b/src/Kernel.package/Character.class/instance/isFinalQuote.st
@@ -1,0 +1,3 @@
+testing
+isFinalQuote
+^ self characterSet isFinalQuote: self

--- a/src/Kernel.package/Character.class/instance/isFormatOther.st
+++ b/src/Kernel.package/Character.class/instance/isFormatOther.st
@@ -1,0 +1,3 @@
+testing
+isFormatOther
+^ self characterSet isFormatOther: self

--- a/src/Kernel.package/Character.class/instance/isInitialQuote.st
+++ b/src/Kernel.package/Character.class/instance/isInitialQuote.st
@@ -1,0 +1,3 @@
+testing
+isInitialQuote
+^ self characterSet isInitialQuote: self

--- a/src/Kernel.package/Character.class/instance/isLetterModifier.st
+++ b/src/Kernel.package/Character.class/instance/isLetterModifier.st
@@ -1,0 +1,3 @@
+testing
+isLetterModifier
+^ self characterSet isLetterModifier: self

--- a/src/Kernel.package/Character.class/instance/isLetterNumber.st
+++ b/src/Kernel.package/Character.class/instance/isLetterNumber.st
@@ -1,0 +1,3 @@
+testing
+isLetterNumber
+^ self characterSet isLetterNumber: self

--- a/src/Kernel.package/Character.class/instance/isLineSeparator.st
+++ b/src/Kernel.package/Character.class/instance/isLineSeparator.st
@@ -1,0 +1,3 @@
+testing
+isLineSeparator
+^ self characterSet isLineSeparator: self

--- a/src/Kernel.package/Character.class/instance/isMathSymbol.st
+++ b/src/Kernel.package/Character.class/instance/isMathSymbol.st
@@ -1,0 +1,3 @@
+testing
+isMathSymbol
+^ self characterSet isMathSymbol: self

--- a/src/Kernel.package/Character.class/instance/isModifierSymbol.st
+++ b/src/Kernel.package/Character.class/instance/isModifierSymbol.st
@@ -1,0 +1,3 @@
+testing
+isModifierSymbol
+^ self characterSet isModifierSymbol: self

--- a/src/Kernel.package/Character.class/instance/isNonspacingMark.st
+++ b/src/Kernel.package/Character.class/instance/isNonspacingMark.st
@@ -1,0 +1,3 @@
+testing
+isNonspacingMark
+^ self characterSet isNonspacingMark: self

--- a/src/Kernel.package/Character.class/instance/isOpenPunctuation.st
+++ b/src/Kernel.package/Character.class/instance/isOpenPunctuation.st
@@ -1,0 +1,3 @@
+testing
+isOpenPunctuation
+^ self characterSet isOpenPunctuation: self

--- a/src/Kernel.package/Character.class/instance/isOtherLetter.st
+++ b/src/Kernel.package/Character.class/instance/isOtherLetter.st
@@ -1,0 +1,3 @@
+testing
+isOtherLetter
+^ self characterSet isOtherLetter: self

--- a/src/Kernel.package/Character.class/instance/isOtherNumber.st
+++ b/src/Kernel.package/Character.class/instance/isOtherNumber.st
@@ -1,0 +1,3 @@
+testing
+isOtherNumber
+^ self characterSet isOtherNumber: self

--- a/src/Kernel.package/Character.class/instance/isOtherPunctuation.st
+++ b/src/Kernel.package/Character.class/instance/isOtherPunctuation.st
@@ -1,0 +1,3 @@
+testing
+isOtherPunctuation
+^ self characterSet isOtherPunctuation: self

--- a/src/Kernel.package/Character.class/instance/isOtherSymbol.st
+++ b/src/Kernel.package/Character.class/instance/isOtherSymbol.st
@@ -1,0 +1,3 @@
+testing
+isOtherSymbol
+^ self characterSet isOtherSymbol: self

--- a/src/Kernel.package/Character.class/instance/isParagraphSeparator.st
+++ b/src/Kernel.package/Character.class/instance/isParagraphSeparator.st
@@ -1,0 +1,3 @@
+testing
+isParagraphSeparator
+^ self characterSet isParagraphSeparator: self

--- a/src/Kernel.package/Character.class/instance/isPrivateOther.st
+++ b/src/Kernel.package/Character.class/instance/isPrivateOther.st
@@ -1,0 +1,3 @@
+testing
+isPrivateOther
+^ self characterSet isPrivateOther: self

--- a/src/Kernel.package/Character.class/instance/isSpaceSeparator.st
+++ b/src/Kernel.package/Character.class/instance/isSpaceSeparator.st
@@ -1,0 +1,3 @@
+testing
+isSpaceSeparator
+^ self characterSet isSpaceSeparator: self

--- a/src/Kernel.package/Character.class/instance/isSpacingCombiningMark.st
+++ b/src/Kernel.package/Character.class/instance/isSpacingCombiningMark.st
@@ -1,0 +1,3 @@
+testing
+isSpacingCombiningMark
+^ self characterSet isSpacingCombiningMark: self

--- a/src/Kernel.package/Character.class/instance/isSurrogateOther.st
+++ b/src/Kernel.package/Character.class/instance/isSurrogateOther.st
@@ -1,0 +1,3 @@
+testing
+isSurrogateOther
+^ self characterSet isSurrogateOther: self

--- a/src/Kernel.package/Character.class/instance/isTitlecaseLetter.st
+++ b/src/Kernel.package/Character.class/instance/isTitlecaseLetter.st
@@ -1,0 +1,3 @@
+testing
+isTitlecaseLetter
+^ self characterSet isTitlecaseLetter: self

--- a/src/Morphic-Base.package/ManifestMorphicBase.class/README.md
+++ b/src/Morphic-Base.package/ManifestMorphicBase.class/README.md
@@ -1,0 +1,1 @@
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser

--- a/src/Morphic-Base.package/ManifestMorphicBase.class/class/ruleRBClassNameInSelectorRuleV1FalsePositive.st
+++ b/src/Morphic-Base.package/ManifestMorphicBase.class/class/ruleRBClassNameInSelectorRuleV1FalsePositive.st
@@ -1,0 +1,3 @@
+code-critics
+ruleRBClassNameInSelectorRuleV1FalsePositive
+	^ #(#(#(#RGMethodDefinition #(#'StringMorph class' #exampleManyStringMorphs #true)) #'2017-09-29T14:22:18.600353+02:00') )

--- a/src/Morphic-Base.package/ManifestMorphicBase.class/class/ruleRBRefersToClassRuleV1FalsePositive.st
+++ b/src/Morphic-Base.package/ManifestMorphicBase.class/class/ruleRBRefersToClassRuleV1FalsePositive.st
@@ -1,0 +1,3 @@
+code-critics
+ruleRBRefersToClassRuleV1FalsePositive
+	^ #(#(#(#RGMethodDefinition #(#'StringMorph class' #exampleManyStringMorphs #true)) #'2017-09-29T14:22:14.93688+02:00') )

--- a/src/Morphic-Base.package/ManifestMorphicBase.class/properties.json
+++ b/src/Morphic-Base.package/ManifestMorphicBase.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "<historical>",
+	"super" : "PackageManifest",
+	"category" : "Morphic-Base",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ManifestMorphicBase",
+	"type" : "normal"
+}

--- a/src/Morphic-Base.package/StringMorph.class/class/contents.font.emphasis..st
+++ b/src/Morphic-Base.package/StringMorph.class/class/contents.font.emphasis..st
@@ -1,3 +1,3 @@
 instance creation
-contents: aString font: aFont emphasis: emphasisCode
-	^ self new initWithContents: aString font: aFont emphasis: emphasisCode
+contents: aString font: aFont emphasis: aCodeOrTextEmphasis
+	^ self new initWithContents: aString font: aFont emphasis: aCodeOrTextEmphasis value

--- a/src/Morphic-Base.package/StringMorph.class/class/exampleBoldAndItalic.st
+++ b/src/Morphic-Base.package/StringMorph.class/class/exampleBoldAndItalic.st
@@ -1,9 +1,11 @@
 examples
-exampleFullEmphaisedString
+exampleBoldAndItalic
 	<sampleInstance>
+	
 	| font |
 	font := LogicalFont familyName: StandardFonts defaultFont familyName pointSize: 42. 
-	^ (self contents: 'This is a StringMorph with emphasis 2r11111' font: font emphasis: 2r11111) 
+	^ (self contents: 'This is a StringMorph with emphasis bold and italic' font: font emphasis: TextEmphasis bold)
+			addEmphasis: TextEmphasis italic;
 			position: 100@100;
 			backgroundColor: Color orange;
 			openInWorld

--- a/src/Morphic-Base.package/StringMorph.class/class/exampleManyStringMorphs.st
+++ b/src/Morphic-Base.package/StringMorph.class/class/exampleManyStringMorphs.st
@@ -1,11 +1,11 @@
 examples
 exampleManyStringMorphs
 	"Return a morph with lots of strings for testing display speed."
-	<exampleWidget>
-	"self test openInWorld"
+	<sampleInstance>
 	
 	| c |
 	c := AlignmentMorph newColumn.
 	self class environment organization categories do:
 		[:cat | c addMorph: (StringMorph new contents: cat)].
-	^ c
+	^ c position: 100@50;
+			openInWorld

--- a/src/Morphic-Base.package/StringMorph.class/instance/addEmphasis..st
+++ b/src/Morphic-Base.package/StringMorph.class/instance/addEmphasis..st
@@ -1,0 +1,3 @@
+accessing
+addEmphasis: aCodeOrTextEmphasis
+	self emphasis: (emphasis bitOr: aCodeOrTextEmphasis value)

--- a/src/Morphic-Base.package/StringMorph.class/instance/emphasis..st
+++ b/src/Morphic-Base.package/StringMorph.class/instance/emphasis..st
@@ -1,7 +1,10 @@
-font
-emphasis: aNumber
-	"
-	Set the receiver's emphasis as indicated. aNumber is a bitmask with the following format:
+accessing
+emphasis: aCodeOrTextEmphasis
+	"Set my emphasis to aCodeOrTextEmphasis, which is either a TextEmphasis object,
+	or a numeric code that is treated as a bitmask.   In the case of a TextEmphasis,
+	sending the message value will return the code number.  
+	
+	The bits have the following significance (see also the class comment for TextEmphasis)
 	
 	bit 			attribute
 	2r1	 (1) 		bold 
@@ -18,6 +21,5 @@ emphasis: aNumber
 	etc...
 	"
 
-	emphasis := aNumber.
-	
+	emphasis := aCodeOrTextEmphasis value.
 	^ self font: font emphasis: emphasis

--- a/src/Morphic-Base.package/StringMorph.class/instance/removeEmphasis..st
+++ b/src/Morphic-Base.package/StringMorph.class/instance/removeEmphasis..st
@@ -1,0 +1,4 @@
+accessing
+removeEmphasis: aCodeOrTextEmphasis
+	self emphasis: 
+		(TextEmphasis fromCode: emphasis) remove: (TextEmphasis fromCode: aCodeOrTextEmphasis)

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isCasedLetter..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isCasedLetter..st
@@ -1,0 +1,3 @@
+character classification
+isCasedLetter: char
+^ Unicode isCasedLetter: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isClosePunctuation..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isClosePunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isClosePunctuation: char
+^ Unicode isClosePunctuation: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isConnectorPunctuation..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isConnectorPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isConnectorPunctuation: char
+^ Unicode isConnectorPunctuation: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isControlOther..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isControlOther..st
@@ -1,0 +1,3 @@
+character classification
+isControlOther: char
+^ Unicode isControlOther: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isCurrencySymbol..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isCurrencySymbol..st
@@ -1,0 +1,3 @@
+character classification
+isCurrencySymbol: char
+^ Unicode isCurrencySymbol: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isDashPunctuation..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isDashPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isDashPunctuation: char
+^ Unicode isDashPunctuation: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isDecimalDigit..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isDecimalDigit..st
@@ -1,0 +1,3 @@
+character classification
+isDecimalDigit: char
+^ Unicode isDecimalDigit: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isEnclosingMark..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isEnclosingMark..st
@@ -1,0 +1,3 @@
+character classification
+isEnclosingMark: char
+^ Unicode isEnclosingMark: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isFinalQuote..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isFinalQuote..st
@@ -1,0 +1,3 @@
+character classification
+isFinalQuote: char
+^ Unicode isFinalQuote: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isFormatOther..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isFormatOther..st
@@ -1,0 +1,3 @@
+character classification
+isFormatOther: char
+^ Unicode isFormatOther: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isInitialQuote..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isInitialQuote..st
@@ -1,0 +1,3 @@
+character classification
+isInitialQuote: char
+^ Unicode isInitialQuote: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isLetterModifier..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isLetterModifier..st
@@ -1,0 +1,3 @@
+character classification
+isLetterModifier: char
+^ Unicode isLetterModifier: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isLetterNumber..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isLetterNumber..st
@@ -1,0 +1,3 @@
+character classification
+isLetterNumber: char
+^ Unicode isLetterNumber: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isLineSeparator..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isLineSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isLineSeparator: char
+^ Unicode isLineSeparator: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isLowercase..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isLowercase..st
@@ -1,0 +1,12 @@
+character classification
+isLowercase: char
+	"Answer whether the receiver is a lowercase letter.
+	The inherited implementation gives the wrong answer for µ and ß,
+	and for accented characters."
+
+	| code |
+	code := char codePoint.
+	(code between: 8r141 and: 8r172) ifTrue: [ ^ true ].
+	(char = $÷) ifTrue: [ ^ false ].
+	(char = $µ) ifTrue: [ ^ true  ].
+	^ code >= 8r337

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isMathSymbol..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isMathSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isMathSymbol: char
+^ Unicode isMathSymbol: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isModifierSymbol..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isModifierSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isModifierSymbol: char
+^ Unicode isModifierSymbol: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isNonspacingMark..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isNonspacingMark..st
@@ -1,0 +1,3 @@
+character classification
+isNonspacingMark: char
+^ Unicode isNonspacingMark: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isOpenPunctuation..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isOpenPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isOpenPunctuation: char
+^ Unicode isOpenPunctuation: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isOtherLetter..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isOtherLetter..st
@@ -1,0 +1,3 @@
+character classification
+isOtherLetter: char
+^ Unicode isOtherLetter: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isOtherNumber..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isOtherNumber..st
@@ -1,0 +1,3 @@
+character classification
+isOtherNumber: char
+^ Unicode isOtherNumber: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isOtherPunctuation..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isOtherPunctuation..st
@@ -1,0 +1,3 @@
+character classification
+isOtherPunctuation: char
+^ Unicode isOtherPunctuation: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isOtherSymbol..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isOtherSymbol..st
@@ -1,0 +1,3 @@
+character classification
+isOtherSymbol: char
+^ Unicode isOtherSymbol: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isParagraphSeparator..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isParagraphSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isParagraphSeparator: char
+^ Unicode isParagraphSeparator: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isPrivateOther..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isPrivateOther..st
@@ -1,0 +1,3 @@
+character classification
+isPrivateOther: char
+^ Unicode isPrivateOther: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isSpaceSeparator..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isSpaceSeparator..st
@@ -1,0 +1,3 @@
+character classification
+isSpaceSeparator: char
+^ Unicode isSpaceSeparator: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isSpacingCombiningMark..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isSpacingCombiningMark..st
@@ -1,0 +1,3 @@
+character classification
+isSpacingCombiningMark: char
+^ Unicode isSpacingCombiningMark: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isSurrogateOther..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isSurrogateOther..st
@@ -1,0 +1,3 @@
+character classification
+isSurrogateOther: char
+^ Unicode isSurrogateOther: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isTitlecaseLetter..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isTitlecaseLetter..st
@@ -1,0 +1,3 @@
+character classification
+isTitlecaseLetter: char
+^ Unicode isTitlecaseLetter: char

--- a/src/Multilingual-Encodings.package/Latin1.class/class/isUppercase..st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/isUppercase..st
@@ -1,0 +1,9 @@
+character classification
+isUppercase: char
+	"Answer whether the receiver is an uppercase letter.
+	(The inherited implementation gives the wrong answers for 
+	accented letters.)"
+
+	(char between: $A and: $Z ) ifTrue: [ ^ true ].
+	char = $× ifTrue: [ ^ false ].
+	^ char between: $À and: $Þ 

--- a/src/Multilingual-Encodings.package/Latin1.class/class/maxValue.st
+++ b/src/Multilingual-Encodings.package/Latin1.class/class/maxValue.st
@@ -1,0 +1,5 @@
+sizing
+maxValue
+	"The maximum value of a character in this character set"
+
+	^ 255

--- a/src/Multilingual-Encodings.package/ManifestMultilingualEncodings.class/class/ruleRBIfTrueReturnsRuleV1FalsePositive.st
+++ b/src/Multilingual-Encodings.package/ManifestMultilingualEncodings.class/class/ruleRBIfTrueReturnsRuleV1FalsePositive.st
@@ -1,0 +1,3 @@
+code-critics
+ruleRBIfTrueReturnsRuleV1FalsePositive
+	^ #(#(#(#RGMetaclassDefinition #(#'Unicode class' #Unicode)) #'2017-09-29T15:56:06.858891+02:00') )

--- a/src/Multilingual-Encodings.package/Unicode.class/class/is.inCategory..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/is.inCategory..st
@@ -1,0 +1,7 @@
+private
+is: char inCategory: cat
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = cat

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isCasedLetter..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isCasedLetter..st
@@ -1,0 +1,4 @@
+character classification
+isCasedLetter: char
+	"There are no Unicode Characters in this Category"
+	^ false

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isClosePunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isClosePunctuation..st
@@ -1,0 +1,7 @@
+character classification
+isClosePunctuation: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Pe

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isClosePunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isClosePunctuation..st
@@ -1,7 +1,3 @@
 character classification
 isClosePunctuation: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Pe
+	^ self is: char inCategory: Pe

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isConnectorPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isConnectorPunctuation..st
@@ -1,7 +1,3 @@
 character classification
 isConnectorPunctuation: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Pc
+	^ self is: char inCategory: Pc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isConnectorPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isConnectorPunctuation..st
@@ -1,0 +1,7 @@
+character classification
+isConnectorPunctuation: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Pc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isControlOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isControlOther..st
@@ -1,7 +1,3 @@
 character classification
 isControlOther: char 
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Cc
+	^ self is: char inCategory: Cc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isControlOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isControlOther..st
@@ -1,0 +1,7 @@
+character classification
+isControlOther: char 
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Cc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isCurrencySymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isCurrencySymbol..st
@@ -1,7 +1,3 @@
 character classification
 isCurrencySymbol: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Sc
+	^ self is: char inCategory: Sc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isCurrencySymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isCurrencySymbol..st
@@ -1,0 +1,7 @@
+character classification
+isCurrencySymbol: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Sc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDashPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDashPunctuation..st
@@ -1,7 +1,3 @@
 character classification
 isDashPunctuation: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Pd
+	^ self is: char inCategory: Pd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDashPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDashPunctuation..st
@@ -1,0 +1,7 @@
+character classification
+isDashPunctuation: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Pd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDecimalDigit..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDecimalDigit..st
@@ -1,7 +1,3 @@
 character classification
 isDecimalDigit: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Nd
+	^ self is: char inCategory: Nd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDecimalDigit..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDecimalDigit..st
@@ -1,0 +1,7 @@
+character classification
+isDecimalDigit: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Nd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDigit..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDigit..st
@@ -1,7 +1,3 @@
 character classification
 isDigit: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Nd
+	^ self is: char inCategory: Nd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isDigit..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isDigit..st
@@ -1,8 +1,7 @@
 character classification
-isDigit: char 
-	| value |
-	value := char charCode.
-	value > (GeneralCategory size - 1)
-		ifTrue: [^ false].
-	^ (GeneralCategory at: value + 1)
-		= Nd
+isDigit: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Nd

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isEnclosingMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isEnclosingMark..st
@@ -1,0 +1,7 @@
+character classification
+isEnclosingMark: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Me

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isEnclosingMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isEnclosingMark..st
@@ -1,7 +1,3 @@
 character classification
 isEnclosingMark: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Me
+	^ self is: char inCategory: Me

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isFinalQuote..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isFinalQuote..st
@@ -1,7 +1,3 @@
 character classification
 isFinalQuote: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Pf
+	^ self is: char inCategory: Pf

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isFinalQuote..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isFinalQuote..st
@@ -1,0 +1,7 @@
+character classification
+isFinalQuote: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Pf

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isFormatOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isFormatOther..st
@@ -1,7 +1,3 @@
 character classification
 isFormatOther: char 
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Cf
+	^ self is: char inCategory: Cf

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isFormatOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isFormatOther..st
@@ -1,0 +1,7 @@
+character classification
+isFormatOther: char 
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Cf

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isInitialQuote..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isInitialQuote..st
@@ -1,0 +1,7 @@
+character classification
+isInitialQuote: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Pi

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isInitialQuote..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isInitialQuote..st
@@ -1,7 +1,3 @@
 character classification
 isInitialQuote: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Pi
+	^ self is: char inCategory: Pi

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLetter..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLetter..st
@@ -1,8 +1,7 @@
 character classification
-isLetter: char 
-	| value codeCat |
-	value := char charCode.
-	value > (GeneralCategory size - 1)
-		ifTrue: [^ false].
-	^ (codeCat := GeneralCategory at: value + 1) >= Ll
-		and: [codeCat <= Lu]
+isLetter: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) between: Ll and: Lu

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLetterModifier..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLetterModifier..st
@@ -1,0 +1,7 @@
+character classification
+isLetterModifier: char 
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [^ false].
+	^ (GeneralCategory at: index) = Lm

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLetterNumber..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLetterNumber..st
@@ -1,7 +1,3 @@
 character classification
 isLetterNumber: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Nl
+	^ self is: char inCategory: Nl

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLetterNumber..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLetterNumber..st
@@ -1,0 +1,7 @@
+character classification
+isLetterNumber: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Nl

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLineSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLineSeparator..st
@@ -1,7 +1,3 @@
 character classification
 isLineSeparator: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Zl
+	^ self is: char inCategory: Zl

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLineSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLineSeparator..st
@@ -1,0 +1,7 @@
+character classification
+isLineSeparator: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Zl

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isLowercase..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isLowercase..st
@@ -1,8 +1,7 @@
 character classification
 isLowercase: char 
-	| value |
-	value := char charCode.
-	value > (GeneralCategory size - 1)
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
 		ifTrue: [^ false].
-	^ (GeneralCategory at: value + 1)
-		= Ll
+	^ (GeneralCategory at: index) = Ll

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isMathSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isMathSymbol..st
@@ -1,7 +1,3 @@
 character classification
 isMathSymbol: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Sm
+	^ self is: char inCategory: Sm

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isMathSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isMathSymbol..st
@@ -1,0 +1,7 @@
+character classification
+isMathSymbol: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Sm

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isModifierSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isModifierSymbol..st
@@ -1,7 +1,3 @@
 character classification
 isModifierSymbol: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Sk
+	^ self is: char inCategory: Sk

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isModifierSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isModifierSymbol..st
@@ -1,0 +1,7 @@
+character classification
+isModifierSymbol: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Sk

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isNonCharacter..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isNonCharacter..st
@@ -1,0 +1,3 @@
+character classification
+isNonCharacter: ch
+	^ self nonCharacters includes: ch codePoint 

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isNonspacingMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isNonspacingMark..st
@@ -1,0 +1,7 @@
+character classification
+isNonspacingMark: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Mn

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isNonspacingMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isNonspacingMark..st
@@ -1,7 +1,3 @@
 character classification
 isNonspacingMark: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Mn
+	^ self is: char inCategory: Mn

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOpenPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOpenPunctuation..st
@@ -1,0 +1,7 @@
+character classification
+isOpenPunctuation: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Ps

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOpenPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOpenPunctuation..st
@@ -1,7 +1,3 @@
 character classification
 isOpenPunctuation: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Ps
+	^ self is: char inCategory: Ps

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherLetter..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherLetter..st
@@ -1,0 +1,7 @@
+character classification
+isOtherLetter: char 
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [^ false].
+	^ (GeneralCategory at: index) = Lo

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherNumber..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherNumber..st
@@ -1,7 +1,3 @@
 character classification
 isOtherNumber: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = No
+	^ self is: char inCategory: No

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherNumber..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherNumber..st
@@ -1,0 +1,7 @@
+character classification
+isOtherNumber: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = No

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherPunctuation..st
@@ -1,0 +1,7 @@
+character classification
+isOtherPunctuation: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Po

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherPunctuation..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherPunctuation..st
@@ -1,7 +1,3 @@
 character classification
 isOtherPunctuation: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Po
+	^ self is: char inCategory: Po

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherSymbol..st
@@ -1,7 +1,3 @@
 character classification
 isOtherSymbol: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = So
+	^ self is: char inCategory: So

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isOtherSymbol..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isOtherSymbol..st
@@ -1,0 +1,7 @@
+character classification
+isOtherSymbol: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = So

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isParagraphSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isParagraphSeparator..st
@@ -1,0 +1,7 @@
+character classification
+isParagraphSeparator: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Zp

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isParagraphSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isParagraphSeparator..st
@@ -1,7 +1,3 @@
 character classification
 isParagraphSeparator: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Zp
+	^ self is: char inCategory: Zp

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isPrivateOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isPrivateOther..st
@@ -1,7 +1,3 @@
 character classification
 isPrivateOther: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Co
+	^ self is: char inCategory: Co

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isPrivateOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isPrivateOther..st
@@ -1,0 +1,7 @@
+character classification
+isPrivateOther: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Co

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isSpaceSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isSpaceSeparator..st
@@ -1,7 +1,3 @@
 character classification
 isSpaceSeparator: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Zs
+	^ self is: char inCategory: Zs

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isSpaceSeparator..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isSpaceSeparator..st
@@ -1,0 +1,7 @@
+character classification
+isSpaceSeparator: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Zs

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isSpacingCombiningMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isSpacingCombiningMark..st
@@ -1,7 +1,3 @@
 character classification
 isSpacingCombiningMark: char
-	| index |
-	index := char charCode + 1.
-	index > GeneralCategory size
-		ifTrue: [ ^ false ].
-	^ (GeneralCategory at: index) = Mc
+	^ self is: char inCategory: Mc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isSpacingCombiningMark..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isSpacingCombiningMark..st
@@ -1,0 +1,7 @@
+character classification
+isSpacingCombiningMark: char
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Mc

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isSurrogateOther..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isSurrogateOther..st
@@ -1,0 +1,7 @@
+character classification
+isSurrogateOther: char 
+	| index |
+	index := char charCode + 1.
+	index > (GeneralCategory size)
+		ifTrue: [ ^ false ].
+	^ (GeneralCategory at: index) = Cs

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isTitlecaseLetter..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isTitlecaseLetter..st
@@ -1,0 +1,7 @@
+character classification
+isTitlecaseLetter: char 
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
+		ifTrue: [^ false].
+	^ (GeneralCategory at: index) = Lt

--- a/src/Multilingual-Encodings.package/Unicode.class/class/isUppercase..st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/isUppercase..st
@@ -1,8 +1,7 @@
 character classification
 isUppercase: char 
-	| value |
-	value := char charCode.
-	value > (GeneralCategory size - 1)
+	| index |
+	index := char charCode + 1.
+	index > GeneralCategory size
 		ifTrue: [^ false].
-	^ (GeneralCategory at: value + 1)
-		= Lu
+	^ (GeneralCategory at: index) = Lu

--- a/src/Multilingual-Encodings.package/Unicode.class/class/maxValue.st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/maxValue.st
@@ -1,0 +1,5 @@
+sizing
+maxValue
+	"The maximum value of a character in this character set"
+
+	^ 16r10FFFF

--- a/src/Multilingual-Encodings.package/Unicode.class/class/nonCharacters.st
+++ b/src/Multilingual-Encodings.package/Unicode.class/class/nonCharacters.st
@@ -1,4 +1,4 @@
-private
+class initialization
 nonCharacters
 	nonCharacters
 		ifNil: [ nonCharacters := (16rFDD0 to: 16rFDEF) asOrderedCollection

--- a/src/Multilingual-Encodings.package/Unicode.class/properties.json
+++ b/src/Multilingual-Encodings.package/Unicode.class/properties.json
@@ -39,7 +39,8 @@
 		"ToUpper",
 		"Zl",
 		"Zp",
-		"Zs"
+		"Zs",
+		"nonCharacters"
 	],
 	"instvars" : [ ],
 	"name" : "Unicode",

--- a/src/Spec-Core.package/ComposableModel.class/instance/newList.st
+++ b/src/Spec-Core.package/ComposableModel.class/instance/newList.st
@@ -1,3 +1,3 @@
 widgets
 newList
-	^ self instantiate: ListModel
+	^ self instantiate: FastTableModel

--- a/src/Text-Core.package/TextEmphasis.class/class/allBits.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/allBits.st
@@ -1,0 +1,5 @@
+constants
+allBits
+	"all of the bits use in encoding my Instances"
+
+	^2r11111

--- a/src/Text-Core.package/TextEmphasis.class/class/bold.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/bold.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 bold
 	^ self new emphasisCode: 1

--- a/src/Text-Core.package/TextEmphasis.class/class/fromCode..st
+++ b/src/Text-Core.package/TextEmphasis.class/class/fromCode..st
@@ -1,0 +1,3 @@
+instance creation
+fromCode: anIntegerBitMask
+	^ self new emphasisCode: (anIntegerBitMask bitAnd: self allBits)

--- a/src/Text-Core.package/TextEmphasis.class/class/italic.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/italic.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 italic
 	^ self new emphasisCode: 2

--- a/src/Text-Core.package/TextEmphasis.class/class/narrow.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/narrow.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 narrow
-	^ TextKern kern: -1
+	^ self new emphasisCode: 8

--- a/src/Text-Core.package/TextEmphasis.class/class/normal.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/normal.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 normal
 	^ self new emphasisCode: 0

--- a/src/Text-Core.package/TextEmphasis.class/class/struckOut.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/struckOut.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 struckOut
 	^ self new emphasisCode: 16

--- a/src/Text-Core.package/TextEmphasis.class/class/underlined.st
+++ b/src/Text-Core.package/TextEmphasis.class/class/underlined.st
@@ -1,3 +1,3 @@
-defaults
+instance creation
 underlined
 	^ self new emphasisCode: 4

--- a/src/Text-Core.package/TextEmphasis.class/instance/^equals.st
+++ b/src/Text-Core.package/TextEmphasis.class/instance/^equals.st
@@ -1,4 +1,3 @@
 comparing
 = other 
-	^ (other class == self class) 
-		and: [other emphasisCode = emphasisCode]
+	^ other value = self value

--- a/src/Text-Core.package/TextEmphasis.class/instance/add..st
+++ b/src/Text-Core.package/TextEmphasis.class/instance/add..st
@@ -1,0 +1,4 @@
+combining
+add: anotherCodeOrEmphasis
+	"add anotherCodeOrEmphasis to me"
+	emphasisCode := emphasisCode bitOr: anotherCodeOrEmphasis value

--- a/src/Text-Core.package/TextEmphasis.class/instance/allBits.st
+++ b/src/Text-Core.package/TextEmphasis.class/instance/allBits.st
@@ -1,0 +1,3 @@
+private
+allBits
+	^ self class allBits

--- a/src/Text-Core.package/TextEmphasis.class/instance/remove..st
+++ b/src/Text-Core.package/TextEmphasis.class/instance/remove..st
@@ -1,0 +1,5 @@
+combining
+remove: anotherCodeOrEmphasis
+	"remove anotherCodeOrEmphasis from me"
+	emphasisCode := emphasisCode bitAnd: 
+		((anotherCodeOrEmphasis value bitInvert) bitAnd: (self allBits))

--- a/src/Text-Core.package/TextEmphasis.class/instance/value.st
+++ b/src/Text-Core.package/TextEmphasis.class/instance/value.st
@@ -1,0 +1,5 @@
+styling
+value
+	"a synonym for empahasisCode, to make me polymorphic with Numbers"
+	
+	^ emphasisCode

--- a/src/Text-Scanning.package/TextEmphasis.extension/instance/emphasizeScanner..st
+++ b/src/Text-Scanning.package/TextEmphasis.extension/instance/emphasizeScanner..st
@@ -1,4 +1,4 @@
 *Text-Scanning
 emphasizeScanner: scanner
-	"Set the emphasist for text scanning"
+	"Set the emphasis for text scanning"
 	scanner addEmphasis: emphasisCode

--- a/src/Text-Tests.package/TextEmphasisTest.class/instance/testAdd.st
+++ b/src/Text-Tests.package/TextEmphasisTest.class/instance/testAdd.st
@@ -1,0 +1,6 @@
+tests
+testAdd
+	| t1  |
+	t1 := TextEmphasis bold.
+	t1 add: TextEmphasis italic.
+	self assert: (t1 = 2r11) description: 'bold and italics didn''t add correctly'

--- a/src/Text-Tests.package/TextEmphasisTest.class/instance/testFromCode.st
+++ b/src/Text-Tests.package/TextEmphasisTest.class/instance/testFromCode.st
@@ -1,0 +1,5 @@
+tests
+testFromCode
+	| t1  |
+	t1 := TextEmphasis fromCode: 2r10101.
+	self assert: t1 value equals: 2r10101.

--- a/src/Text-Tests.package/TextEmphasisTest.class/instance/testRemove.st
+++ b/src/Text-Tests.package/TextEmphasisTest.class/instance/testRemove.st
@@ -1,0 +1,7 @@
+tests
+testRemove
+	| t1  |
+	t1 := TextEmphasis bold.
+	t1 add: TextEmphasis italic.
+	t1 remove: TextEmphasis bold.
+	self assert: t1 = TextEmphasis italic description: 'Removing bold didn''t leave italics'


### PR DESCRIPTION
This commit responds to Issue 20471.

It adds character classification methods on Unicode class for the 29 Unicode categories, and
testing methods (isMathSymbol, etc)  in Character instances that delegate  to
these methods.  Because CharacterSets are pluggable, this commit also implements
the same 29 character classification methods on AsciiCharset class and Latin1 class.   The
methods on AsciiCharset class are self-contained, but those on Latin1 class delegate to Unicode,
as did the existing Latin1 class>>#isLetter method.