### PR TITLE
20507 Typos in QACritiqueTest

### DIFF
--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDialogPopping..st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDialogPopping..st
@@ -1,6 +1,6 @@
 running
 runWithDialogPopping: anAssertingBlock
-
+ 
 	UIManager default class = MorphicUIManager
 		ifTrue: [ self runWithMorphicDialogPopping: anAssertingBlock ]
 		ifFalse: anAssertingBlock

--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDialogPopping..st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDialogPopping..st
@@ -1,0 +1,6 @@
+running
+runWithDialogPopping: anAssertingBlock
+
+	UIManager default class = MorphicUIManager
+		ifTrue: [ self runWithMorphicDialogPopping: anAssertingBlock ]
+		ifFalse: anAssertingBlock

--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDidalogPopping..st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithDidalogPopping..st
@@ -1,6 +1,0 @@
-running
-runWithDidalogPopping: anAssertingBlock
-
-	UIManager default class = MorphicUIManager
-		ifTrue: [ self runWithMorphicDidalogPopping: anAssertingBlock ]
-		ifFalse: anAssertingBlock

--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithMorphicDialogPopping..st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/runWithMorphicDialogPopping..st
@@ -1,5 +1,5 @@
 running
-runWithMorphicDidalogPopping: anAssertingBlock
+runWithMorphicDialogPopping: anAssertingBlock
 
 	| semaphore worldSubmoprhs newMorphs closingProcess |
 

--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/testFixAction.st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/testFixAction.st
@@ -14,7 +14,7 @@ testFixAction
 	
 	action := crit actions detect: [ :a | a description = 'Automatically resolve the issue' ].
 	
-	self runWithDidalogPopping: [
+	self runWithDialogPopping: [
 		self
 			shouldnt: [ action actOnCritic: crit ofEntity: crit sourceAnchor entity ]
 			raise: Error ]

--- a/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/testGuidedBan.st
+++ b/src/QualityAssistant-Test.package/QACritiqueTest.class/instance/testGuidedBan.st
@@ -11,6 +11,6 @@ testGuidedBan
 		for: thisContext method
 		by: (RBLintRule allSubclasses detect: #isVisible) new.
 	
-	self runWithDidalogPopping: [
+	self runWithDialogPopping: [
 		self shouldnt: [ crit guidedBan ] raise: Error ]
 	


### PR DESCRIPTION
Two methods with typos in this class:

runWithDidalogPopping:
runWithMorphicDidalogPopping:

were renamed 