### PR TITLE
20514 Recategorise detectIndex: to not be an extension method

### DIFF
--- a/src/Collections-Abstract.package/SequenceableCollection.class/instance/detectIndex..st
+++ b/src/Collections-Abstract.package/SequenceableCollection.class/instance/detectIndex..st
@@ -1,4 +1,4 @@
-*Morphic-Base-Pluggable Widgets
+enumerating
 detectIndex: aBlock
 
 	^ self detectIndex: aBlock ifNone: [ self errorNotFound: aBlock ] 

--- a/src/Collections-Abstract.package/SequenceableCollection.class/instance/detectIndex.ifNone..st
+++ b/src/Collections-Abstract.package/SequenceableCollection.class/instance/detectIndex.ifNone..st
@@ -1,4 +1,4 @@
-*Morphic-Base-Pluggable Widgets
+enumerating
 detectIndex: aBlock ifNone: exceptionBlock
 
 	self doWithIndex: [:each :index | (aBlock value: each) ifTrue: [^ index]].

--- a/src/Morphic-Base.package/SequenceableCollection.extension/properties.json
+++ b/src/Morphic-Base.package/SequenceableCollection.extension/properties.json
@@ -1,3 +1,0 @@
-{
-	"name" : "SequenceableCollection"
-}


### PR DESCRIPTION
detectIndex: and detechIndex:ifNone: not as extension methods


https://pharo.fogbugz.com/f/cases/20514/recategorise-detectIndex-to-not-be-an-extension-method