### PR TITLE
20523-MCOrganizationDefinition-lacks-hash-method

### DIFF
--- a/src/Monticello.package/MCDictionaryRepository.class/instance/hash.st
+++ b/src/Monticello.package/MCDictionaryRepository.class/instance/hash.st
@@ -1,0 +1,3 @@
+comparing
+hash
+	^ self identityHash

--- a/src/Monticello.package/MCDictionaryRepository.class/instance/hash.st
+++ b/src/Monticello.package/MCDictionaryRepository.class/instance/hash.st
@@ -1,3 +1,4 @@
 comparing
 hash
+
 	^ self identityHash

--- a/src/Monticello.package/MCOrganizationDefinition.class/instance/hash.st
+++ b/src/Monticello.package/MCOrganizationDefinition.class/instance/hash.st
@@ -1,0 +1,5 @@
+comparing
+hash
+	^ (self species hash 
+		bitXor: super hash)
+		bitXor: self categories hash


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20523/MCOrganizationDefinition-lacks-hash-method