### PR TITLE
20533 Cleanup package Gofer-Tests

### DIFF
--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testBlueplane.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testBlueplane.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testBlueplane
 	gofer blueplane: 'SIXX'.
 	self assert: gofer repositories: #('http://squeaksource.blueplane.jp/SIXX')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testConstraintReference.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testConstraintReference.st
@@ -1,4 +1,4 @@
-testing-references
+tests - references
 testConstraintReference
 	gofer 
 		repository: self monticelloRepository; 

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testCustomRepository.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testCustomRepository.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testCustomRepository
 	gofer repository: self monticelloRepository.
 	self assert: gofer repositories: (Array with: self monticelloRepository description).

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testDirectoryRepository.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testDirectoryRepository.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testDirectoryRepository
 	gofer directory: FileSystem disk workingDirectory fullName.
 	self assert: gofer repositories: (Array with: FileSystem disk workingDirectory fullName).

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testGemsource.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testGemsource.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testGemsource
 	gofer gemsource: 'Seaside29'.
 	self assert: gofer repositories: #('http://seaside.gemstone.com/ss/Seaside29')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepository.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepository.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testHttpRepository
 	gofer url: 'http://source.lukas-renggli.ch/pier' username: 'foo' password: 'bar'.
 	self assert: gofer repositories: #('http://source.lukas-renggli.ch/pier').

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepositoryOverrideStoredCredentials.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepositoryOverrideStoredCredentials.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testHttpRepositoryOverrideStoredCredentials
 
 	| exampleServer registry |

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepositoryUseStoredCredentials.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testHttpRepositoryUseStoredCredentials.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testHttpRepositoryUseStoredCredentials
 
 	| exampleServer registry |

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testImpara.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testImpara.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testImpara
 	gofer impara: 'Tweak'.
 	self assert: gofer repositories: #('http://source.impara.de/Tweak')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testInitialReferences.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testInitialReferences.st
@@ -1,3 +1,3 @@
-testing
+tests
 testInitialReferences
 	self assert: gofer references isEmpty

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testInitialRepositories.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testInitialRepositories.st
@@ -1,4 +1,4 @@
-testing
+tests
 testInitialRepositories
 	gofer := Gofer new.
 	self assert: (gofer repositories size = 1).

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testPackageCache.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testPackageCache.st
@@ -1,4 +1,4 @@
-testing-repositories-options
+tests - repositories - options
 testPackageCache
 	gofer squeaksource: 'r1'; squeaksource: 'r2'.
 	

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testPackageReference.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testPackageReference.st
@@ -1,4 +1,4 @@
-testing-references
+tests - references
 testPackageReference
 	gofer 
 		repository: self monticelloRepository;

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testRenggli.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testRenggli.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testRenggli
 	gofer renggli: 'pier'.
 	self assert: gofer repositories: #('http://source.lukas-renggli.ch/pier')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testRepositoryErrors.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testRepositoryErrors.st
@@ -1,4 +1,4 @@
-testing-repositories-options
+tests - repositories - options
 testRepositoryErrors
 	gofer
 		url: 'http://pharo-project.org/page-that-will-never-ever-exist';

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testSmalltalkhub.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testSmalltalkhub.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testSmalltalkhub
 	gofer smalltalkhubUser: 'dh83' project: 'ci'.
 	self assert: gofer repositories: #('http://smalltalkhub.com/mc/dh83/ci/main/')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testSqueakfoundation.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testSqueakfoundation.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testSqueakfoundation
 	gofer squeakfoundation: '39a'.
 	self assert: gofer repositories: #('http://source.squeakfoundation.org/39a')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testSqueaksource.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testSqueaksource.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testSqueaksource
 	gofer squeaksource: 'Seaside29'.
 	self assert: gofer repositories: #('http://www.squeaksource.com/Seaside29')

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testSubDirectoryRepository.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testSubDirectoryRepository.st
@@ -1,4 +1,4 @@
-testing-repositories
+tests - repositories
 testSubDirectoryRepository
 	Smalltalk globals
 		at: #MCSubDirectoryRepository

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testVersionReference.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testVersionReference.st
@@ -1,4 +1,4 @@
-testing-references
+tests - references
 testVersionReference
 	gofer 
 		repository: self monticelloRepository; 

--- a/src/Gofer-Tests.package/GoferApiTest.class/instance/testWiresong.st
+++ b/src/Gofer-Tests.package/GoferApiTest.class/instance/testWiresong.st
@@ -1,4 +1,4 @@
-testing-repositories-places
+tests - repositories - places
 testWiresong
 	gofer wiresong: 'ob'.
 	self assert: gofer repositories: #('http://source.wiresong.ca/ob')

--- a/src/Gofer-Tests.package/GoferApiTest.class/properties.json
+++ b/src/Gofer-Tests.package/GoferApiTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/5/2014 09:36",
 	"super" : "GoferTest",
-	"category" : "Gofer-Tests",
+	"category" : "Gofer-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testCleanup.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testCleanup.st
@@ -1,4 +1,4 @@
-testing
+tests
 testCleanup
 	| class |
 	gofer

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testCommit.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testCommit.st
@@ -1,4 +1,4 @@
-testing
+tests
 testCommit
 	| repository |
 	repository := MCDictionaryRepository new.

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testFetch.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testFetch.st
@@ -1,4 +1,4 @@
-testing
+tests
 testFetch
 	gofer package: 'GoferFoo'.
 	gofer fetch

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testLoad.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testLoad.st
@@ -1,4 +1,4 @@
-testing
+tests
 testLoad
 	gofer version: 'GoferFoo-lr.1'.
 	gofer load.

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testLocalChanges.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testLocalChanges.st
@@ -1,4 +1,4 @@
-testing
+tests
 testLocalChanges
 	| changes |
 	gofer

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testMerge.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testMerge.st
@@ -1,4 +1,4 @@
-testing
+tests
 testMerge
 	| initial |
 	initial := gofer copy.

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testPush.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testPush.st
@@ -1,4 +1,4 @@
-testing
+tests
 testPush
 	| repository |
 	gofer := Gofer new.

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRecompile.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRecompile.st
@@ -1,4 +1,4 @@
-testing
+tests
 testRecompile
 	gofer package: 'Gofer-Core'.
 	gofer recompile

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testReinitialize.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testReinitialize.st
@@ -1,4 +1,4 @@
-testing
+tests
 testReinitialize
 	| class |
 	gofer

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRemoteChanges.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRemoteChanges.st
@@ -1,4 +1,4 @@
-testing
+tests
 testRemoteChanges
 	| changes |
 	gofer

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRevert.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testRevert.st
@@ -1,4 +1,4 @@
-testing
+tests
 testRevert
 	gofer
 		package: 'GoferFoo';

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testUnload.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testUnload.st
@@ -1,4 +1,4 @@
-testing
+tests
 testUnload
 	gofer
 		package: 'GoferFoo';

--- a/src/Gofer-Tests.package/GoferOperationTest.class/instance/testUpdate.st
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/instance/testUpdate.st
@@ -1,4 +1,4 @@
-testing
+tests
 testUpdate
 	| initial |
 	initial := gofer copy.

--- a/src/Gofer-Tests.package/GoferOperationTest.class/properties.json
+++ b/src/Gofer-Tests.package/GoferOperationTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/5/2014 09:36",
 	"super" : "GoferTest",
-	"category" : "Gofer-Tests",
+	"category" : "Gofer-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testBranchAfterAuthorIsNotABranch.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testBranchAfterAuthorIsNotABranch.st
@@ -1,4 +1,4 @@
-testing
+tests
 testBranchAfterAuthorIsNotABranch
 	| queryReference |
 	queryReference := GoferVersionReference name: 'Seaside-Core-jf.configcleanup.3'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testContraintShouldFindLatestVersion.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testContraintShouldFindLatestVersion.st
@@ -1,4 +1,4 @@
-testing-reference
+tests - reference
 testContraintShouldFindLatestVersion
 	| constraintReference reference |
 	constraintReference := GoferConstraintReference 

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testContraintShouldFindWorkingCopy.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testContraintShouldFindWorkingCopy.st
@@ -1,4 +1,4 @@
-testing-working
+tests - working
 testContraintShouldFindWorkingCopy
 	| constraintReference workingCopy |
 	constraintReference := GoferConstraintReference 

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testLoadableShouldSortCorrectly.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testLoadableShouldSortCorrectly.st
@@ -1,4 +1,4 @@
-testing
+tests
 testLoadableShouldSortCorrectly
 	| sorted |
 	sorted := self versionReferences

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testPackageShouldFindLatestVersion.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testPackageShouldFindLatestVersion.st
@@ -1,4 +1,4 @@
-testing-reference
+tests - reference
 testPackageShouldFindLatestVersion
 	| packageReference reference |
 	packageReference := GoferPackageReference name: 'GoferFoo'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testPackageShouldFindWorkingCopy.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testPackageShouldFindWorkingCopy.st
@@ -1,4 +1,4 @@
-testing-working
+tests - working
 testPackageShouldFindWorkingCopy
 	| packageReference workingCopy |
 	packageReference := GoferPackageReference name: 'Gofer-Core'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testResolvedShouldFindLatestVersion.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testResolvedShouldFindLatestVersion.st
@@ -1,4 +1,4 @@
-testing-reference
+tests - reference
 testResolvedShouldFindLatestVersion
 	| versionReference reference |
 	versionReference := GoferResolvedReference name: 'GoferFoo-lr.2' repository: self monticelloRepository.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testResolvedShouldFindWorkingCopy.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testResolvedShouldFindWorkingCopy.st
@@ -1,4 +1,4 @@
-testing-working
+tests - working
 testResolvedShouldFindWorkingCopy
 	| versionReference workingCopy |
 	versionReference := GoferResolvedReference name: 'Gofer-Core-lr.18' repository: self monticelloRepository.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldFindLatestVersion.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldFindLatestVersion.st
@@ -1,4 +1,4 @@
-testing-reference
+tests - reference
 testVersionShouldFindLatestVersion
 	| versionReference reference |
 	versionReference := GoferVersionReference name: 'GoferFoo-lr.2'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldFindWorkingCopy.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldFindWorkingCopy.st
@@ -1,4 +1,4 @@
-testing-working
+tests - working
 testVersionShouldFindWorkingCopy
 	| versionReference workingCopy |
 	versionReference := GoferVersionReference name: 'Gofer-Core-lr.18'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldParseComplexName.st
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/instance/testVersionShouldParseComplexName.st
@@ -1,4 +1,4 @@
-testing
+tests
 testVersionShouldParseComplexName
 	| queryReference |
 	queryReference := GoferVersionReference name: 'Seaside2.8b5'.

--- a/src/Gofer-Tests.package/GoferReferenceTest.class/properties.json
+++ b/src/Gofer-Tests.package/GoferReferenceTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/5/2014 09:37",
 	"super" : "GoferTest",
-	"category" : "Gofer-Tests",
+	"category" : "Gofer-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/Gofer-Tests.package/GoferResource.class/properties.json
+++ b/src/Gofer-Tests.package/GoferResource.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/5/2014 09:30",
 	"super" : "TestResource",
-	"category" : "Gofer-Tests",
+	"category" : "Gofer-Tests-Resources",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/Gofer-Tests.package/GoferTest.class/README.md
+++ b/src/Gofer-Tests.package/GoferTest.class/README.md
@@ -1,1 +1,1 @@
-SUnit tests for Gofer
+Abstract superclass for Gofer tests

--- a/src/Gofer-Tests.package/GoferTest.class/properties.json
+++ b/src/Gofer-Tests.package/GoferTest.class/properties.json
@@ -1,7 +1,7 @@
 {
-	"commentStamp" : "TorstenBergmann 2/5/2014 09:30",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:41",
 	"super" : "TestCase",
-	"category" : "Gofer-Tests",
+	"category" : "Gofer-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/Gofer-Tests.package/monticello.meta/categories.st
+++ b/src/Gofer-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,3 @@
 SystemOrganization addCategory: #'Gofer-Tests'!
+SystemOrganization addCategory: #'Gofer-Tests-Resources'!
+SystemOrganization addCategory: #'Gofer-Tests-Tests'!


### PR DESCRIPTION
- category "testing" -> "tests" for test methods
- tag some classes different (like the SUnit resource different than tests)
- add class comment of GoferTest to depict it as an abstract superclass for Gofer based tests