### PR TITLE
20534 Cleanup Graphics-Tests package

### DIFF
--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/README.md
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for class BMPReadWriter

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp16Bit.st
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp16Bit.st
@@ -1,4 +1,4 @@
-reading
+tests - reading
 testBmp16Bit
 	| reader form |
 	reader := BMPReadWriter new on: self bmpData16bit readStream.

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp24Bit.st
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp24Bit.st
@@ -1,4 +1,4 @@
-reading
+tests - reading
 testBmp24Bit
 	| reader form |
 	reader := BMPReadWriter new on: (ReadStream on: self bmpData24bit).

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp32Bit.st
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp32Bit.st
@@ -1,4 +1,4 @@
-reading
+tests - reading
 testBmp32Bit
 	| reader form |
 	reader := BMPReadWriter new on: self bmpData32bit readStream.

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp4Bit.st
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp4Bit.st
@@ -1,4 +1,4 @@
-reading
+tests - reading
 testBmp4Bit
 	| reader form |
 	reader := BMPReadWriter new on: self bmpData4bit readStream.

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp8Bit.st
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/instance/testBmp8Bit.st
@@ -1,4 +1,4 @@
-reading
+tests - reading
 testBmp8Bit
 	| reader form |
 	reader := BMPReadWriter new on: self bmpData8bit readStream.

--- a/src/Graphics-Tests.package/BMPReadWriterTest.class/properties.json
+++ b/src/Graphics-Tests.package/BMPReadWriterTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:55",
 	"super" : "TestCase",
 	"category" : "Graphics-Tests-Files",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/README.md
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for BitBlt clipping bugs

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside2.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside2.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside2
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside3.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside3.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside3
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside4.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside4.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside4
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside5.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside5.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside5
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside6.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testDrawingWayOutside6.st
@@ -1,4 +1,4 @@
-accessing
+tests - drawing
 testDrawingWayOutside6
 	| f1 bb f2 |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside.st
@@ -1,4 +1,4 @@
-accessing
+tests - filling
 testFillingWayOutside
 	| f1 bb |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside2.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside2.st
@@ -1,4 +1,4 @@
-accessing
+tests - filling
 testFillingWayOutside2
 	| f1 bb |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside3.st
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/instance/testFillingWayOutside3.st
@@ -1,4 +1,4 @@
-accessing
+tests - filling
 testFillingWayOutside3
 	| f1 bb |
 	f1 := Form extent: 100 @ 100 depth: 1.

--- a/src/Graphics-Tests.package/BitBltClipBugsTest.class/properties.json
+++ b/src/Graphics-Tests.package/BitBltClipBugsTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:54",
 	"super" : "TestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/BitBltTest.class/README.md
+++ b/src/Graphics-Tests.package/BitBltTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for class BitBlt

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testAlphaCompositing
 	"self run: #testAlphaCompositing"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing2.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing2.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testAlphaCompositing2
 	"self run: #testAlphaCompositing2"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing2Simulated.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositing2Simulated.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testAlphaCompositing2Simulated
 	"self run: #testAlphaCompositing2Simulated"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositingSimulated.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testAlphaCompositingSimulated.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testAlphaCompositingSimulated
 	"self run: #testAlphaCompositingSimulated"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testPeekerUnhibernateBug.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testPeekerUnhibernateBug.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testPeekerUnhibernateBug
 	"self run: #testPeekerUnhibernateBug"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/instance/testPokerUnhibernateBug.st
+++ b/src/Graphics-Tests.package/BitBltTest.class/instance/testPokerUnhibernateBug.st
@@ -1,4 +1,4 @@
-bugs
+tests - bugs
 testPokerUnhibernateBug
 	"self run: #testPokerUnhibernateBug"
 

--- a/src/Graphics-Tests.package/BitBltTest.class/properties.json
+++ b/src/Graphics-Tests.package/BitBltTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:55",
 	"super" : "ClassTestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/ColorTest.class/README.md
+++ b/src/Graphics-Tests.package/ColorTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for class Color

--- a/src/Graphics-Tests.package/ColorTest.class/instance/test32BitBlackColorTranformation.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/test32BitBlackColorTranformation.st
@@ -1,5 +1,5 @@
-tests
-test32BlackColorTranformation
+tests - 32 bit
+test32BitBlackColorTranformation
 	"Solve bug: https://pharo.fogbugz.com/f/cases/14619/Strange-behavior-of-TestRunner-Icon"
 
 	self assert: ((Color black pixelWordForDepth: 32) asColorOfDepth: 32) equals: Color black

--- a/src/Graphics-Tests.package/ColorTest.class/instance/test32BitOpaqueBlackIsTotallyBlack.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/test32BitOpaqueBlackIsTotallyBlack.st
@@ -1,4 +1,4 @@
-testing
+tests - 32 bit
 test32BitOpaqueBlackIsTotallyBlack
 	"The pixel value of a black at depth32 should really be black..."
 	"At the time of this test, it returned 16rFF000001 ...."

--- a/src/Graphics-Tests.package/ColorTest.class/instance/test32BitTranslucentPixelValueKeepsRGB.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/test32BitTranslucentPixelValueKeepsRGB.st
@@ -1,4 +1,4 @@
-testing
+tests - 32 bit
 test32BitTranslucentPixelValueKeepsRGB
 	"The pixel value of a translucent color at depth32 should keep the RGB component irrespective of alpha.
 	At the time of this test, setting an alpha of zero made the entire pixel 0 irrespective of depth..."

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testAsColorrefPrimaryColors.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testAsColorrefPrimaryColors.st
@@ -1,4 +1,4 @@
-testing
+tests
 testAsColorrefPrimaryColors
 "issue 13784 Color>>#asColorref ignores blue"
 	self assertColorrefFor: Color black equals: 16r000000;

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testAsHexString.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testAsHexString.st
@@ -1,4 +1,4 @@
-testing
+tests
 testAsHexString
 
 	| table aColorString |

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testColorFrom.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testColorFrom.st
@@ -1,4 +1,4 @@
-testing
+tests
 testColorFrom
 	self assert: ((Color colorFrom: #white) asHexString sameAs: 'ffffff').
 	self assert: ((Color colorFrom: #(1.0 0.5 0.0)) asHexString sameAs: 'ff8000').

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testFromString.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testFromString.st
@@ -1,4 +1,4 @@
-testing
+tests
 testFromString
 	self assert: ((Color fromString: '#FF8800') asHexString sameAs: 'ff8800');
 		assert: ((Color fromString: 'FF8800') asHexString sameAs: 'ff8800');

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByArray.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByArray.st
@@ -1,4 +1,4 @@
-testing
+tests - multiply
 testMultiplyByArray
 	| newColor oldColor tolerance |
 	tolerance := 0.001.

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByArrayIdentityTransform.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByArrayIdentityTransform.st
@@ -1,4 +1,4 @@
-testing
+tests - multiply
 testMultiplyByArrayIdentityTransform
 	| newColor oldColor tolerance |
 	tolerance := 0.001.

--- a/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByNumber.st
+++ b/src/Graphics-Tests.package/ColorTest.class/instance/testMultiplyByNumber.st
@@ -1,4 +1,4 @@
-testing
+tests - multiply
 testMultiplyByNumber
 	| newColor oldColor tolerance |
 	tolerance := 0.001.

--- a/src/Graphics-Tests.package/ColorTest.class/properties.json
+++ b/src/Graphics-Tests.package/ColorTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:56",
 	"super" : "ClassTestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/FormTest.class/README.md
+++ b/src/Graphics-Tests.package/FormTest.class/README.md
@@ -1,1 +1,1 @@
-Various tests for class form.
+SUnit tests for class Form

--- a/src/Graphics-Tests.package/FormTest.class/instance/test32BitFormBlackShouldStayBlackAfterSave.st
+++ b/src/Graphics-Tests.package/FormTest.class/instance/test32BitFormBlackShouldStayBlackAfterSave.st
@@ -1,4 +1,4 @@
-tests
+tests - 32 bit
 test32BitFormBlackShouldStayBlackAfterSave
 	"Solve bug: https://pharo.fogbugz.com/f/cases/14619/Strange-behavior-of-TestRunner-Icon"
 

--- a/src/Graphics-Tests.package/FormTest.class/instance/test32BitTranslucentBlackIsBlack.st
+++ b/src/Graphics-Tests.package/FormTest.class/instance/test32BitTranslucentBlackIsBlack.st
@@ -1,4 +1,4 @@
-tests
+tests - 32 bit
 test32BitTranslucentBlackIsBlack
 	|form|
 	form := Form extent: 1@1 depth: 32.

--- a/src/Graphics-Tests.package/FormTest.class/properties.json
+++ b/src/Graphics-Tests.package/FormTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "ar 7/21/2007 21:39",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:55",
 	"super" : "ClassTestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/MarginTest.class/README.md
+++ b/src/Graphics-Tests.package/MarginTest.class/README.md
@@ -1,1 +1,1 @@
-This is the unit test for the class Margin. 
+SUnit tests for class Margin

--- a/src/Graphics-Tests.package/MarginTest.class/properties.json
+++ b/src/Graphics-Tests.package/MarginTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "HenrikNergaard 7/28/2016 20:07",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:56",
 	"super" : "TestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/PNGReadWriterTest.class/README.md
+++ b/src/Graphics-Tests.package/PNGReadWriterTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for class PNGReadWriter

--- a/src/Graphics-Tests.package/PNGReadWriterTest.class/properties.json
+++ b/src/Graphics-Tests.package/PNGReadWriterTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:55",
 	"super" : "TestCase",
 	"category" : "Graphics-Tests-Files",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/PointTest.class/README.md
+++ b/src/Graphics-Tests.package/PointTest.class/README.md
@@ -1,1 +1,1 @@
-This is the unit test for the class Point. 
+SUnit tests for class Point

--- a/src/Graphics-Tests.package/PointTest.class/instance/testAbs.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testAbs.st
@@ -1,4 +1,4 @@
-tests-arithmetic
+tests - arithmetic
 testAbs
 
 	self assert: (0 @ 0) abs = (0 @ 0).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testAsFloatPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testAsFloatPoint.st
@@ -1,4 +1,4 @@
-tests-converting
+tests - converting
 testAsFloatPoint
 	|testPoint|
 	self assert: (1 @ 1) asFloatPoint = (1.0 @ 1.0).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testAsIntegerPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testAsIntegerPoint.st
@@ -1,4 +1,4 @@
-tests-converting
+tests - converting
 testAsIntegerPoint
 	|testPoint|
 	self assert: (1 @ 1) asIntegerPoint = (1 @ 1).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testAsPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testAsPoint.st
@@ -1,4 +1,4 @@
-tests-converting
+tests - converting
 testAsPoint
 
 	self deny: 1 isPoint.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testCrossProduct.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testCrossProduct.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testCrossProduct
 
 	self assert: (0 @ 0 crossProduct: 0 @ 0) = 0.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testDist.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testDist.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testDist
 
 	self assert: (0 @ 0 dist: 0 @ 0) = 0.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testDistanceTo.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testDistanceTo.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testDistanceTo
 
 	self assert: (0 @ 0 distanceTo: 0 @ 0) = 0.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testEightNeighbors.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testEightNeighbors.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testEightNeighbors
 
 	| x y |

--- a/src/Graphics-Tests.package/PointTest.class/instance/testFlipByCenterAt.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testFlipByCenterAt.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testFlipByCenterAt
 
 	| center a direction |

--- a/src/Graphics-Tests.package/PointTest.class/instance/testInsideTriangleWithWith.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testInsideTriangleWithWith.st
@@ -1,4 +1,4 @@
-tests-point functions
+tests - point functions
 testInsideTriangleWithWith
 	self assert:   ( (2 @ 3) insideTriangle:  (1 @ 1 ) with: (1 @ 7) with: (3 @ 3)).
 	self deny:    ( (3 @ 1) insideTriangle:  (1 @ 1 ) with: (1 @ 7) with: (3 @ 3)).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testIsFloatPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testIsFloatPoint.st
@@ -1,4 +1,4 @@
-tests-truncation and roundoff
+tests - truncation and roundoff
 testIsFloatPoint
 
 	self deny: (1 @ 1) isFloatPoint.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testIsIntegerPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testIsIntegerPoint.st
@@ -1,4 +1,4 @@
-tests-truncation and roundoff
+tests - truncation and roundoff
 testIsIntegerPoint
 
 	self assert: (1 @ 1) isIntegerPoint.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testIsPoint.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testIsPoint.st
@@ -1,4 +1,4 @@
-tests-converting
+tests - converting
 testIsPoint
 
 	self deny: nil isPoint.

--- a/src/Graphics-Tests.package/PointTest.class/instance/testNegated.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testNegated.st
@@ -1,4 +1,4 @@
-tests-transforming
+tests - transforming
 testNegated
 
 	self assert: (0 @ 0) negated = (0 @ 0).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testReciprocal.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testReciprocal.st
@@ -1,4 +1,4 @@
-tests-arithmetic
+tests - arithmetic
 testReciprocal
 
 	self assert: (1 @ 1) reciprocal = (1 @ 1).

--- a/src/Graphics-Tests.package/PointTest.class/instance/testToIntersectsTo.st
+++ b/src/Graphics-Tests.package/PointTest.class/instance/testToIntersectsTo.st
@@ -1,4 +1,4 @@
-tests-geometry
+tests - geometry
 testToIntersectsTo
 
 	self assert: ( (1 @ 1) to: ( 1 @ 6) intersects: (1 @ 1) to: (2 @ 9) ).

--- a/src/Graphics-Tests.package/PointTest.class/properties.json
+++ b/src/Graphics-Tests.package/PointTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "StephaneDucasse 7/7/2010 23:43",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:56",
 	"super" : "ClassTestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],

--- a/src/Graphics-Tests.package/RectangleTest.class/README.md
+++ b/src/Graphics-Tests.package/RectangleTest.class/README.md
@@ -1,0 +1,1 @@
+SUnit tests for class Rectangle

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testArea.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testArea.st
@@ -1,4 +1,4 @@
-tests-accessing
+tests - accessing
 testArea
 
 	self assert: (0 @ 0 corner: 5 @ 5) area = 25.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testBottom.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testBottom.st
@@ -1,4 +1,4 @@
-tests-accessing
+tests - accessing
 testBottom
 |rect|
 rect:=(0 @ 0 corner: 20 @ 20) bottom:10.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testFlipByCenterAt.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testFlipByCenterAt.st
@@ -1,4 +1,4 @@
-tests-transforming
+tests - transforming
 testFlipByCenterAt
 
 	| rectangle |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testLeft.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testLeft.st
@@ -1,4 +1,4 @@
-tests-accessing
+tests - accessing
 testLeft
 |rect|
 rect:=(0 @ 0 corner: 20 @ 20) left:10.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testPointNearestTo.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testPointNearestTo.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testPointNearestTo
 
 	| rectangle negativeRectangle |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testRight.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testRight.st
@@ -1,4 +1,4 @@
-tests-accessing
+tests - accessing
 testRight
 |rect|
 rect:=(0 @ 0 corner: 20 @ 20) right:10.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testSideNearestTo.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testSideNearestTo.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testSideNearestTo
 	"rectangular area of screen implies that negalive coordinates not allowed"
 	| rectangle |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testTop.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testTop.st
@@ -1,4 +1,4 @@
-tests-accessing
+tests - accessing
 testTop
 |rect|
 rect:=(0 @ 0 corner: 20 @ 20) top:10.

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testWithBottom.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testWithBottom.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testWithBottom
 
 	| r |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testWithHeight.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testWithHeight.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testWithHeight
 
 	| r |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testWithTop.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testWithTop.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testWithTop
 
 	| r |

--- a/src/Graphics-Tests.package/RectangleTest.class/instance/testWithWidth.st
+++ b/src/Graphics-Tests.package/RectangleTest.class/instance/testWithWidth.st
@@ -1,4 +1,4 @@
-tests-rectangle functions
+tests - rectangle functions
 testWithWidth
 
 	| r |

--- a/src/Graphics-Tests.package/RectangleTest.class/properties.json
+++ b/src/Graphics-Tests.package/RectangleTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "TorstenBergmann 10/12/2017 22:56",
 	"super" : "TestCase",
 	"category" : "Graphics-Tests-Primitives",
 	"classinstvars" : [ ],


### PR DESCRIPTION
- properly categorize
- unify class comments 
- also rename test32BlackColorTranformation into test32BitBlackColorTranformation to be in synch with the other test32Bit... methods

https://pharo.fogbugz.com/f/cases/20534/Cleanup-Graphics-Tests-package

ONLY RECATEGORIZATION, TAGGING AND ONE METHOD RENAME - NO CHANGE IN BEHAVIOR