### PR TITLE
20535  Cleanup SmartSuggestions-Tests and Shout-Tests package

### DIFF
--- a/src/Shout-Tests.package/SHParserST80Test.class/README.md
+++ b/src/Shout-Tests.package/SHParserST80Test.class/README.md
@@ -1,1 +1,1 @@
-SUnit tests for shouts ST80 parser
+SUnit tests for Shouts ST80 parser

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/d.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/d.st
@@ -1,3 +1,3 @@
-tests-manual
+manual
 d
 	"ensure that d is defined so that we don't get an #undefinedUnary token type "

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/e.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/e.st
@@ -1,3 +1,3 @@
-tests-manual
+manual
 e
 	"ensure that e is defined so that we don't get an #undefinedUnary token type "

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/q.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/q.st
@@ -1,3 +1,3 @@
-tests-manual
+manual
 q
 	"ensure that q is defined so that we don't get an #undefinedUnary token type "

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/r.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/r.st
@@ -1,3 +1,3 @@
-tests-manual
+manual
 r
 	"ensure that r is defined so that we don't get an #undefinedUnary token type "

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/s.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/s.st
@@ -1,3 +1,3 @@
-tests-manual
+manual
 s
 	"ensure that s is defined so that we don't get an #undefinedUnary token type "

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/testBooleanHierarchy.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/testBooleanHierarchy.st
@@ -1,3 +1,3 @@
-tests-smoke
+tests - smoke
 testBooleanHierarchy
 	self verifyHierarchy: Boolean

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/testCollectionHierarchy.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/testCollectionHierarchy.st
@@ -1,4 +1,4 @@
-tests-smoke
+tests - smoke
 testCollectionHierarchy
 	self skip: 'Too slow for too little value added'.
 	self verifyHierarchy: Collection

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/testNumberHierarchy.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/testNumberHierarchy.st
@@ -1,3 +1,3 @@
-tests-smoke
+tests - smoke
 testNumberHierarchy
 	self verifyHierarchy: Number

--- a/src/Shout-Tests.package/SHParserST80Test.class/instance/testObjectClass.st
+++ b/src/Shout-Tests.package/SHParserST80Test.class/instance/testObjectClass.st
@@ -1,3 +1,3 @@
-tests-smoke
+tests - smoke
 testObjectClass
 	self verifyClass: Object

--- a/src/Shout-Tests.package/SHParserST80Test.class/properties.json
+++ b/src/Shout-Tests.package/SHParserST80Test.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "TorstenBergmann 2/12/2014 23:22",
+	"commentStamp" : "TorstenBergmann 10/12/2017 23:04",
 	"super" : "TestCase",
 	"category" : "Shout-Tests-Parsing",
 	"classinstvars" : [ ],

--- a/src/Shout-Tests.package/SHStyleElementTest.class/README.md
+++ b/src/Shout-Tests.package/SHStyleElementTest.class/README.md
@@ -1,1 +1,1 @@
-I am testing the class SHStyleElement
+SUnit tests for class SHStyleElement

--- a/src/Shout-Tests.package/SHStyleElementTest.class/properties.json
+++ b/src/Shout-Tests.package/SHStyleElementTest.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "AlexandreBergel 9/30/2011 15:22",
+	"commentStamp" : "TorstenBergmann 10/12/2017 23:04",
 	"super" : "TestCase",
 	"category" : "Shout-Tests-Styling",
 	"classinstvars" : [ ],

--- a/src/Shout-Tests.package/monticello.meta/categories.st
+++ b/src/Shout-Tests.package/monticello.meta/categories.st
@@ -1,3 +1,3 @@
 SystemOrganization addCategory: #'Shout-Tests'!
-SystemOrganization addCategory: 'Shout-Tests-Parsing'!
-SystemOrganization addCategory: 'Shout-Tests-Styling'!
+SystemOrganization addCategory: #'Shout-Tests-Parsing'!
+SystemOrganization addCategory: #'Shout-Tests-Styling'!

--- a/src/SmartSuggestions-Tests.package/MockContainer.class/class/for..st
+++ b/src/SmartSuggestions-Tests.package/MockContainer.class/class/for..st
@@ -1,4 +1,4 @@
-as yet unclassified
+instance creation
 for: model
 	^ self new 
 		model: model; 

--- a/src/SmartSuggestions-Tests.package/MockContainer.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/MockContainer.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "<historical>",
 	"super" : "Object",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Mocks",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testContextForNautilusItsANautilusContext.st
+++ b/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testContextForNautilusItsANautilusContext.st
@@ -1,4 +1,4 @@
-valid-context
+tests - valid context
 testContextForNautilusItsANautilusContext
 	| nautilus |
 	

--- a/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testDebuggerIsAValidContext.st
+++ b/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testDebuggerIsAValidContext.st
@@ -1,4 +1,4 @@
-valid-context
+tests - valid context
 testDebuggerIsAValidContext
 	| debugger |
 	

--- a/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testTetModelIsAValidContext.st
+++ b/src/SmartSuggestions-Tests.package/SugsContextTest.class/instance/testTetModelIsAValidContext.st
@@ -1,4 +1,4 @@
-valid-context
+tests - valid context
 testTetModelIsAValidContext
 	| textModel |
 	

--- a/src/SmartSuggestions-Tests.package/SugsContextTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsContextTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:43",
 	"super" : "TestCase",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForClassItsRBVariable.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForClassItsRBVariable.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForClassItsRBVariable
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForClassVarItsRBVariable.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForClassVarItsRBVariable.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForClassVarItsRBVariable
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForInstanceVariableItsRBVariable.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForInstanceVariableItsRBVariable.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForInstanceVariableItsRBVariable
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForLiteralItsRBLiteral.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForLiteralItsRBLiteral.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForLiteralItsRBLiteral
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMessageNodeItsRBMessageSend.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMessageNodeItsRBMessageSend.st
@@ -1,6 +1,6 @@
-nodes
+tests - nodes
 testFindBestNodeForMessageNodeItsRBMessageSend
 	| node |
 
-	node :=SugsMenuBuilder findBestNodeFor:  SugsMockContext mesageContext  .
+	node :=SugsMenuBuilder findBestNodeFor:  SugsMockContext messageContext  .
 	self assert: node class equals: RBMessageNode .

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMethodNodeItsRBMehod.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMethodNodeItsRBMehod.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForMethodNodeItsRBMehod
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMultilineItsRBSequence.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForMultilineItsRBSequence.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForMultilineItsRBSequence
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForSelfNodeItsRBSelf.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForSelfNodeItsRBSelf.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForSelfNodeItsRBSelf
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForSelfNodeItsRBSuper.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForSelfNodeItsRBSuper.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForSelfNodeItsRBSuper
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForTemporaryVariableItsRBVariable.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testFindBestNodeForTemporaryVariableItsRBVariable.st
@@ -1,4 +1,4 @@
-nodes
+tests - nodes
 testFindBestNodeForTemporaryVariableItsRBVariable
 	| node |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testNoSuggestionForSelfNode.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testNoSuggestionForSelfNode.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testNoSuggestionForSelfNode
 	| suggestions expected |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testNoSuggestionForSuperNode.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testNoSuggestionForSuperNode.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testNoSuggestionForSuperNode
 	| suggestions expected |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAAssigmentNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAAssigmentNodeIncludesAllDeclared.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAAssigmentNodeIncludesAllDeclared
 	| suggestions expected|
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAClassNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAClassNodeIncludesAllDeclared.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAClassNodeIncludesAllDeclared
 	| suggestions expected|
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAClassVariableNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAClassVariableNodeIncludesAllDeclared.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAClassVariableNodeIncludesAllDeclared
 	| suggestions expected|
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAMehodNodeIncludesAllValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAMehodNodeIncludesAllValid.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAMehodNodeIncludesAllValid
 	| suggestions expected context |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAMessageNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAMessageNodeIncludesAllDeclared.st
@@ -1,8 +1,8 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAMessageNodeIncludesAllDeclared
 	| suggestions expected|
 
-	suggestions :=SugsMenuBuilder findSuggestionsFor: SugsMockContext mesageContext.
+	suggestions :=SugsMenuBuilder findSuggestionsFor: SugsMockContext messageContext.
 
 	expected := SugsSuggestionFactory commandsForMessage .	
 	self assert: (expected allSatisfy:[:expect | suggestions includes: expect]).

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForATemporaryVariableNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForATemporaryVariableNodeIncludesAllDeclared.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForATemporaryVariableNodeIncludesAllDeclared
 	| suggestions expected|
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAnInstanceVariableNodeIncludesAllDeclared.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForAnInstanceVariableNodeIncludesAllDeclared.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForAnInstanceVariableNodeIncludesAllDeclared
 	| suggestions expected|
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForLiteralNodeIncludesAllExpected.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForLiteralNodeIncludesAllExpected.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForLiteralNodeIncludesAllExpected
 	| suggestions expected |
 

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForSourceNodeIncludesAllValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/instance/testSuggestionForSourceNodeIncludesAllValid.st
@@ -1,4 +1,4 @@
-suggstions-by-selection
+tests - suggestions by selection
 testSuggestionForSourceNodeIncludesAllValid
 	| suggestions expected context |
 	context := SugsMockContext sourceContext.

--- a/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsMenuBuilderTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:43",
 	"super" : "TestCase",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/class/messageContext.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/class/messageContext.st
@@ -1,3 +1,3 @@
 instance creation
-mesageContext
+messageContext
 	^ self new selectorToUse: #withMesage; yourself.

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/code.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/code.st
@@ -1,3 +1,3 @@
-api-context
+api - context
 code
 	^ self selectedMethod sourceCode

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/message..st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/message..st
@@ -1,3 +1,3 @@
-api-context
+api - context
 message: theName
 	^ message := theName.

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedClass..st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedClass..st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedClass: aClass
 	selectedClass := aClass.

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedClass.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedClass.st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedClass
 	^selectedClass ifNil: [self class] ifNotNil:[selectedClass].

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedInterval..st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedInterval..st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedInterval: interval
 	selectedInterval := interval.

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedInterval.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedInterval.st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedInterval
 	^self interval: self selectorToUse 

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedMessageName.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedMessageName.st
@@ -1,4 +1,4 @@
-api-context
+api - context
 selectedMessageName
 
 	^message ifNil:[super selectedMessageName] ifNotNil: [ message ]

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedMethod.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedMethod.st
@@ -1,4 +1,4 @@
-api-context
+api - context
 selectedMethod
 	^selectorToUse 
 		ifNotNil: [self selectedClass 

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedVariable..st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedVariable..st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedVariable: aVariableName.
 	selectedVariable := aVariableName.

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedVariableName.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/selectedVariableName.st
@@ -1,3 +1,3 @@
-api-context
+api - context
 selectedVariableName
 	^selectedVariable ifNil: [ super selectedVariableName ] ifNotNil:   [selectedVariable]

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/sourceTextArea.st
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/instance/sourceTextArea.st
@@ -1,3 +1,3 @@
-api-context
+api - context
 sourceTextArea
 	^ RubScrolledTextMorph new

--- a/src/SmartSuggestions-Tests.package/SugsMockContext.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsMockContext.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "<historical>",
 	"super" : "SugsAbstractContext",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Mocks",
 	"classinstvars" : [
 		"anInstanceVar"
 	],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsNotValidIfAccessorsAreAlreadyCreated.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsNotValidIfAccessorsAreAlreadyCreated.st
@@ -1,4 +1,4 @@
-inst-var
+tests - instance variables
 testCreateAccessorsIsNotValidIfAccessorsAreAlreadyCreated
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfAccessIsMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfAccessIsMissed.st
@@ -1,4 +1,4 @@
-inst-var
+tests - instance variables
 testCreateAccessorsIsValidIfAccessIsMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfAccessorsAreMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfAccessorsAreMissed.st
@@ -1,4 +1,4 @@
-inst-var
+tests - instance variables
 testCreateAccessorsIsValidIfAccessorsAreMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfMuttatorMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateAccessorsIsValidIfMuttatorMissed.st
@@ -1,4 +1,4 @@
-inst-var
+tests - instance variables
 testCreateAccessorsIsValidIfMuttatorMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsNotValidIfAccessorsAreAlreadyCreated.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsNotValidIfAccessorsAreAlreadyCreated.st
@@ -1,4 +1,4 @@
-class-var
+tests - class variables
 testCreateClassAccessorsIsNotValidIfAccessorsAreAlreadyCreated
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfAccessIsMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfAccessIsMissed.st
@@ -1,4 +1,4 @@
-class-var
+tests - class variables
 testCreateClassAccessorsIsValidIfAccessIsMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfAccessorsAreMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfAccessorsAreMissed.st
@@ -1,4 +1,4 @@
-class-var
+tests - class variables
 testCreateClassAccessorsIsValidIfAccessorsAreMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfMuttatorMissed.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/instance/testCreateClassAccessorsIsValidIfMuttatorMissed.st
@@ -1,4 +1,4 @@
-class-var
+tests - class variables
 testCreateClassAccessorsIsValidIfMuttatorMissed
 	| suggestion context |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionCreateAccessorsTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:43",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/instance/testDelegateSelectionWithInstaceVariablesItsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/instance/testDelegateSelectionWithInstaceVariablesItsValid.st
@@ -1,4 +1,4 @@
-source
+tests - source
 testDelegateSelectionWithInstaceVariablesItsValid
 	| suggestion |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/instance/testDelegateSelectionWithoutInstaceVariablesItsNotValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/instance/testDelegateSelectionWithoutInstaceVariablesItsNotValid.st
@@ -1,4 +1,4 @@
-source
+tests - source
 testDelegateSelectionWithoutInstaceVariablesItsNotValid
 	| suggestion |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionDelegateTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:43",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInALiteralNodeIsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInALiteralNodeIsValid.st
@@ -1,4 +1,4 @@
-valid
+tests - valid
 testExtractLocalInALiteralNodeIsValid
 	| literal context suggestion |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInAMessageNodeIsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInAMessageNodeIsValid.st
@@ -1,4 +1,4 @@
-valid
+tests - valid
 testExtractLocalInAMessageNodeIsValid
 	| context suggestion |
 	context := SugsMockContext withMessageName: 'justAName'.

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInASequenceNodeWithMoreSentencesIsNotValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInASequenceNodeWithMoreSentencesIsNotValid.st
@@ -1,4 +1,4 @@
-valid
+tests - valid
 testExtractLocalInASequenceNodeWithMoreSentencesIsNotValid
 	| multipleLines context suggestion |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInASequenceNodeWithOneSentenceIsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/instance/testExtractLocalInASequenceNodeWithOneSentenceIsValid.st
@@ -1,4 +1,4 @@
-valid
+tests - valid
 testExtractLocalInASequenceNodeWithOneSentenceIsValid
 	| oneLine context suggestion |
 	

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionExtractLocalTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:44",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/instance/testPushDownWithSubclassIsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/instance/testPushDownWithSubclassIsValid.st
@@ -1,4 +1,4 @@
-method
+tests - methods
 testPushDownWithSubclassIsValid
 	| suggestion subclass |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/instance/testPushDownWithoutSubclassIsNotValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/instance/testPushDownWithoutSubclassIsNotValid.st
@@ -1,4 +1,4 @@
-method
+tests - methods
 testPushDownWithoutSubclassIsNotValid
 	| suggestion |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionPushDownTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:44",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/instance/testRemoveArgsWithArgsItsValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/instance/testRemoveArgsWithArgsItsValid.st
@@ -1,4 +1,4 @@
-methods
+tests - methods
 testRemoveArgsWithArgsItsValid
 	| suggestion |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/instance/testRemoveArgsWithoutArgsItsNotValid.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/instance/testRemoveArgsWithoutArgsItsNotValid.st
@@ -1,4 +1,4 @@
-methods
+tests - methods
 testRemoveArgsWithoutArgsItsNotValid
 	| suggestion |
 

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionRemoveArgTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:44",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionSwapMethodTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionSwapMethodTest.class/properties.json
@@ -1,7 +1,7 @@
 {
 	"commentStamp" : "TorstenBergmann 2/3/2014 23:44",
 	"super" : "SugsSuggestionTest",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/README.md
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/README.md
@@ -1,1 +1,1 @@
-Superclass for SUnit tests for smart suggestions
+Abstract superclass for SUnit tests for smart suggestions classes

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/class/isAbstract.st
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/class/isAbstract.st
@@ -1,0 +1,4 @@
+testing
+isAbstract
+
+	^self name = #SugsSuggestionTest

--- a/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/properties.json
+++ b/src/SmartSuggestions-Tests.package/SugsSuggestionTest.class/properties.json
@@ -1,7 +1,7 @@
 {
-	"commentStamp" : "TorstenBergmann 2/3/2014 23:42",
+	"commentStamp" : "TorstenBergmann 10/12/2017 23:09",
 	"super" : "TestCase",
-	"category" : "SmartSuggestions-Tests",
+	"category" : "SmartSuggestions-Tests-Tests",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],

--- a/src/SmartSuggestions-Tests.package/monticello.meta/categories.st
+++ b/src/SmartSuggestions-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,3 @@
 SystemOrganization addCategory: #'SmartSuggestions-Tests'!
+SystemOrganization addCategory: #'SmartSuggestions-Tests-Mocks'!
+SystemOrganization addCategory: #'SmartSuggestions-Tests-Tests'!


### PR DESCRIPTION
- define #isAbstract in SugsSuggestionTest
- add comment in SugsSuggestionTest that it is abstract
- tests should be in categories starting with "tests"
- proper comments
- proper method categorization
- categorize uncategorized methods like MockContainer(class)>>for:
- rename #mesageContext into #messageContext (typo)
- create package tags for "Mocks" and "Tests" in package SmartSuggestions-Tests to ease browsing the package

https://pharo.fogbugz.com/f/cases/20535/Cleanup-SmartSuggestions-Tests-and-Shout-Tests

CLEANUPS ONLY LIKE COMMENTING, RECATEGORIZATION, RENAMING -  NO CHANGE IN BEHAVIOR