### PR TITLE
20546-There-is-no-denyequals-method-in-TestCase-

### DIFF
--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.equals..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.equals..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual equals: expected
+	^ self
+		deny: expected = actual
+		description: [self comparingStringBetween: actual and: expected]

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.equals..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.equals..st
@@ -2,4 +2,4 @@ asserting
 deny: actual equals: expected
 	^ self
 		deny: expected = actual
-		description: [self comparingStringBetween: actual and: expected]
+		description: [self unexpectedEqualityStringBetween: actual and: expected]

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/denyCollection.equals..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/denyCollection.equals..st
@@ -1,0 +1,6 @@
+asserting
+denyCollection: actual equals: expected
+	"Specialized test method that generates a proper error message for collection"
+	^ self
+		deny: expected = actual
+		description: [ self unexpectedEqualityStringBetween: actual and: expected ]

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/unexpectedEqualityStringBetween.and..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/unexpectedEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TAssertable.trait/instance/deny.equals..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/deny.equals..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual equals: expected
+	^ self
+		deny: expected = actual
+		description: [self comparingStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TAssertable.trait/instance/deny.equals..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/deny.equals..st
@@ -2,4 +2,4 @@ asserting
 deny: actual equals: expected
 	^ self
 		deny: expected = actual
-		description: [self comparingStringBetween: actual and: expected]
+		description: [self unexpectedEqualityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TAssertable.trait/instance/denyCollection.equals..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/denyCollection.equals..st
@@ -1,0 +1,6 @@
+asserting
+denyCollection: actual equals: expected
+	"Specialized test method that generates a proper error message for collection"
+	^ self
+		deny: expected = actual
+		description: [ self unexpectedEqualityStringBetween: actual and: expected ]

--- a/src/SUnit-Core.package/TAssertable.trait/instance/unexpectedEqualityStringBetween.and..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/unexpectedEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TestAsserter.class/instance/deny.equals..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/deny.equals..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual equals: expected
+	^ self
+		deny: expected = actual
+		description: [self comparingStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TestAsserter.class/instance/deny.equals..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/deny.equals..st
@@ -2,4 +2,4 @@ asserting
 deny: actual equals: expected
 	^ self
 		deny: expected = actual
-		description: [self comparingStringBetween: actual and: expected]
+		description: [self unexpectedEqualityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TestAsserter.class/instance/denyCollection.equals..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/denyCollection.equals..st
@@ -1,0 +1,6 @@
+asserting
+denyCollection: actual equals: expected
+	"Specialized test method that generates a proper error message for collection"
+	^ self
+		deny: expected = actual
+		description: [ self unexpectedEqualityStringBetween: actual and: expected ]

--- a/src/SUnit-Core.package/TestAsserter.class/instance/unexpectedEqualityStringBetween.and..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/unexpectedEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20546- simulate TAssertable flattening- use different unexpected equality error message
- add denyCollection:equals: