### PR TITLE
20545-clean-announcers-in-sublcasses-of-Model

### DIFF
--- a/src/GT-InspectorExtensions-Core.package/NewValueHolder.extension/instance/gtAnnouncer.st
+++ b/src/GT-InspectorExtensions-Core.package/NewValueHolder.extension/instance/gtAnnouncer.st
@@ -1,3 +1,3 @@
 *GT-InspectorExtensions-Core
 gtAnnouncer
-	^ announcer
+	^ self announcer

--- a/src/GT-InspectorExtensions-Core.package/NewValueHolder.extension/instance/gtInspectorPresentationsIn.inContext..st
+++ b/src/GT-InspectorExtensions-Core.package/NewValueHolder.extension/instance/gtInspectorPresentationsIn.inContext..st
@@ -1,5 +1,5 @@
 *GT-InspectorExtensions-Core
 gtInspectorPresentationsIn: composite inContext: aGTInspector
 	composite 
-		updateOn: Announcement from: announcer.
+		updateOn: Announcement from: self announcer.
 	super gtInspectorPresentationsIn: composite inContext: aGTInspector

--- a/src/NewValueHolder.package/CollectionValueHolder.class/instance/valueAdded..st
+++ b/src/NewValueHolder.package/CollectionValueHolder.class/instance/valueAdded..st
@@ -1,4 +1,4 @@
 announcing
 valueAdded: newValue
-	announcer announce: (ValueAdded newValue: newValue).
+	self announcer announce: (ValueAdded newValue: newValue).
 	self valueChanged: newValue

--- a/src/NewValueHolder.package/CollectionValueHolder.class/instance/valueRemoved..st
+++ b/src/NewValueHolder.package/CollectionValueHolder.class/instance/valueRemoved..st
@@ -1,4 +1,4 @@
 announcing
 valueRemoved: oldValue
-	announcer announce: (ValueRemoved oldValue: oldValue).
+	self announcer announce: (ValueRemoved oldValue: oldValue).
 	self valueChanged: oldValue

--- a/src/NewValueHolder.package/CollectionValueHolder.class/instance/whenAddedDo..st
+++ b/src/NewValueHolder.package/CollectionValueHolder.class/instance/whenAddedDo..st
@@ -2,4 +2,4 @@ announcements
 whenAddedDo: aBlock
 	"Culled block [ :newValue :announcement | ]"
 
-	announcer when: ValueAdded do: [ :ann | aBlock cull: ann newValue cull: ann ]
+	self announcer when: ValueAdded do: [ :ann | aBlock cull: ann newValue cull: ann ]

--- a/src/NewValueHolder.package/CollectionValueHolder.class/instance/whenRemovedDo..st
+++ b/src/NewValueHolder.package/CollectionValueHolder.class/instance/whenRemovedDo..st
@@ -2,4 +2,4 @@ announcements
 whenRemovedDo: aBlock
 	"Culled block [ :oldValue :announcement | ]"
 
-	announcer when: ValueRemoved do: [ :ann | aBlock cull: ann oldValue cull: ann ]
+	self announcer when: ValueRemoved do: [ :ann | aBlock cull: ann oldValue cull: ann ]

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/initialize.st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/initialize.st
@@ -3,5 +3,4 @@ initialize
 
 	super initialize.
 	
-	announcer := Announcer new.
 	lock := false.

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged..st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged..st
@@ -1,4 +1,4 @@
 accessing
 valueChanged: oldValue
 	
-	announcer announce: (ValueChanged oldValue: oldValue newValue: value)
+	self announcer announce: (ValueChanged oldValue: oldValue newValue: value)

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged.st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged.st
@@ -1,4 +1,4 @@
 accessing
 valueChanged
 	
-	announcer announce: (ValueChanged newValue: value)
+	self announcer announce: (ValueChanged newValue: value)

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged.to..st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/valueChanged.to..st
@@ -1,4 +1,4 @@
 accessing
 valueChanged: oldValue to: newValue
 	
-	announcer announce: (ValueChanged oldValue: oldValue newValue: newValue)
+	self announcer announce: (ValueChanged oldValue: oldValue newValue: newValue)

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/whenChangedDo..st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/whenChangedDo..st
@@ -9,4 +9,4 @@ whenChangedDo: aBlock
 		cull: announcement oldValue
 		cull: announcement
 		cull: ann ].
-	announcer when: ValueChanged do: block
+	self announcer when: ValueChanged do: block

--- a/src/NewValueHolder.package/NewValueHolder.class/instance/whenChangedSend.to..st
+++ b/src/NewValueHolder.package/NewValueHolder.class/instance/whenChangedSend.to..st
@@ -1,4 +1,4 @@
 announcements
 whenChangedSend: aSelector to: aReceiver
 
-	announcer when: ValueChanged send: aSelector to: aReceiver
+	self announcer when: ValueChanged send: aSelector to: aReceiver

--- a/src/NewValueHolder.package/NewValueHolder.class/properties.json
+++ b/src/NewValueHolder.package/NewValueHolder.class/properties.json
@@ -6,7 +6,6 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"announcer",
 		"lock",
 		"value"
 	],

--- a/src/PragmaCollector.package/PragmaCollector.class/instance/release.st
+++ b/src/PragmaCollector.package/PragmaCollector.class/instance/release.st
@@ -1,6 +1,6 @@
 dependents access
 release
 	self noMoreNotifications.
-	announcer := nil.
+	self destroyAnnouncer.
 	collected := nil.
 	super release

--- a/src/PragmaCollector.package/PragmaCollector.class/properties.json
+++ b/src/PragmaCollector.package/PragmaCollector.class/properties.json
@@ -8,7 +8,6 @@
 	"instvars" : [
 		"collected",
 		"filter",
-		"announcer",
 		"announcing"
 	],
 	"name" : "PragmaCollector",

--- a/src/Rubric.package/RubMethodEditingExample.class/properties.json
+++ b/src/Rubric.package/RubMethodEditingExample.class/properties.json
@@ -10,8 +10,7 @@
 		"code",
 		"className",
 		"selector",
-		"classIsMeta",
-		"announcer"
+		"classIsMeta"
 	],
 	"name" : "RubMethodEditingExample",
 	"type" : "normal"

--- a/src/Rubric.package/RubPluggableTextMorphExample.class/instance/announcer.st
+++ b/src/Rubric.package/RubPluggableTextMorphExample.class/instance/announcer.st
@@ -1,3 +1,0 @@
-accessing
-announcer
-	^ announcer ifNil: [ announcer := Announcer new ]

--- a/src/Rubric.package/RubPluggableTextMorphExample.class/properties.json
+++ b/src/Rubric.package/RubPluggableTextMorphExample.class/properties.json
@@ -4,7 +4,6 @@
 	"instvars" : [
 		"selection",
 		"scrollValue",
-		"announcer",
 		"classIsMeta",
 		"selectedClassName",
 		"selectedMethodName",

--- a/src/SUnit-Core.package/TestSuite.class/instance/testSuiteAnnouncer.st
+++ b/src/SUnit-Core.package/TestSuite.class/instance/testSuiteAnnouncer.st
@@ -1,3 +1,3 @@
 announcements
 testSuiteAnnouncer
-	self announcer
+	^ self announcer

--- a/src/SUnit-Core.package/TestSuite.class/instance/testSuiteAnnouncer.st
+++ b/src/SUnit-Core.package/TestSuite.class/instance/testSuiteAnnouncer.st
@@ -1,4 +1,3 @@
 announcements
 testSuiteAnnouncer
-	announcer ifNil:[ announcer := Announcer new.].
-	^ announcer.
+	self announcer

--- a/src/SUnit-Core.package/TestSuite.class/properties.json
+++ b/src/SUnit-Core.package/TestSuite.class/properties.json
@@ -8,8 +8,7 @@
 	"instvars" : [
 		"tests",
 		"resources",
-		"name",
-		"announcer"
+		"name"
 	],
 	"name" : "TestSuite",
 	"type" : "normal"

--- a/src/Spec-Core.package/ComposablePresenter.class/instance/announcer.st
+++ b/src/Spec-Core.package/ComposablePresenter.class/instance/announcer.st
@@ -1,4 +1,0 @@
-accessing
-announcer
-
-	^ announcer

--- a/src/Spec-Core.package/ComposablePresenter.class/instance/initialize.st
+++ b/src/Spec-Core.package/ComposablePresenter.class/instance/initialize.st
@@ -7,7 +7,6 @@ initialize
 	keyStrokesForNextFocusHolder := { KMNoShortcut new } asValueHolder.
 	keyStrokesForPreviousFocusHolder := { KMNoShortcut new } asValueHolder.
 	additionalKeyBindings := Dictionary new.
-	announcer := Announcer new.
 	aboutText := nil asValueHolder.
 	windowIcon := nil asValueHolder.
 	window := nil asValueHolder.

--- a/src/Spec-Core.package/ComposablePresenter.class/properties.json
+++ b/src/Spec-Core.package/ComposablePresenter.class/properties.json
@@ -13,7 +13,6 @@
 		"extentHolder",
 		"needRebuild",
 		"additionalKeyBindings",
-		"announcer",
 		"keyStrokesForNextFocusHolder",
 		"keyStrokesForPreviousFocusHolder",
 		"windowIcon",

--- a/src/System-Model.package/Model.class/instance/announcer.st
+++ b/src/System-Model.package/Model.class/instance/announcer.st
@@ -1,4 +1,4 @@
 accessing
 announcer
-	"pay attention we name this instance variable announceur and not announcer because subclasses may already have an announcer instance variable. We will remove them and rename this one in the future."
-	^ announceur ifNil: [ announceur := Announcer new ]
+
+	^ announcer ifNil: [ announcer := Announcer new ]

--- a/src/System-Model.package/Model.class/instance/destroyAnnouncer.st
+++ b/src/System-Model.package/Model.class/instance/destroyAnnouncer.st
@@ -1,0 +1,4 @@
+announcing
+destroyAnnouncer
+
+	announcer := nil.

--- a/src/System-Model.package/Model.class/properties.json
+++ b/src/System-Model.package/Model.class/properties.json
@@ -7,7 +7,7 @@
 	"classvars" : [ ],
 	"instvars" : [
 		"dependents",
-		"announceur"
+		"announcer"
 	],
 	"name" : "Model",
 	"type" : "normal"


### PR DESCRIPTION
remove announcer instance variables from subclass of Model to be able to finally rename "announceur" instance varialbe to "announcer"