### PR TITLE
20547-missing-assertidenticalTo-and-denyidenticalTo-object-identity-equality

### DIFF
--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/assert.identicalTo..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/assert.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+assert: actual identicalTo: expected
+	^ self
+		assert: expected == actual
+		description: [self comparingIdentityStringBetween: actual and: expected]

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/comparingIdentityStringBetween.and..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/comparingIdentityStringBetween.and..st
@@ -1,0 +1,9 @@
+private
+comparingIdentityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' is not identical to ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.identicalTo..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/deny.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual identicalTo: expected
+	^ self
+		deny: expected == actual
+		description: [self unexpectedIdentityEqualityStringBetween: actual and: expected]

--- a/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/unexpectedIdentityEqualityStringBetween.and..st
+++ b/src/Kernel-Tests.package/DatePrintFormatTester.class/instance/unexpectedIdentityEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedIdentityEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected identity equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TAssertable.trait/instance/assert.identicalTo..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/assert.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+assert: actual identicalTo: expected
+	^ self
+		assert: expected == actual
+		description: [self comparingIdentityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TAssertable.trait/instance/comparingIdentityStringBetween.and..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/comparingIdentityStringBetween.and..st
@@ -1,0 +1,9 @@
+private
+comparingIdentityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' is not identical to ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TAssertable.trait/instance/deny.identicalTo..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/deny.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual identicalTo: expected
+	^ self
+		deny: expected == actual
+		description: [self unexpectedIdentityEqualityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TAssertable.trait/instance/unexpectedIdentityEqualityStringBetween.and..st
+++ b/src/SUnit-Core.package/TAssertable.trait/instance/unexpectedIdentityEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedIdentityEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected identity equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TestAsserter.class/instance/assert.identicalTo..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/assert.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+assert: actual identicalTo: expected
+	^ self
+		assert: expected == actual
+		description: [self comparingIdentityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TestAsserter.class/instance/comparingIdentityStringBetween.and..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/comparingIdentityStringBetween.and..st
@@ -1,0 +1,9 @@
+private
+comparingIdentityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' is not identical to ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']

--- a/src/SUnit-Core.package/TestAsserter.class/instance/deny.identicalTo..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/deny.identicalTo..st
@@ -1,0 +1,5 @@
+asserting
+deny: actual identicalTo: expected
+	^ self
+		deny: expected == actual
+		description: [self unexpectedIdentityEqualityStringBetween: actual and: expected]

--- a/src/SUnit-Core.package/TestAsserter.class/instance/unexpectedIdentityEqualityStringBetween.and..st
+++ b/src/SUnit-Core.package/TestAsserter.class/instance/unexpectedIdentityEqualityStringBetween.and..st
@@ -1,0 +1,10 @@
+private
+unexpectedIdentityEqualityStringBetween: actual and: expected
+
+	^ String streamContents: [:stream |
+			stream
+				nextPutAll: 'Unexpected identity equality of ';
+				nextPutAll: actual fullPrintString;
+				nextPutAll: ' and ';
+				nextPutAll: expected fullPrintString;
+				nextPutAll: '.']


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20547/missing-assert-identicalTo-and-deny-identicalTo-object-identity-equalityadd assert:identicalTo: and deny:identicalTo: