### PR TITLE
20548-sync-NewValueHolder-and-Model-announcing-interface-2

### DIFF
--- a/src/System-Model.package/Model.class/instance/whenChangedDo..st
+++ b/src/System-Model.package/Model.class/instance/whenChangedDo..st
@@ -1,4 +1,4 @@
-announcements
+announcing
 whenChangedDo: aBlock
 	"Culled block [ :newValue :oldValue :announcement :announcer | ]"
 

--- a/src/System-Model.package/Model.class/instance/whenChangedSend.to..st
+++ b/src/System-Model.package/Model.class/instance/whenChangedSend.to..st
@@ -1,4 +1,4 @@
-announcements
+announcing
 whenChangedSend: aSelector to: aReceiver
 
 	self announcer when: ValueChanged send: aSelector to: aReceiver


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20548/sync-NewValueHolder-and-Model-announcing-interfacemove announcements methods from NewValueHolder to Model