### PR TITLE
19533-Configuration-command-line-handler-should-not-save-and-quit-by-himself

### DIFF
--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/README.md
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/README.md
@@ -1,7 +1,9 @@
 Command line handler for dealing with Metacello configurations from the command line
 
-Usage: config [--help] <repository url> [<configuration>] [--install[=<version>]] [--group=<group>] [--username=<username>] [--password=<password>]
+Usage: config [--help] <repository url> [<configuration>] [--install[=<version>]] [--group=<group>] [--username=<username>] [--password=<password>][--no-quit][--no-save]
 	--help              show this help message
+	--no-quit        keep the image running after configuration install
+	--no-save       Don't save the image after configuration install
 	<repository url>    A Monticello repository name 
 	<configuration>     A valid Metacello Configuration name
 	<version>           A valid version for the given configuration

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/activate.st
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/activate.st
@@ -7,4 +7,6 @@ activate
 		ifFalse: [ ^ self list ].
 		
 	self installConfiguration.
+	
+	self postConfiguration.
 		

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/installVersion..st
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/installVersion..st
@@ -9,5 +9,3 @@ installVersion: aVersionName
 		(self hasOption: 'group')
 			ifTrue: [ metacelloVersion load: self groups ]
 			ifFalse: [ metacelloVersion load ]].
-	
-	Smalltalk snapshot: true andQuit: true.

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/noQuit.st
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/noQuit.st
@@ -1,0 +1,3 @@
+accessing
+noQuit
+	^ self hasOption: 'no-quit'

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/noSave.st
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/noSave.st
@@ -1,0 +1,3 @@
+accessing
+noSave
+	^ self hasOption: 'no-save'

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/postConfiguration.st
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/instance/postConfiguration.st
@@ -1,0 +1,3 @@
+actions
+postConfiguration
+	Smalltalk snapshot: (self noSave not) andQuit: (self noQuit not).

--- a/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/properties.json
+++ b/src/ConfigurationCommandLineHandler-Core.package/ConfigurationCommandLineHandler.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "TorstenBergmann 2/6/2014 08:17",
+	"commentStamp" : "RafaelLuque 10/18/2017 19:48",
 	"super" : "CommandLineHandler",
 	"category" : "ConfigurationCommandLineHandler-Core",
 	"classinstvars" : [ ],


### PR DESCRIPTION
Add optional options --no-quit and --no-save to the ConfigurationCommandLineHandler.Fix for issue https://pharo.fogbugz.com/f/cases/19533/Configuration-command-line-handler-should-not-save-and-quit-by-himself