### PR TITLE
20605-In-the-Changes-browser-diffing-a-method-not-in-the-image-causes-a-walkback

### DIFF
--- a/src/Rubric.package/RubSmalltalkEditor.class/instance/implementorsOfIt.st
+++ b/src/Rubric.package/RubSmalltalkEditor.class/instance/implementorsOfIt.st
@@ -3,6 +3,5 @@ implementorsOfIt
 	"Open an implementors browser on the selected selector"
 
 	| aSelector |
-	"self lineSelectAndEmptyCheck: [^ self]."
 	(aSelector := self selectedSelector) == nil ifTrue: [^ textArea flash].
 	self implementorsOf: aSelector

--- a/src/Rubric.package/RubSmalltalkEditor.class/instance/implementorsOfIt.st
+++ b/src/Rubric.package/RubSmalltalkEditor.class/instance/implementorsOfIt.st
@@ -3,6 +3,6 @@ implementorsOfIt
 	"Open an implementors browser on the selected selector"
 
 	| aSelector |
-	self lineSelectAndEmptyCheck: [^ self].
+	"self lineSelectAndEmptyCheck: [^ self]."
 	(aSelector := self selectedSelector) == nil ifTrue: [^ textArea flash].
 	self implementorsOf: aSelector

--- a/src/Tool-ExternalBrowser.package/ExternalChangesBrowser.class/instance/canCompareToCurrent.st
+++ b/src/Tool-ExternalBrowser.package/ExternalChangesBrowser.class/instance/canCompareToCurrent.st
@@ -1,5 +1,10 @@
 menu
 canCompareToCurrent
 
-	^ changes selectedItems size = 1
-		and: [ changes selectedItem isMethodDeclaration ]
+	| aMethodDeclaration |
+	(changes selectedItems size = 1) ifFalse: [ ^ false ].
+	((aMethodDeclaration := changes selectedItem) isMethodDeclaration) ifFalse: [  ^ false ].
+	
+	( aMethodDeclaration existsBehavior) ifFalse: [ ^ false ].
+	^ aMethodDeclaration targetClass includesSelector: aMethodDeclaration methodSelector
+	


### PR DESCRIPTION
Does not enable the "Compare to Current" menu item unless
there is a current method with which to comapre.