### PR TITLE
18391-Debugger must guard against actions on process termination

### DIFF
--- a/src/DebuggerModel.package/DebugSession.class/instance/pcRangeForContext..st
+++ b/src/DebuggerModel.package/DebugSession.class/instance/pcRangeForContext..st
@@ -2,9 +2,11 @@ context
 pcRangeForContext: aContext
 	"Answer the indices in the source code for the method corresponding to 
 	aContext's program counter value."
-
-	aContext isDead ifTrue:
+	(aContext isNil) ifTrue: [ 
+		self terminate.
+		 ] ifFalse: [  
+	(aContext isDead) ifTrue:
 		[^1 to: 0].
 	^aContext debuggerMap
 		rangeForPC: aContext pc
-		contextIsActiveContext: (self isLatestContext: aContext)
+		contextIsActiveContext: (self isLatestContext: aContext) ]

--- a/src/GT-Debugger.package/GTMoldableDebugger.class/instance/updateBrowser.st
+++ b/src/GT-Debugger.package/GTMoldableDebugger.class/instance/updateBrowser.st
@@ -3,6 +3,10 @@ updateBrowser
 	| browserPane session |
 	
 	session := self session.
+	session interruptedContext ifNil: [ 
+		self close.
+		UIManager default inform: 'End of debugged execution'.
+		 ] ifNotNil: [  
 	browserPane := self browser pane.
 	(browserPane port: #entity) silentValue: nil.
-	(browserPane port: #entity) value: session.
+	(browserPane port: #entity) value: session. ]

--- a/src/Kernel.package/Context.class/instance/runUntilErrorOrReturnFrom..st
+++ b/src/Kernel.package/Context.class/instance/runUntilErrorOrReturnFrom..st
@@ -26,7 +26,7 @@ runUntilErrorOrReturnFrom: aSender
 	"Control resumes here once above ensure block or exception handler is executed"
 	^ error ifNil: [
 		"No error was raised, remove ensure context by stepping until popped"
-		[context isDead] whileFalse: [topContext := topContext stepToCallee].
+		[(context isDead)or: [ topContext isNil  ]] whileFalse: [topContext := topContext stepToCallee].
 		{topContext. nil}
 
 	] ifNotNil: [

--- a/src/Kernel.package/Process.class/instance/terminate.st
+++ b/src/Kernel.package/Process.class/instance/terminate.st
@@ -6,7 +6,6 @@ terminate
 	terminating := self isTerminating
 		ifTrue: [ ^ ProcessAlreadyTerminating signal ]
 		ifFalse: [ true ].
-		
 	self isActiveProcess 
 		ifTrue: [
 			ctxt := thisContext.


### PR DESCRIPTION
added guards so the debugger doesn't send stepping messages to nil contexts. (This was the cause of the freezing because it would loop until the context was dead).

Now the debugger closes when we are stepping out of  a 'terminal' context instead of showing a 'nil doesNotUnderstand: isDead' exception. (It notifiies the user through an inform that the debugging session is finished)