### PR TITLE
20296-Add-InputWidget-back-

### DIFF
--- a/src/Morphic-Widgets-Pluggable.package/PluggableTextFieldMorph.class/instance/acceptContents.st
+++ b/src/Morphic-Widgets-Pluggable.package/PluggableTextFieldMorph.class/instance/acceptContents.st
@@ -1,0 +1,3 @@
+visiting
+acceptContents
+	self accept.

--- a/src/Spec-PolyWidgets.package/InputWidget.class/README.md
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/README.md
@@ -1,0 +1,4 @@
+I am a generic widget far a user to enter a string
+
+Example (printMe):
+	self example inspect.

--- a/src/Spec-PolyWidgets.package/InputWidget.class/class/defaultSpec.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/class/defaultSpec.st
@@ -1,0 +1,8 @@
+specs
+defaultSpec
+	<spec>
+	
+	^ SpecLayout composed
+		newRow: #label bottom: 0.5;
+		newRow: #input top: 0.5;
+		yourself

--- a/src/Spec-PolyWidgets.package/InputWidget.class/class/example.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/class/example.st
@@ -1,0 +1,12 @@
+example
+example
+	"self example inspect"
+
+	| widget |	
+	widget := self new.
+	widget
+		title: 'Name';
+		label: 'What''s your name?';
+		ghostText: 'John Doe'.
+	widget openDialogWithSpec modalRelativeTo: self currentWorld.
+	^ widget value

--- a/src/Spec-PolyWidgets.package/InputWidget.class/class/example2.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/class/example2.st
@@ -1,0 +1,14 @@
+example
+example2
+	"self example2"
+	
+	| widget buttonModel buttonWindow |
+	buttonModel := ButtonModel new.
+	buttonWindow := buttonModel openWithSpec.
+	widget := self new.
+	widget
+		title: 'Label?';
+		label: 'Enter a button label';
+		ghostText: 'Ok'.
+	widget openDialogWithSpec modalRelativeTo: buttonWindow.
+	buttonModel label: widget value

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/ghostText..st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/ghostText..st
@@ -1,0 +1,4 @@
+api
+ghostText: aString
+
+	input ghostText: aString

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/initialExtent.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/initialExtent.st
@@ -1,0 +1,4 @@
+api
+initialExtent
+
+	^ 250@125

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/initialize.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/initialize.st
@@ -1,0 +1,8 @@
+initialization
+initialize
+
+	okAction := [ ] asValueHolder.
+	value := '' asValueHolder.
+	title := 'Title' asValueHolder.
+	
+	super initialize.

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializeDialogWindow..st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializeDialogWindow..st
@@ -1,0 +1,4 @@
+initialization
+initializeDialogWindow: aWindow
+
+	aWindow okAction: [ self ok ]

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializePresenter.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializePresenter.st
@@ -1,0 +1,8 @@
+initialization
+initializePresenter
+
+	input whenTextIsAccepted: [:text |
+		self ok == false
+			ifFalse: [ value value: text ] ].
+		
+	title whenChangedDo: [ self updateTitle ]

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializeWidgets.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/initializeWidgets.st
@@ -1,0 +1,13 @@
+initialization
+initializeWidgets
+
+	input 	:= self newTextInput.
+	label	:= self newLabel.
+			
+	input
+		ghostText: 'input';
+		acceptBlock: [ self triggerOkAction ];
+		entryCompletion: nil;
+		acceptOnCR: true.
+		
+	label label: 'label'

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/input.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/input.st
@@ -1,0 +1,3 @@
+accessing
+input
+	^ input

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/label..st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/label..st
@@ -1,0 +1,4 @@
+api
+label: aString
+
+	label label: aString.

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/label.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/label.st
@@ -1,0 +1,3 @@
+accessing
+label
+	^ label

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/ok.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/ok.st
@@ -1,0 +1,5 @@
+actions
+ok
+
+	input accept.
+	^ okAction value value

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/title..st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/title..st
@@ -1,0 +1,4 @@
+api
+title: aString
+
+	title value: aString

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/title.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/title.st
@@ -1,0 +1,4 @@
+api-events
+title
+
+	^ title value

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/triggerOkAction.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/triggerOkAction.st
@@ -1,0 +1,5 @@
+api
+triggerOkAction
+
+	self window 
+		ifNotNil: [ :w | w triggerOkAction ]

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/value.st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/value.st
@@ -1,0 +1,4 @@
+api
+value
+
+	^ value value

--- a/src/Spec-PolyWidgets.package/InputWidget.class/instance/whenValueChanged..st
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/instance/whenValueChanged..st
@@ -1,0 +1,4 @@
+api-events
+whenValueChanged: aBlock
+
+	value whenChangedDo: aBlock

--- a/src/Spec-PolyWidgets.package/InputWidget.class/properties.json
+++ b/src/Spec-PolyWidgets.package/InputWidget.class/properties.json
@@ -1,0 +1,17 @@
+{
+	"commentStamp" : "SeanDeNigris 1/23/2014 11:40",
+	"super" : "ComposablePresenter",
+	"category" : "Spec-PolyWidgets-Widgets",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"input",
+		"label",
+		"okAction",
+		"value",
+		"title"
+	],
+	"name" : "InputWidget",
+	"type" : "normal"
+}


### PR DESCRIPTION
Adds InputWidget as an example class.  We needed to add #acceptContents: to PluggableTextFieldMorph to make it work.