### PR TITLE
20602 file locator local directory should be inside image directory

### DIFF
--- a/src/FileSystem-Core.package/SystemResolver.class/class/userLocalDirectory.st
+++ b/src/FileSystem-Core.package/SystemResolver.class/class/userLocalDirectory.st
@@ -1,4 +1,4 @@
 accessing
 userLocalDirectory
 	^ UserLocalDirectory ifNil: [ 
-		FileLocator imageDirectory / self defaultLocalDirectoryName  ]
+		(FileLocator imageDirectory / self defaultLocalDirectoryName) resolve  ]

--- a/src/FileSystem-Core.package/SystemResolver.class/class/userLocalDirectory.st
+++ b/src/FileSystem-Core.package/SystemResolver.class/class/userLocalDirectory.st
@@ -1,4 +1,4 @@
 accessing
 userLocalDirectory
 	^ UserLocalDirectory ifNil: [ 
-		FileLocator workingDirectory / self defaultLocalDirectoryName  ]
+		FileLocator imageDirectory / self defaultLocalDirectoryName  ]


### PR DESCRIPTION
UserLocalDirectory should be placed in imageDirectory by default.

https://pharo.fogbugz.com/f/cases/20602/FileLocator-localDirectory-should-be-inside-image-directory