### PR TITLE
20634 missing super messages in set up and tear down in kernel tests unit tests

### DIFF
--- a/src/Kernel-Tests-Rules/FloatReferencesRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/FloatReferencesRuleTest.class.st
@@ -9,14 +9,15 @@ Class {
 
 { #category : #running }
 FloatReferencesRuleTest >> setUp [
-
+	super setUp.
 	testClass := Object newAnonymousSubclass.
 ]
 
 { #category : #running }
 FloatReferencesRuleTest >> tearDown [
 
-	testClass := nil
+	testClass := nil.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Rules/OverridesDeprecatedMethodRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/OverridesDeprecatedMethodRuleTest.class.st
@@ -16,7 +16,7 @@ OverridesDeprecatedMethodRuleTest >> methodName [
 
 { #category : #running }
 OverridesDeprecatedMethodRuleTest >> setUp [
-
+	super setUp.
 	testClass := Object newAnonymousSubclass.
 	testSubclass := testClass newAnonymousSubclass.
 	
@@ -27,7 +27,8 @@ OverridesDeprecatedMethodRuleTest >> setUp [
 OverridesDeprecatedMethodRuleTest >> tearDown [
 
 	testClass := nil.
-	testSubclass := nil
+	testSubclass := nil.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/AdditionalMethodStateTest.class.st
+++ b/src/Kernel-Tests/AdditionalMethodStateTest.class.st
@@ -14,7 +14,7 @@ Class {
 AdditionalMethodStateTest >> setUp [
 
 	| pragma |
-
+	super setUp.
 	pragma := (Object compiledMethodAt: #at:) penultimateLiteral at: #primitive:.
 	
 	atState := AdditionalMethodState selector: #at: with: pragma copy.

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -24,6 +24,7 @@ ClassOrganizationTest >> runCase [
 
 { #category : #running }
 ClassOrganizationTest >> setUp [ 
+	super setUp.
 	class := Object subclass: #ClassForTests instanceVariableNames: '' classVariableNames: '' category: 'ClassOrganizer-Tests'.
 	organization := ClassOrganization forClass: class.
 	organization addCategory: 'empty'.

--- a/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
@@ -15,6 +15,8 @@ Class {
 
 { #category : #running }
 DateAndTimeDosEpochTest >> setUp [
+
+	super setUp.
 	localTimeZoneToRestore := DateAndTime localTimeZone.
 	aDateAndTime :=  DateAndTime localTimeZone: TimeZone default; dosEpoch.
 	aTimeZone := TimeZone offset: (Duration minutes: 135) name: 'DOS Epoch Test Time Zone' abbreviation: 'DTZ'.

--- a/src/Kernel-Tests/DateAndTimeEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeEpochTest.class.st
@@ -29,7 +29,8 @@ Class {
 
 { #category : #running }
 DateAndTimeEpochTest >> setUp [
-     localTimeZoneToRestore := DateAndTime localTimeZone.
+ 	super setUp.  
+	localTimeZoneToRestore := DateAndTime localTimeZone.
 	aDateAndTime :=  DateAndTime localTimeZone: TimeZone default; epoch.
 	aTimeZone := TimeZone offset: (Duration minutes: 135) name: 'Epoch Test Time Zone' abbreviation: 'ETZ'.
 	aDuration := Duration days: 1 hours: 2 minutes: 3 seconds: 4 nanoSeconds: 5 

--- a/src/Kernel-Tests/DateAndTimeLeapTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeLeapTest.class.st
@@ -19,6 +19,7 @@ Class {
 
 { #category : #running }
 DateAndTimeLeapTest >> setUp [
+	super setUp.
 	aDateAndTime := (DateAndTime 
 		year: 2004 month: 2 day: 29 
 		hour: 13 minute: 33 second: 0 

--- a/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
@@ -15,7 +15,8 @@ Class {
 
 { #category : #running }
 DateAndTimeUnixEpochTest >> setUp [
-     localTimeZoneToRestore := DateAndTime localTimeZone.
+	super setUp.
+   localTimeZoneToRestore := DateAndTime localTimeZone.
 	aDateAndTime :=  DateAndTime localTimeZone: TimeZone default; unixEpoch.
 	aTimeZone := TimeZone offset: (Duration minutes: 135) name: 'Unix Epoch Test Time Zone' abbreviation: 'UTZ'.
 	aDuration := Duration days: 1 hours: 2 minutes: 3 seconds: 4 nanoSeconds: 5 

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -51,7 +51,7 @@ DateTest >> selectorsToBeIgnored [
 
 { #category : #running }
 DateTest >> setUp [
-	super setUP.
+	super setUp.
 	june2nd1973 := self dateClass year: 1973 day: 153.
 	january23rd2004 := Date readFrom: '01-23-2004' readStream.
 	aTime := Time readFrom: '12:34:56 pm' readStream

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -51,7 +51,7 @@ DateTest >> selectorsToBeIgnored [
 
 { #category : #running }
 DateTest >> setUp [
-
+	super setUP.
 	june2nd1973 := self dateClass year: 1973 day: 153.
 	january23rd2004 := Date readFrom: '01-23-2004' readStream.
 	aTime := Time readFrom: '12:34:56 pm' readStream

--- a/src/Kernel-Tests/DurationTest.class.st
+++ b/src/Kernel-Tests/DurationTest.class.st
@@ -31,6 +31,7 @@ DurationTest >> selectorsToBeIgnored [
 
 { #category : #running }
 DurationTest >> setUp [
+	super setUp.
 	aDuration := Duration days: 1 hours: 2 minutes: 3 seconds: 4 nanoSeconds: 5 
 ]
 

--- a/src/Kernel-Tests/LocalRecursionStopperTest.class.st
+++ b/src/Kernel-Tests/LocalRecursionStopperTest.class.st
@@ -60,7 +60,7 @@ LocalRecursionStopperTest >> recursion [
 
 { #category : #running }
 LocalRecursionStopperTest >> setUp [
-
+	super setUp.
 	value := 0
 ]
 
@@ -68,6 +68,7 @@ LocalRecursionStopperTest >> setUp [
 LocalRecursionStopperTest >> tearDown [
 
 	fork ifNotNil: [ fork terminate. fork := nil ].
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/StopwatchTest.class.st
+++ b/src/Kernel-Tests/StopwatchTest.class.st
@@ -36,6 +36,7 @@ StopwatchTest >> selectorsToBeIgnored [
 
 { #category : #running }
 StopwatchTest >> setUp [
+	super setUp.
 	aStopwatch := Stopwatch new.
 	aDelay := Delay forMilliseconds: 1.
 ]

--- a/src/Kernel-Tests/TimeTest.class.st
+++ b/src/Kernel-Tests/TimeTest.class.st
@@ -37,7 +37,7 @@ TimeTest >> selectorsToBeIgnored [
 
 { #category : #running }
 TimeTest >> setUp [
-
+	super setUp.
 	localTimeZoneToRestore := DateAndTime localTimeZone.
 	DateAndTime localTimeZone: TimeZone default.
 	time := self timeClass fromSeconds: 14567.		"4:02:47 am"

--- a/src/Kernel-Tests/TimespanDoSpanAYearTest.class.st
+++ b/src/Kernel-Tests/TimespanDoSpanAYearTest.class.st
@@ -18,6 +18,7 @@ Class {
 
 { #category : #running }
 TimespanDoSpanAYearTest >> setUp [
+	super setUp.
 	aDate := DateAndTime year: 2004 month: 12 day: 25 hour: 0 minute: 0 second: 0.
 	aDuration := Duration days: 91 hours: 0 minutes: 0 seconds: 0 nanoSeconds: 0.
 

--- a/src/Kernel-Tests/TimespanDoTest.class.st
+++ b/src/Kernel-Tests/TimespanDoTest.class.st
@@ -19,6 +19,7 @@ Class {
 
 { #category : #running }
 TimespanDoTest >> setUp [
+	super setUp.
 	aDate := DateAndTime
 				year: 2003
 				month: 01

--- a/src/Kernel-Tests/TimespanTest.class.st
+++ b/src/Kernel-Tests/TimespanTest.class.st
@@ -29,7 +29,7 @@ TimespanTest >> classToBeTested [
 
 { #category : #running }
 TimespanTest >> setUp [
-
+	super setUp.
 	localTimeZoneToRestore := DateAndTime localTimeZone.
 	DateAndTime localTimeZone: TimeZone default.
 

--- a/src/Kernel-Tests/UnicodeTest.class.st
+++ b/src/Kernel-Tests/UnicodeTest.class.st
@@ -48,6 +48,7 @@ UnicodeTest >> checkCorrespondanceOf: aSelector and: aCategoryTag [
 
 { #category : #running }
 UnicodeTest >> setUp [
+	super setUp.
 	unicodeGenerator := UnicodeTestRNG current
 ]
 

--- a/src/Kernel-Tests/UnicodeTestRNG.class.st
+++ b/src/Kernel-Tests/UnicodeTestRNG.class.st
@@ -60,5 +60,6 @@ UnicodeTestRNG >> randomCodePointBetween: lower and: upper [
 
 { #category : #running }
 UnicodeTestRNG >> setUp [
+	super setUp.
 	generator := Random seed: 14159265.
 ]

--- a/src/Kernel-Tests/YearMonthWeekTest.class.st
+++ b/src/Kernel-Tests/YearMonthWeekTest.class.st
@@ -14,6 +14,7 @@ Class {
 
 { #category : #running }
 YearMonthWeekTest >> setUp [
+	super setUp.
 	restoredStartDay := Week startDay.
 	restoredTimeZone := DateAndTime localTimeZone.
 
@@ -25,6 +26,7 @@ YearMonthWeekTest >> setUp [
 YearMonthWeekTest >> tearDown [
 	Week startDay: restoredStartDay.
 	DateAndTime localTimeZone: restoredTimeZone.
+	super tearDown 
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Add missing super messages in #setUp and #tearDown in Kernel-Tests  

https://pharo.fogbugz.com/f/cases/20634/Missing-super-messages-in-setUp-and-tearDown-in-Kernel-Tests-unit-tests