### PR TITLE
20651-Old-Compiler-is-loaded-using-wrong-repository-specification

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -905,7 +905,7 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 
 	MCMethodDefinition initializersEnabled: false.
 	
-	repo := MCFileTreeRepository new
+	repo := TonelRepository new
 	directory: './pharo-core/src' asFileReference;
 	yourself.
 		


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20651/Old-Compiler-is-loaded-using-wrong-repository-specificationuse TonelRepository for loading of the old Compiler