### PR TITLE
20552-Breakpoints-stay-in-the-breakpoints-browser-even-after-their-method-is-recompiled

### DIFF
--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -39,6 +39,19 @@ BreakpointTest >> tearDown [
 ]
 
 { #category : #tests }
+BreakpointTest >> testModifyMethodWithBreakpoint [
+	cls compile: 'dummy ^42'.
+	self assert: Breakpoint all isEmpty.
+	Breakpoint new
+		node: (cls >> #dummy) ast;
+		once;
+		install.
+	self assert: (cls >> #dummy) hasBreakpoint.
+	cls compile: 'dummy ^43'.
+	self assert: Breakpoint all isEmpty
+]
+
+{ #category : #tests }
 BreakpointTest >> testRemoveClassWithBreakpoint [
 	cls compile: 'dummy ^42'.
 	self assert: Breakpoint all isEmpty.

--- a/src/Reflectivity-Tools/Breakpoint.class.st
+++ b/src/Reflectivity-Tools/Breakpoint.class.st
@@ -51,6 +51,11 @@ Breakpoint class >> handleClassRemoved: anAnnouncement [
 ]
 
 { #category : #'system announcements' }
+Breakpoint class >> handleMethodModified: anAnnouncement [
+	self removeBreakpointsFromMethod: anAnnouncement oldMethod
+]
+
+{ #category : #'system announcements' }
 Breakpoint class >> handleMethodRemoved: anAnnouncement [
 	self removeBreakpointsFromMethod: anAnnouncement method
 ]
@@ -79,6 +84,7 @@ Breakpoint class >> registerInsterestToSystemAnnouncement [
 	SystemAnnouncer uniqueInstance
 		unsubscribe: self.
 	SystemAnnouncer uniqueInstance weak subscribe: MethodRemoved send: #handleMethodRemoved: to: self.
+	SystemAnnouncer uniqueInstance weak subscribe: MethodModified send: #handleMethodModified: to: self.
 	SystemAnnouncer uniqueInstance weak subscribe: ClassRemoved send: #handleClassRemoved: to: self.
 ]
 


### PR DESCRIPTION
Issue URL: https://pharo.fogbugz.com/f/cases/20552/Breakpoints-stay-in-the-breakpoints-browser-even-after-their-method-is-recompiledBreakpoint class now subscribes to the MethodChanged announcement, and remove from its list the breakpoints from methods that get recompiled.
Also added a test for this behaviour.