### PR TITLE
20363-ThemeIconsdownloadTo-has-an-argument-which-is-never-referenced-in-code

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -237,15 +237,8 @@ ThemeIcons >> doesNotUnderstand: aMessage [
 
 { #category : #loading }
 ThemeIcons >> downloadFromUrl [
-	| dir |
-	dir := self class destinationPath ensureCreateDirectory. 
-	^ self downloadTo: dir
-]
-
-{ #category : #private }
-ThemeIcons >> downloadTo: dir [
 	| zipArchive |
-	
+	self class destinationPath ensureCreateDirectory. 	
 	zipArchive := self class destinationPath / (self name, '.zip').
 	zipArchive exists 
 		ifFalse: [ 


### PR DESCRIPTION
fix for https://pharo.fogbugz.com/f/cases/20363/ThemeIcons-downloadTo-has-an-argument-which-is-never-referenced-in-code