### PR TITLE
20661-Fixing-test-from-debugger-should-mark-test-as-green-when-proceed-

### DIFF
--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -355,6 +355,9 @@ TestResult >> runCaseForDebug: aTestCase [
 	aTestCase announce: TestCaseStarted withResult: self.
 	aTestCase runCaseManaged.
 	aTestCase announce: TestCaseEnded  withResult: self.
+	"To not affect performance of big test suites following logic is not inside addPass: method"
+	errors remove: aTestCase ifAbsent: [].
+	failures remove: aTestCase ifAbsent: [].
 	self addPass: aTestCase]
 		on: self class failure , self class skip, self class warning, self class error
 		do: [:ex | ex sunitAnnounce: aTestCase toResult: self. ex pass]


### PR DESCRIPTION
Now runCaseForDebug: removes passed test case from errors and failures.
This logic is not inside addPass: method directly to not affect bug suite result collecting because it can become slow if it will clean errors and failures for every green test.
Maybe in future we can improve this part.https://pharo.fogbugz.com/f/cases/20661/Fixing-test-from-debugger-should-mark-test-as-green-when-proceed