### PR TITLE
20263-Debugger-DoesNotUnderstandDebugAction-is-missing-a-defaultHelp-method-so-hover-help-shows-missing

### DIFF
--- a/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
+++ b/src/DebuggerActions/DoesNotUnderstandDebugAction.class.st
@@ -41,6 +41,11 @@ DoesNotUnderstandDebugAction >> askForSuperclassOf: aClass toImplement: aSelecto
 ]
 
 { #category : #accessing }
+DoesNotUnderstandDebugAction >> defaultHelp [
+    ^ 'Create the missing method in the user prompted class and restart the debugger at that location where it can be edited.'
+]
+
+{ #category : #accessing }
 DoesNotUnderstandDebugAction >> defaultLabel [
 
 	^  'Create'


### PR DESCRIPTION
Debugger DoesNotUnderstandDebugAction is missing a #defaultHelp method so hover help shows missing

https://pharo.fogbugz.com/f/cases/20263/