### PR TITLE
17654-SpecPreDebugWindow-and-subclasses-relies-on-doesNotUnderstand-delegation-to-find-the-stackPane

### DIFF
--- a/src/Spec-Debugger/SpecPreDebugWindow.class.st
+++ b/src/Spec-Debugger/SpecPreDebugWindow.class.st
@@ -336,6 +336,11 @@ SpecPreDebugWindow >> setTitle: aString [
 	self updateTitle 
 ]
 
+{ #category : #accessing }
+SpecPreDebugWindow >> stackPane [
+	^widgets at: #stackPane
+]
+
 { #category : #api }
 SpecPreDebugWindow >> title [
 


### PR DESCRIPTION
SpecPreDebugWindow and subclasses relies on #doesNotUnderstand delegation to find the stackPane

https://pharo.fogbugz.com/f/cases/17654