### PR TITLE
20670-unused-var-in-generateDefaultFileOutResultsName

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -624,7 +624,6 @@ TestRunner >> generateDefaultFileOutResultsName [
 	| filename |
 	filename := String
 		streamContents: [ :st | 
-			| printedDate |
 			st nextPutAll: 'tests_'.
 			st nextPutAll: SystemVersion current version.
 			st nextPutAll: '_'.


### PR DESCRIPTION
unused var in #generateDefaultFileOutResultsName

https://pharo.fogbugz.com/f/cases/20670/unused-var-in-generateDefaultFileOutResultsName