### PR TITLE
20679-Reloading-of-OSWindow-SDL2-causes-Tonel-parsing-error

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
+++ b/src/OSWindow-SDL2/OSSDL2WindowHandle.class.st
@@ -334,7 +334,6 @@ OSSDL2WindowHandle >> show [
 { #category : #cursor }
 OSSDL2WindowHandle >> showCursor: aBoolean [
 	SDL2 showCursor: (aBoolean ifTrue: [SDL_ENABLE] ifFalse: [SDL_DISABLE]).
-                 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20679/Reloading-of-OSWindow-SDL2-causes-Tonel-parsing-errorfix broken UTF8 character