### PR TITLE
20685-Do-not-use-hardcoded-URLs-in-system-baselines

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -34,7 +34,7 @@ BaselineOfBasicTools >> baseline: spec [
         
 	| repository | 
 	
-	repository := 'tonel://./pharo-core/src'.    
+	repository := self packageRepositoryURL.
 
 	spec for: #common do: [
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -107,7 +107,7 @@ BaselineOfIDE >> baseline: spec [
 
  	| repository | 
 	
-	repository := 'tonel://./pharo-core/src'.     
+	repository := self packageRepositoryURL.
        
 	spec for: #common do: [
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -31,7 +31,8 @@ BaselineOfMorphic >> baseline: spec [
         
 	| repository | 
 	
-	repository := 'tonel://./pharo-core/src'.    
+	repository := self packageRepositoryURL.
+
 	spec for: #common do: [
 		spec preLoadDoIt: #'preload:package:'.
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -23,7 +23,7 @@ BaselineOfMorphicCore >> baseline: spec [
 
 	| repository | 
 	
-	repository := 'tonel://./pharo-core/src'. 
+	repository := self packageRepositoryURL.
 
 	spec for: #common do: [
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -27,7 +27,7 @@ BaselineOfUI >> baseline: spec [
 
 	| repository |
 	 
-	repository := 'tonel://./pharo-core/src'.    
+	repository := self packageRepositoryURL.
        
 	spec for: #common do: [
 		spec postLoadDoIt: #'postload:package:'.

--- a/src/Metacello-PharoExtensions/BaselineOf.extension.st
+++ b/src/Metacello-PharoExtensions/BaselineOf.extension.st
@@ -7,6 +7,18 @@ BaselineOf class >> allPackageNames [
 ]
 
 { #category : #'*Metacello-PharoExtensions' }
+BaselineOf >> packageRepositoryURL [
+
+	" Tries to determine a repository URL from which the baseline is being loaded. Useful for 
+	refering other baselines in the same repository. "
+
+	^ (self class package mcWorkingCopy repositoryGroup repositories reject: [:each | each = MCCacheRepository uniqueInstance]) anyOne description.
+
+
+	
+]
+
+{ #category : #'*Metacello-PharoExtensions' }
 BaselineOf class >> packagesOfGroupNamed: aName [
 
 	^ (self version groups detect: [ :g | g name = aName ]) includes

--- a/src/Metacello-PharoExtensions/BaselineOf.extension.st
+++ b/src/Metacello-PharoExtensions/BaselineOf.extension.st
@@ -11,8 +11,11 @@ BaselineOf >> packageRepositoryURL [
 
 	" Tries to determine a repository URL from which the baseline is being loaded. Useful for 
 	refering other baselines in the same repository. "
+	
 
-	^ (self class package mcWorkingCopy repositoryGroup repositories reject: [:each | each = MCCacheRepository uniqueInstance]) anyOne description.
+	^ (self class package mcWorkingCopy repositoryGroup repositories reject: [:each | each = MCCacheRepository uniqueInstance]) 
+		ifNotEmpty: [ :repositories | repositories anyOne description ]
+		ifEmpty: [ '' ]
 
 
 	


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20685/Do-not-use-hardcoded-URLs-in-system-baselinesuse repository URL of the baseline package for loading of other baselines from the same repository