### PR TITLE
20686-disabling-of-FreeType-fonts-should-set-bitmap-Source-Pro-fonts

### DIFF
--- a/src/FreeType/FreeTypeSystemSettings.class.st
+++ b/src/FreeType/FreeTypeSystemSettings.class.st
@@ -109,12 +109,14 @@ FreeTypeSystemSettings class >> loadFt2Library [
 { #category : #settings }
 FreeTypeSystemSettings class >> loadFt2Library: aBoolean [
 	(LoadFT2Library = aBoolean) 
-		ifTrue: [^ self].
+		ifTrue: [ ^ self ].
 	LoadFT2Library := aBoolean.
 	aBoolean 
-		ifTrue: [FreeTypeFontProvider current updateFromSystem]
-		ifFalse: [StandardFonts restoreDefaultFonts.
-			FreeTypeFontProvider unload]
+		ifTrue: [ 
+			FreeTypeFontProvider current updateFromSystem ]
+		ifFalse: [
+			StandardFonts setSmallBitmapFonts.
+			FreeTypeFontProvider unload ]
 
 ]
 

--- a/src/Graphics-Fonts/StandardFonts.class.st
+++ b/src/Graphics-Fonts/StandardFonts.class.st
@@ -393,14 +393,14 @@ StandardFonts class >> setSmallBitmapFonts [
 	sans := 'Bitmap Source Sans Pro'.
 	fixed := 'Bitmap Source Code Pro'.
 	
-	StandardFonts defaultFont: (LogicalFont familyName: sans pointSize: 10).
-	StandardFonts codeFont: (LogicalFont familyName: fixed pointSize: 10).
-	StandardFonts listFont: (LogicalFont familyName: sans pointSize: 10).
-	StandardFonts menuFont: (LogicalFont familyName: sans pointSize: 10).
-	StandardFonts buttonFont: (LogicalFont familyName: sans pointSize: 10).
- 	StandardFonts windowTitleFont: (LogicalFont familyName: sans pointSize: 11).
-	StandardFonts balloonFont: (LogicalFont familyName: sans pointSize: 9).
- 	StandardFonts haloFont: (LogicalFont familyName: sans pointSize: 9).
+	self defaultFont: (LogicalFont familyName: sans pointSize: 10).
+	self codeFont: (LogicalFont familyName: fixed pointSize: 10).
+	self listFont: (LogicalFont familyName: sans pointSize: 10).
+	self menuFont: (LogicalFont familyName: sans pointSize: 10).
+	self buttonFont: (LogicalFont familyName: sans pointSize: 10).
+ 	self windowTitleFont: (LogicalFont familyName: sans pointSize: 11).
+	self balloonFont: (LogicalFont familyName: sans pointSize: 9).
+ 	self haloFont: (LogicalFont familyName: sans pointSize: 9).
 ]
 
 { #category : #styles }

--- a/src/Graphics-Fonts/StandardFonts.class.st
+++ b/src/Graphics-Fonts/StandardFonts.class.st
@@ -385,6 +385,24 @@ StandardFonts class >> setFontsToVeryLarge [
 	self setFontsToStyleNamed: #verylarge
 ]
 
+{ #category : #choosing }
+StandardFonts class >> setSmallBitmapFonts [
+
+	| sans fixed |
+	
+	sans := 'Bitmap Source Sans Pro'.
+	fixed := 'Bitmap Source Code Pro'.
+	
+	StandardFonts defaultFont: (LogicalFont familyName: sans pointSize: 10).
+	StandardFonts codeFont: (LogicalFont familyName: fixed pointSize: 10).
+	StandardFonts listFont: (LogicalFont familyName: sans pointSize: 10).
+	StandardFonts menuFont: (LogicalFont familyName: sans pointSize: 10).
+	StandardFonts buttonFont: (LogicalFont familyName: sans pointSize: 10).
+ 	StandardFonts windowTitleFont: (LogicalFont familyName: sans pointSize: 11).
+	StandardFonts balloonFont: (LogicalFont familyName: sans pointSize: 9).
+ 	StandardFonts haloFont: (LogicalFont familyName: sans pointSize: 9).
+]
+
 { #category : #styles }
 StandardFonts class >> smallPointSizeForStyleNamed: aSymbol [
 	| all s idx |


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20686/disabling-of-FreeType-fonts-should-set-bitmap-Source-Pro-fontsset bitmap source pro fonts after disabling of FreeType