### PR TITLE
20688-move-Monticello-Browser-to-the-Tools-submenu-in-the-World-menu

### DIFF
--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -32,9 +32,9 @@ Class {
 MCWorkingCopyBrowser class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Monticello Browser')
-		parent: #MostUsedTools;
+		parent: #Tools;
 		action: [ Smalltalk tools openMonticelloBrowser ];
-		order: 0.9;
+		order: 0.20;
 		keyText: 'o, p';
 		icon: Smalltalk tools monticelloBrowser taskbarIcon
 ]


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20688/move-Monticello-Browser-to-the-Tools-submenu-in-the-World-menuMove Monticello Browser to the World menu under the Catalog Browser