### PR TITLE
20693-Incorrect-basename-of-empty-relative-path

### DIFF
--- a/src/FileSystem-Path/AbsolutePath.class.st
+++ b/src/FileSystem-Path/AbsolutePath.class.st
@@ -20,6 +20,18 @@ AbsolutePath class >> from: aString delimiter: aDelimiterCharater [
 	^ super from: aString delimiter: aDelimiterCharater
 ]
 
+{ #category : #accessing }
+AbsolutePath >> basename [
+	"Returns the base of the basename, 
+		i.e. 
+		/foo/gloops.taz basename is 'gloops.taz'
+		/ basename is '/'"
+	self size == 0
+		"the root node"
+		ifTrue: [ ^ '/'].
+	^ self at: self size
+]
+
 { #category : #testing }
 AbsolutePath >> isAbsolute [
 	^ true

--- a/src/FileSystem-Path/AbsolutePath.class.st
+++ b/src/FileSystem-Path/AbsolutePath.class.st
@@ -20,18 +20,6 @@ AbsolutePath class >> from: aString delimiter: aDelimiterCharater [
 	^ super from: aString delimiter: aDelimiterCharater
 ]
 
-{ #category : #accessing }
-AbsolutePath >> basename [
-	"Returns the base of the basename, 
-		i.e. 
-		/foo/gloops.taz basename is 'gloops.taz'
-		/ basename is '/'"
-	self size == 0
-		"the root node"
-		ifTrue: [ ^ '/'].
-	^ self at: self size
-]
-
 { #category : #testing }
 AbsolutePath >> isAbsolute [
 	^ true

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -342,7 +342,7 @@ Path >> do: aBlock [
 Path >> emptyPathString [
 	"Answer the string representing an empty (size = 0) instance of the receiver"
 
-	^String with: self delimiter
+	^self delimiter asString
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -252,7 +252,7 @@ Path >> basename [
 		/foo/gloops.taz basename is 'gloops.taz'
 		If empty, it is the emptyPathString"
 
-	self isEmpty	ifTrue: 
+	self isEmpty ifTrue: 
 		[ ^ self emptyPathString ].
 	^ self at: self size
 ]

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -247,14 +247,9 @@ Path >> base [
 
 { #category : #accessing }
 Path >> basename [
-	"Returns the base of the basename, 
-		i.e. 
-		/foo/gloops.taz basename is 'gloops.taz'
-		/ basename is '/'"
-	self size == 0
-		"the root node"
-		ifTrue: [ ^ '/'].
-	^ self at: self size
+	"Returns the base of the basename"
+
+	^self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -247,9 +247,14 @@ Path >> base [
 
 { #category : #accessing }
 Path >> basename [
-	"Returns the base of the basename"
+	"Returns the base of the basename, 
+		i.e. 
+		/foo/gloops.taz basename is 'gloops.taz'
+		If empty, it is the emptyPathString"
 
-	^self subclassResponsibility
+	self isEmpty	ifTrue: 
+		[ ^ self emptyPathString ].
+	^ self at: self size
 ]
 
 { #category : #accessing }
@@ -331,6 +336,13 @@ Path >> do: aBlock [
 			[ :index || segment |
 			segment := self at: index.
 			segment isEmpty ifFalse: [ aBlock value: segment ] ]
+]
+
+{ #category : #accessing }
+Path >> emptyPathString [
+	"Answer the string representing an empty (size = 0) instance of the receiver"
+
+	^String with: self delimiter
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Path/RelativePath.class.st
+++ b/src/FileSystem-Path/RelativePath.class.st
@@ -9,15 +9,11 @@ Class {
 }
 
 { #category : #accessing }
-RelativePath >> basename [
-	"Returns the base of the basename, 
-		i.e. 
-		/foo/gloops.taz basename is 'gloops.taz'
-		. basename is '.'"
-	self size == 0
-		"the current directory"
-		ifTrue: [ ^ '.'].
-	^ self at: self size
+RelativePath >> emptyPathString [
+	"Answer the string representing an empty (size = 0) instance of the receiver.
+	For a relative path, this is the current directory"
+
+	^'.'
 ]
 
 { #category : #testing }

--- a/src/FileSystem-Path/RelativePath.class.st
+++ b/src/FileSystem-Path/RelativePath.class.st
@@ -8,6 +8,18 @@ Class {
 	#category : #FileSystem-Path
 }
 
+{ #category : #accessing }
+RelativePath >> basename [
+	"Returns the base of the basename, 
+		i.e. 
+		/foo/gloops.taz basename is 'gloops.taz'
+		. basename is '.'"
+	self size == 0
+		"the current directory"
+		ifTrue: [ ^ '.'].
+	^ self at: self size
+]
+
 { #category : #testing }
 RelativePath >> isAbsolute [
 	^ false

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -75,6 +75,18 @@ PathTest >> testBasename [
 ]
 
 { #category : #tests }
+PathTest >> testBasenameNoParent [
+	| path |
+
+	path := Path / 'griffle'.
+	self assert: path parent basename equals: '/'.
+
+	path := Path * 'griffle'.
+	self assert: path parent basename equals: '.'.
+
+]
+
+{ #category : #tests }
 PathTest >> testBasenameWithoutExtension [
 	"self debug: #testBasenameWithoutExtension"
 	| path |


### PR DESCRIPTION
20693 Incorrect basename of empty relative path

- Modify Path and subclasses to return the current directory for an empty relative path.
- Add PathTest>>testBasenameNoParent to confirm correct behaviour.