### PR TITLE
20708 Unused temps in TSequencedConcatenationTest and TextEditor

### DIFF
--- a/src/Collections-Tests/TSequencedConcatenationTest.trait.st
+++ b/src/Collections-Tests/TSequencedConcatenationTest.trait.st
@@ -78,7 +78,7 @@ TSequencedConcatenationTest >> testNewStreamContentsReturnsCollectionOfCorrectSi
 
 { #category : #'tests - streaming' }
 TSequencedConcatenationTest >> testStreamContents [
-	| result index |
+	| result |
 	result:= self collectionClass streamContents: [ :s|
 		s 
 			nextPutAll: self firstCollection;
@@ -88,7 +88,7 @@ TSequencedConcatenationTest >> testStreamContents [
 
 { #category : #'tests - streaming' }
 TSequencedConcatenationTest >> testStreamContentsProtocol [
-	| result index |
+	| result |
 	result:= self collectionClass << [ :s|
 		s 
 			nextPutAll: self firstCollection;

--- a/src/Morphic-Base/TextMorph.class.st
+++ b/src/Morphic-Base/TextMorph.class.st
@@ -900,7 +900,6 @@ TextMorph >> handleInteraction: interactionBlock [
 { #category : #'event handling' }
 TextMorph >> handleKeystroke: anEvent [ 
 	"System level event handling."
-	| pasteUp |
 
 	anEvent wasHandled
 		ifTrue: [^ self].

--- a/src/Multilingual-TextConversion/TextConverter.class.st
+++ b/src/Multilingual-TextConversion/TextConverter.class.st
@@ -158,18 +158,17 @@ TextConverter >> installLineEndConvention: lineEndStringOrNil [
 
 { #category : #conversion }
 TextConverter >> next: anInteger putAll: aString startingAt: startIndex toStream: aStream [
-        "Handle fast conversion if ByteString"
+	"Handle fast conversion if ByteString"
+             
+   aString class == ByteString ifFalse: [
+		startIndex to: startIndex + anInteger - 1 do: [ :index | 
+			self nextPut: (aString at: index) toStream: aStream ].
+      ^aString ].
+	aStream isBinary ifTrue: [
+		aStream basicNext: anInteger putAll: aString startingAt: startIndex.
+		^aString ].
         
-        | lastIndex nextIndex |
-        aString class == ByteString ifFalse: [
-                startIndex to: startIndex + anInteger - 1 do: [ :index |
-                        self nextPut: (aString at: index) toStream: aStream ].
-                ^aString ].
-        aStream isBinary ifTrue: [
-                aStream basicNext: anInteger putAll: aString startingAt: startIndex.
-                ^aString ].
-        
-        ^self next: anInteger putByteString: aString startingAt: startIndex toStream: aStream
+	^self next: anInteger putByteString: aString startingAt: startIndex toStream: aStream
 ]
 
 { #category : #private }
@@ -204,7 +203,6 @@ TextConverter >> nextPut: aCharacter toStream: aStream [
 TextConverter >> nextPutAll: aString toStream: aStream [
 	"Handle fast conversion if ByteString"
 	
-	| lastIndex nextIndex |
 	aString class == ByteString ifFalse: [
 		aString do: [:char | self nextPut: char toStream: aStream].
 		^self].

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -452,7 +452,7 @@ TextEditor >> acceptCR: aKeyboardEvent return: return [
 
 { #category : #'undo-redo private' }
 TextEditor >> addDeleteSelectionUndoRecord [
-	| undoText redoText undoRec |
+	| undoText redoText |
 	undoText := self selection.
 	redoText := self nullText.
 	self editingState
@@ -469,7 +469,7 @@ TextEditor >> addString: aString [
 
 { #category : #'undo-redo private' }
 TextEditor >> addTypeInUndoRecord [
-	| begin stop undoText redoText undoRec |
+	| begin stop undoText redoText |
 	begin := self startOfTyping min: self stopIndex. 
 	stop := self stopIndex max: self startOfTyping.
 	self editingState 
@@ -898,7 +898,7 @@ TextEditor >> copySelection [
 TextEditor >> correctFrom: start to: stop with: aString [
 	"Make a correction in the model that the user has authorised from somewhere else in the system (such as from the compilier).  
 	The user's selection is not changed, only corrected."
-	| wasShowing userSelection delta loc |
+	| userSelection delta |
 	
 	userSelection := self selectionInterval.
 	self selectInvisiblyFrom: start to: stop.
@@ -1017,7 +1017,7 @@ TextEditor >> deselect [
 
 { #category : #'typing support' }
 TextEditor >> dispatchCommandOn: aKeyboardEvent return: return [
-	|asciiValue honorCommandKeys char|
+	|asciiValue honorCommandKeys|
 
 	asciiValue := aKeyboardEvent keyValue.
 	honorCommandKeys := self cmdKeysInText.
@@ -1064,7 +1064,7 @@ TextEditor >> dispatchOn: aKeyboardEvent [
 	Type-ahead is passed so some routines can flush or use it."
 	"TODO rename to dispatch: "
 	
-	| char return keyEvents|
+	| char return |
  	return := [:val| ^ val].
 
 	self acceptCR: aKeyboardEvent return: return.
@@ -1791,7 +1791,7 @@ TextEditor >> mouseMove: evt [
 TextEditor >> mouseUp: evt [
 	"An attempt to break up the old processRedButton 
 	code into three phases"
-	| mouseDownInterval clickPoint b|
+	| mouseDownInterval |
 	
 	(mouseDownInterval := self editingState mouseDownInterval)
 		ifNil: [^ self]. 
@@ -2030,7 +2030,7 @@ TextEditor >> replace: xoldInterval with: newText and: selectingBlock [
 	"Replace the text in oldInterval with newText and
 	execute selectingBlock to establish the new selection.
 	Create an UndoRecord to allow perfect undoing."
-	| prevSel currInterval undoRec |
+	| prevSel currInterval |
 	self selectInterval: xoldInterval.
 	prevSel := self selection.
 	currInterval := self selectionInterval.
@@ -2431,8 +2431,6 @@ TextEditor >> unapplyAttribute: aTextAttribute [
 	"The user selected aTextAttribute to be removed.
 	If there is a selection, unapply the attribute to the selection.
 	In any case do not use the attribute for the user input (emphasisHere)"
-
-	| thisSel interval |
 
 	self editingState emphasisHere: (self emphasisHere copyWithout: aTextAttribute).
 	self selection


### PR DESCRIPTION
Remove unused temps in
TextMorph>>#handleKeystroke:
TSequencedConcatenationTest>>#testStreamContents
TSequencedConcatenationTest>>#testStreamContentsProtocol
TextConverter>>#next:putAll:startingAt:toStream:
TextConverter>>#nextPutAll:toStream:
TextEditor>>#addDeleteSelectionUndoRecord
TextEditor>>#addTypeInUndoRecord
TextEditor>>#correctFrom:to:with:
TextEditor>>#dispatchCommandOn:return:
TextEditor>>#dispatchOn:
TextEditor>>#mouseUp:
TextEditor>>#replace:with:and:
TextEditor>>#unapplyAttribute: