### PR TITLE
20710 Unused temps in StringMorph, SimpleGridExample, SmalltalkEditor, SHMethodEditingMode, SelectorChooserMorph

### DIFF
--- a/src/Athens-Morphic/StringMorph.extension.st
+++ b/src/Athens-Morphic/StringMorph.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #StringMorph }
 
 { #category : #'*Athens-Morphic' }
 StringMorph >> drawOnAthensCanvas: canvas [
-	| pt bnd gap |
+	| bnd |
 "	bnd := self bounds.
 	gap := self layoutInset.
 "	bnd := self bounds topLeft + self layoutInset.

--- a/src/Morphic-Examples/SimpleGridExample.class.st
+++ b/src/Morphic-Examples/SimpleGridExample.class.st
@@ -36,7 +36,7 @@ SimpleGridExample >> rootNodeClassFromItem: anItem [
 
 { #category : #'user interface' }
 SimpleGridExample >> treeMorph [
-	| treeMorph oddColor evenColor |
+	| treeMorph |
 	treeMorph := (self treeMorphClass on: self)
 		beCheckList;
 		beMultiple;

--- a/src/Shout/SHMethodEditingMode.class.st
+++ b/src/Shout/SHMethodEditingMode.class.st
@@ -149,7 +149,7 @@ SHMethodEditingMode >> methodSelector [
 
 { #category : #view }
 SHMethodEditingMode >> open [
-	| window bar editor |
+	| window editor |
 	window := (StandardWindow labelled: 'Method editor with shout') model: self.
 	editor := window newTextEditorFor:  self getText:  #code setText: #code: getEnabled: nil. 
 	window addMorph: (window newColumn: { window newRow: { self classSelector. self metaSwitch. self methodSelector}. editor} )

--- a/src/Text-Edition/SelectorChooserMorph.class.st
+++ b/src/Text-Edition/SelectorChooserMorph.class.st
@@ -93,7 +93,7 @@ SelectorChooserMorph >> defaultBaseColor [
 
 { #category : #drawing }
 SelectorChooserMorph >> drawCommonPrefixAreasOn: aCanvas [
-	| firstMenu firstMenuItem topLeft bottomLeft lastMenuItem |
+	 
 	requestor ifNil: [^ self].
 	prefix 
 		ifNotNil: [ self choiceMenus 

--- a/src/Text-Edition/SmalltalkEditor.class.st
+++ b/src/Text-Edition/SmalltalkEditor.class.st
@@ -559,7 +559,7 @@ SmalltalkEditor >> internalCallToBrowse: aSelector [
 SmalltalkEditor >> internalCallToBrowseIt [
 	"Launch a browser for the class indicated by the current selection. 
 	If multiple classes matching the selection exist, let the user choose among them."
-	| aClass |
+ 
 	self lineSelectAndEmptyCheck: [^ self].
 	self internalCallToBrowse: (self selection string copyWithoutAll: CharacterSet crlf)
 ]


### PR DESCRIPTION
Remove unused temps from

StringMorph>>#drawOnAthensCanvas:
SimpleGridExample>>#treeMorph
SmalltalkEditor>>#internalCallToBrowseIt
SHMethodEditingMode>>#open
SelectorChooserMorph>>#drawCommonPrefixAreasOn: