### PR TITLE
20711 Unused temps in RubTextEditor, RubParagraph, RubMethodEditingExample, ReflectiveMethod, RxMatcher

### DIFF
--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -232,7 +232,7 @@ ReflectiveMethod >> printOn: aStream [
 
 { #category : #evaluation }
 ReflectiveMethod >> recompileAST [
-	| links |
+ 
 	OCASTSemanticCleaner clean: ast.
 	ast compilationContext 
 		semanticAnalyzerClass: RFSemanticAnalyzer;

--- a/src/Regex-Core/RxMatcher.class.st
+++ b/src/Regex-Core/RxMatcher.class.st
@@ -219,7 +219,7 @@ RxMatcher >> currentState [
 	"Answer an opaque object that can later be used to restore the
 	matcher's state (for backtracking)."
 
-	| origPosition origLastChar |
+	| origPosition |
 	origPosition := stream position.
 	^	[stream position: origPosition]
 ]

--- a/src/Rubric/RubMethodEditingExample.class.st
+++ b/src/Rubric/RubMethodEditingExample.class.st
@@ -148,7 +148,7 @@ RubMethodEditingExample >> okToChange [
 
 { #category : #view }
 RubMethodEditingExample >> open [
-	| window bar editor |
+	| window editor |
 	window := (StandardWindow labelled: 'Method editor with shout') model: self.
 	editor := self newScrolledText.
 	editor hResizing: #spaceFill; vResizing: #spaceFill.

--- a/src/Rubric/RubParagraph.class.st
+++ b/src/Rubric/RubParagraph.class.st
@@ -559,7 +559,7 @@ RubParagraph >> selectionRects [
 RubParagraph >> selectionRectsFrom: characterBlock1 to: characterBlock2 [
 	"Return an array of rectangles representing the area between the two character blocks given as arguments."
 
-	| line1 line2 rects cb1 cb2 w |
+	| line1 line2 cb1 cb2 |
 	characterBlock1 = characterBlock2
 		ifTrue: [ ^ #() ].
 	characterBlock1 <= characterBlock2

--- a/src/Rubric/RubSelectorChooserMorph.class.st
+++ b/src/Rubric/RubSelectorChooserMorph.class.st
@@ -78,7 +78,7 @@ RubSelectorChooserMorph >> defaultBaseColor [
 
 { #category : #drawing }
 RubSelectorChooserMorph >> drawCommonPrefixAreasOn: aCanvas [
-	| firstMenu firstMenuItem topLeft bottomLeft lastMenuItem |
+
 	requestor ifNil: [^ self ].
 	prefix  
 		ifNotNil: [ self choiceMenus 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -132,7 +132,7 @@ RubTextEditor >> accept: aKeyboardEvent [
 
 { #category : #'undo-redo private' }
 RubTextEditor >> addDeleteSelectionUndoRecord [
-	| undoText redoText undoRec |
+	| undoText redoText |
 	undoText := self selection.
 	redoText := self nullText.
 	self
@@ -601,7 +601,7 @@ RubTextEditor >> copySelection: aKeyboardEvent [
 RubTextEditor >> correctFrom: start to: stop with: aString [
 	"Make a correction in the model that the user has authorised from somewhere else in the system (such as from the compilier).  
 	The user's selection is not changed, only corrected."
-	| wasShowing userSelection delta loc |
+	| userSelection delta |
 	
 	userSelection := self selectionInterval.
 	self selectInvisiblyFrom: start to: stop.
@@ -1064,7 +1064,7 @@ RubTextEditor >> exchangeWith: prior [
 	 exchanged with a caret).  If both selections are carets, flash & do nothing.
 	 Don't affect the paste buffer.  Undoer: itself; Redoer: Undoer."
 
-	| start stop before currSelection priorSelection delta redoArgs altInterval undoArgs undoRec |
+	| start stop before currSelection priorSelection delta redoArgs altInterval undoArgs |
 	start := self startIndex.
 	stop := self stopIndex - 1.
 	((prior first <= prior last) | (start <= stop) "Something to exchange" and:


### PR DESCRIPTION
Remove unused temps in

ReflectiveMethod>>#recompileAST
RubMethodEditingExample>>#open
RubParagraph>>#selectionRectsFrom:to:
RubSelectorChooserMorph>>#drawCommonPrefixAreasOn:
RubTextEditor>>#addDeleteSelectionUndoRecord
RubTextEditor>>#correctFrom:to:with:
RubTextEditor>>#exchangeWith:
RxMatcher>>#currentState