### PR TITLE
20725 Unused temps in DosTimestampTest, Decompiler, DiskStore, DosTimestampTest, DateTest

### DIFF
--- a/src/Compiler/Decompiler.class.st
+++ b/src/Compiler/Decompiler.class.st
@@ -874,7 +874,7 @@ Decompiler >> statementsTo: end [
 	to the destination of the jump, or the end of the method; otherwise, set
 	exit = end. Leave pc = end."
 
-	| blockPos stackPos t |
+	| blockPos stackPos |
 	blockPos := statements size.
 	stackPos := stack size.
 	[pc < end]

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -385,7 +385,7 @@ DiskStore >> openFileStream: path writable: writable [
 { #category : #public }
 DiskStore >> rename: sourcePath to: destinationPath [
 
-	| sourcePathString encodedSourcePathString targetPathString encodedTargetPathString result |
+	| sourcePathString encodedSourcePathString targetPathString encodedTargetPathString |
 	sourcePathString := self stringFromPath: sourcePath.
 	encodedSourcePathString := Primitives encode: sourcePathString.
 	targetPathString := self stringFromPath: destinationPath.

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -378,7 +378,7 @@ DateTest >> testPreviousByName [
 { #category : #tests }
 DateTest >> testPrintFormat [
 
-	| format monthTypes |
+	| format |
 	format := DatePrintFormatTester on: january23rd2004.
 	format dayPosition: 1 monthPosition: 2 yearPosition: 3 delimiter: $/ monthType: 1 yearType: 1.
 	format shouldEqual: '23/1/2004'.

--- a/src/Kernel-Tests/DosTimestampTest.class.st
+++ b/src/Kernel-Tests/DosTimestampTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #tests }
 DosTimestampTest >> testAsDateAndTime [
 	
-	| remoteDatetime timestamp |
+	| timestamp |
 	timestamp := DosTimestamp on: 16r40B57856.
 	self assert: timestamp asDateAndTime equals: '21 May 2012 3:02:44 pm' asDateAndTime.
 ]
@@ -18,7 +18,7 @@ DosTimestampTest >> testAsDateAndTime [
 { #category : #tests }
 DosTimestampTest >> testFromDateAndTime [
 
-	| aDateAndTime timestamp |
+	| timestamp |
 	timestamp := DosTimestamp fromDateAndTime: '21 May 2012 3:02:44 pm' asDateAndTime.
 	
 	self assert: timestamp value equals: 16r40B57856.


### PR DESCRIPTION
Fix unused temps in

DosTimestampTest>>#testFromDateAndTime
Decompiler>>#statementsTo:
DiskStore>>#rename:to:
DosTimestampTest>>#testAsDateAndTime
DateTest>>#testPrintFormat