### PR TITLE
Avoid costly & useless LargeInteger arithmetics when raisedToFraction will be inexact

### DIFF
--- a/src/Kernel/Fraction.class.st
+++ b/src/Kernel/Fraction.class.st
@@ -316,14 +316,11 @@ Fraction >> negative [
 Fraction >> nthRoot: aPositiveInteger [
 	"Answer the nth root of the receiver."
 
-	| d n |
-	n := numerator nthRoot: aPositiveInteger.
-	d := denominator nthRoot: aPositiveInteger.
-	"The #sqrt method in integer will only answer a Float if there's no exact square root.
-	So, we need a float anyway."
-	(n isInfinite or: [ d isInfinite ]) ifTrue: [
-		^self asFloat nthRoot: aPositiveInteger ].
-	^n / d
+	| guess |
+	guess := (numerator nthRootTruncated: aPositiveInteger) / (denominator nthRootTruncated: aPositiveInteger).
+	(guess raisedTo: aPositiveInteger) = self ifTrue: [^guess].
+	"There is no exact nth root, so answer a Float approximation"
+	^(self abs ln / aPositiveInteger) exp * self sign
 ]
 
 { #category : #private }
@@ -374,6 +371,14 @@ Fraction >> printOn: aStream showingDecimalPlaces: placesDesired [
 			integerPart printOn: aStream.
 			aStream nextPut: $..
 			roundedFractionPart printOn: aStream base: 10 length: placesDesired padded: true].
+]
+
+{ #category : #'mathematical functions' }
+Fraction >> raisedToFraction: aFraction [
+	| root |
+	root := (self numerator nthRootTruncated: aFraction denominator) / (self denominator nthRootTruncated: aFraction denominator).
+	(root raisedToInteger: aFraction denominator) = self ifTrue: [^root raisedToInteger: aFraction numerator].
+	^super raisedToFraction: aFraction
 ]
 
 { #category : #'mathematical functions' }

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1870,6 +1870,14 @@ Integer >> raisedTo: n modulo: m [
 ]
 
 { #category : #'mathematical functions' }
+Integer >> raisedToFraction: aFraction [
+	| root |
+	root := self nthRootTruncated: aFraction denominator.
+	(root raisedToInteger: aFraction denominator) = self ifTrue: [^root raisedToInteger: aFraction numerator].
+	^super raisedToFraction: aFraction
+]
+
+{ #category : #'mathematical functions' }
 Integer >> raisedToInteger: exp modulo: m [
 	(exp = 0) ifTrue: [^ 1].
 	exp even

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -761,16 +761,28 @@ Number >> raisedTo: aNumber [
 		^ self raisedToInteger: aNumber].
 	aNumber isFraction ifTrue: [
 		"Special case for fraction power"
-		^ (self nthRoot: aNumber denominator) raisedToInteger: aNumber numerator ].
+		^ self raisedToFraction: aNumber].
 	self < 0 ifTrue: [
 		^ ArithmeticError signal: 'Negative numbers can''t be raised to float powers.' ].
 	0 = aNumber ifTrue: [^ self class one].	"Special case of exponent=0"
 	1 = aNumber ifTrue: [^ self].	"Special case of exponent=1"
 	0 = self ifTrue: [				"Special case of self = 0"
 		aNumber < 0
-			ifTrue: [^ (ZeroDivide dividend: self) signal]
+			ifTrue: [^ (ZeroDivide dividend: 1) signal]
 			ifFalse: [^ self]].
 	^ (aNumber * self ln) exp		"Otherwise use logarithms"
+]
+
+{ #category : #'mathematical functions' }
+Number >> raisedToFraction: aFraction [
+	self isZero
+		ifTrue:
+			[aFraction negative ifTrue: [^ (ZeroDivide dividend: 1) signal].
+			^self].
+	self negative ifFalse: [^(self ln * aFraction) exp].
+	aFraction denominator even
+		ifTrue: [^ ArithmeticError signal: 'nth root only defined for positive Integer n.'].
+	^(self negated ln * aFraction) exp negated
 ]
 
 { #category : #'mathematical functions' }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -187,6 +187,15 @@ ScaledDecimal >> raisedTo: aNumber [
 ]
 
 { #category : #'mathematical functions' }
+ScaledDecimal >> raisedToFraction: aFraction [
+	| result |
+	result := self asFraction raisedToFraction: aFraction.
+	^result isFloat
+		ifTrue: [result]
+		ifFalse: [result asScaledDecimal: scale]
+]
+
+{ #category : #'mathematical functions' }
 ScaledDecimal >> raisedToInteger: aNumber [
 	^self class newFromNumber: (super raisedToInteger: aNumber) scale: scale
 ]


### PR DESCRIPTION

This example was raised in https://pharo.fogbugz.com/f/cases/20432/vm-crash-when-using-rairedTo-with-fractions
(2009/2000) raisedTo: (3958333/100000)

The fix is importing the changes from http://source.squeak.org/trunk/Kernel-nice.1111.diff