### PR TITLE
20727-WeakAnnouncerTesttestWeakDoubleAnnouncer-should-be-long

### DIFF
--- a/src/Announcements-Tests-Core/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Tests-Core/WeakAnnouncerTest.class.st
@@ -69,7 +69,7 @@ WeakAnnouncerTest >> testNoDeadWeakSubscriptions [
 
 	self longTestCase.
 
-	Smalltalk garbageCollect.
+	5 timesRepeat: [ Smalltalk garbageCollect ].		
 	
 	self assert: (WeakAnnouncementSubscription allSubInstances select: [ :sub | sub subscriber isNil ]) size isZero.
 	
@@ -122,7 +122,7 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 	assert: a1 subscriptions numberOfSubscriptions = 1;
 	assert: a2 subscriptions numberOfSubscriptions = 1.
 	
-	Smalltalk garbageCollect.
+	3 timesRepeat: [ Smalltalk garbageCollect ].
 	
 	self 
 	assert: a1 subscriptions numberOfSubscriptions = 1;
@@ -130,7 +130,7 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 
 	o := nil.
 	
-	Smalltalk garbageCollect.
+	3 timesRepeat: [ Smalltalk garbageCollect ].
 	
 	self 
 	assert: a1 subscriptions numberOfSubscriptions isZero;

--- a/src/Announcements-Tests-Core/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Tests-Core/WeakAnnouncerTest.class.st
@@ -57,10 +57,19 @@ WeakAnnouncerTest >> benchWeakSubscriptionStatic [
 	] timeToRun
 ]
 
+{ #category : #utility }
+WeakAnnouncerTest >> longTestCase [
+
+	self timeLimit: 60 seconds.
+
+]
+
 { #category : #tests }
 WeakAnnouncerTest >> testNoDeadWeakSubscriptions [
 
-	5 timesRepeat: [ Smalltalk garbageCollect ].
+	self longTestCase.
+
+	Smalltalk garbageCollect.
 	
 	self assert: (WeakAnnouncementSubscription allSubInstances select: [ :sub | sub subscriber isNil ]) size isZero.
 	
@@ -74,6 +83,9 @@ WeakAnnouncerTest >> testNoWeakBlock [
 	<expectedFailure>
 
 	| counter |
+
+	self longTestCase.
+
 	counter := 0.
 
 	(announcer subscribe: AnnouncementMockA do: [ :ann | counter := counter + 1 ]) makeWeak.
@@ -92,6 +104,8 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 
 	| a1 a2 o |
 	
+	self longTestCase.
+
 	a1 := Announcer new.
 	a2 := Announcer new.
 	
@@ -108,7 +122,7 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 	assert: a1 subscriptions numberOfSubscriptions = 1;
 	assert: a2 subscriptions numberOfSubscriptions = 1.
 	
-	3 timesRepeat: [ Smalltalk garbageCollect ].
+	Smalltalk garbageCollect.
 	
 	self 
 	assert: a1 subscriptions numberOfSubscriptions = 1;
@@ -116,7 +130,7 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 
 	o := nil.
 	
-	3 timesRepeat: [ Smalltalk garbageCollect ].
+	Smalltalk garbageCollect.
 	
 	self 
 	assert: a1 subscriptions numberOfSubscriptions isZero;
@@ -126,6 +140,9 @@ WeakAnnouncerTest >> testWeakDoubleAnnouncer [
 { #category : #tests }
 WeakAnnouncerTest >> testWeakObject [
 	| counter collector forwarder |
+
+	self longTestCase.
+
 	counter := 0.
 	collector := [ counter := counter + 1 ].
 	forwarder := MessageSend receiver: collector selector: #value.
@@ -146,6 +163,8 @@ WeakAnnouncerTest >> testWeakObject [
 { #category : #tests }
 WeakAnnouncerTest >> testWeakSubscription [
 	| obj  subscription |
+
+	self longTestCase.
 	
 	obj := Object new.
 	


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20727/WeakAnnouncerTest-testWeakDoubleAnnouncer-should-be-longincrese timeouts and 	decrease amount of explicit GC calls