### PR TITLE
20730 Unused temps in FileReferenceTest, FLHeaderSerializationTest, FLHookedSubstitutionTest, FT2GlyphRenderer, ...

### DIFF
--- a/src/Athens-Balloon/FT2GlyphRenderer.class.st
+++ b/src/Athens-Balloon/FT2GlyphRenderer.class.st
@@ -97,7 +97,7 @@ FT2GlyphRenderer >> loadSlotInfo [
 
 { #category : #private }
 FT2GlyphRenderer >> loadSurfaceTransform [
-	| m mt org xaxis yaxis sum xmin xmax ymin ymax formW formH fix face bbox |
+	| m org xaxis yaxis sum xmin xmax ymin ymax formW formH fix face bbox |
 	
 	face := font face.
 
@@ -157,7 +157,7 @@ FT2GlyphRenderer >> loadSurfaceTransform [
 { #category : #private }
 FT2GlyphRenderer >> loadUnicode: unicode [
 
-	| ext hintingFlags flags arr face |
+	| flags face |
 	
 	face := font face.
 

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -324,7 +324,7 @@ FileReferenceTest >> testDeleteAll [
 	"allChildren returns all the files and folders recursively nested in a reference"
 	<publicTest>
 	"self debug: #testDeleteAll"
-	| ref children |
+	| ref |
 	filesystem createDirectory: '/alpha'.
 	filesystem createDirectory: '/alpha/beta'.
 	filesystem createDirectory: '/alpha/beta/delta'.
@@ -344,7 +344,7 @@ FileReferenceTest >> testDeleteAllChildren [
 	"allChildren returns all the files and folders recursively nested in a reference"
 	<publicTest>
 	"self debug: #testDeleteAllChildren"
-	| ref children |
+	| ref |
 	filesystem createDirectory: '/alpha'.
 	filesystem createDirectory: '/alpha/beta'.
 	filesystem createDirectory: '/alpha/beta/delta'.
@@ -532,7 +532,7 @@ FileReferenceTest >> testGrandchildOfReference [
 FileReferenceTest >> testHasChildren [
 	<publicTest>
 	"self debug: #testHasChildren"
-	| ref children |
+	| ref |
 	filesystem createDirectory: '/alpha'.
 	filesystem createDirectory: '/alpha/beta'.
 	filesystem createDirectory: '/alpha/beta/delta'.
@@ -550,7 +550,7 @@ FileReferenceTest >> testHasChildren [
 FileReferenceTest >> testHasDirectories [
 	<publicTest>
 	"self debug: #testHasDirectories"
-	| ref children |
+	| ref |
 	filesystem createDirectory: '/alpha'.
 	filesystem createDirectory: '/alpha/beta'.
 	
@@ -568,7 +568,7 @@ FileReferenceTest >> testHasDirectories [
 FileReferenceTest >> testHasFiles [
 	<publicTest>
 	"self debug: #testHasFiles"
-	| ref children |
+	| ref |
 	filesystem createDirectory: '/alpha'.
 	filesystem createDirectory: '/alpha/beta'.
 	(filesystem / 'alpha' / 'beta' / 'delta') ensureCreateFile.
@@ -828,7 +828,7 @@ FileReferenceTest >> testRelativeToReference [
 { #category : #tests }
 FileReferenceTest >> testRename [
 
-	| file newName tmp originalPwd originalFullName |
+	| file tmp originalPwd originalFullName |
 	[
 		file := (FileLocator imageDirectory / 'oldName') ensureCreateFile.
 		originalFullName := file fullName.

--- a/src/FuelTests/FLHeaderSerializationTest.class.st
+++ b/src/FuelTests/FLHeaderSerializationTest.class.st
@@ -10,7 +10,6 @@ Class {
 { #category : #tests }
 FLHeaderSerializationTest >> testAdditionalObjects [
 
-	| materialization |
 	self serializer at: #test putAdditionalObject: 'test'.
 	self serializer at: 42 putAdditionalObject: 68.
 	

--- a/src/FuelTests/FLHookedSubstitutionTest.class.st
+++ b/src/FuelTests/FLHookedSubstitutionTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #tests }
 FLHookedSubstitutionTest >> testAvoidRecursion [
 
-	| aClass result original | 
+	| result original | 
 	original := FLClassWithRecursiveSubstitution new index: 1.
 	
 	result := self resultOfSerializeAndMaterialize: original.

--- a/src/Tool-FileList-Tests/FileDialogWindowTest.class.st
+++ b/src/Tool-FileList-Tests/FileDialogWindowTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 FileDialogWindowTest >> testIssue6406 [
 
-	| aFolder dialog file invalidFolder |
+	| aFolder dialog invalidFolder |
 	aFolder := (FileSystem workingDirectory / 'folder') ensureCreateDirectory.
 	[ 
 	"Absolute folder paths work"


### PR DESCRIPTION
Fix unused temps in

FileReferenceTest>>#testRename
FileReferenceTest>>#testDeleteAllChildren
FileReferenceTest>>#testHasChildren
FileReferenceTest>>#testHasDirectories
FileReferenceTest>>#testHasFiles
FLHeaderSerializationTest>>#testAdditionalObjects
FLHookedSubstitutionTest>>#testAvoidRecursion
FT2GlyphRenderer>>#loadSurfaceTransform
FT2GlyphRenderer>>#loadUnicode:
FileDialogWindowTest>>#testIssue6406
FileReferenceTest>>#testDeleteAll