### PR TITLE
20731 Unused temps in HDCoverageReport and HDLintReport

### DIFF
--- a/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
+++ b/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
@@ -85,7 +85,7 @@ HDCoverageReport >> generatePackage: aPackage class: aClass on: aStream [
 
 { #category : #generating }
 HDCoverageReport >> generatePackage: aPackage method: aReference on: aStream [
-	| items |
+ 
 	aStream tab: 5; nextPutAll: '<method name="'; nextPutAll: (self encode: aReference selector); nextPutAll: '">'; nextPut: Character lf.
 	self
 		generateType: 'method' indent: 6

--- a/src/JenkinsTools-ExtraReports/HDLintReport.class.st
+++ b/src/JenkinsTools-ExtraReports/HDLintReport.class.st
@@ -66,7 +66,7 @@ HDLintReport >> generateClass: aClass selector: aSelector source: sourceStream o
 
 { #category : #generating }
 HDLintReport >> generateClass: aClass source: sourceStream on: aStream [
-	| offset source matching selectors |
+	| offset source matching |
 	offset := self
 		lineAndColumn: sourceStream contents
 		at: sourceStream position.


### PR DESCRIPTION
fix unused temps

HDCoverageReport>>#generatePackage:method:on:
HDLintReport>>#generateClass:source:on:


https://pharo.fogbugz.com/f/cases/20731/Unused-temps-in-HDCoverageReport-and-HDLintReport