### PR TITLE
20732 Unused temps in HistoryNodeTest

### DIFF
--- a/src/System-History-Tests/HistoryNodeTest.class.st
+++ b/src/System-History-Tests/HistoryNodeTest.class.st
@@ -89,7 +89,7 @@ HistoryNodeTest >> testReset [
 
 { #category : #tests }
 HistoryNodeTest >> testTwoConsecutiveCloseGroup [
-	| h i grp1 grp2  i2 i3 i4 | 
+	| h i grp1 grp2 i3 | 
 	h := HistoryNode new.
 	h addItem: (i := HistoryLeaf new).
 	self assert: h size = 1.
@@ -116,7 +116,7 @@ HistoryNodeTest >> testTwoConsecutiveCloseGroup [
 
 { #category : #tests }
 HistoryNodeTest >> testTwoGroups [
-	| h i grp1 grp2  i2 i3 i4 | 
+	| h i grp1 grp2  i2 i3 | 
 	h := HistoryNode new.
 	h addItem: (i := HistoryLeaf new).
 	self assert: h size = 1.


### PR DESCRIPTION
fix unused temps

HistoryNodeTest>>#testTwoConsecutiveCloseGroup
HistoryNodeTest>>#testTwoGroups

https://pharo.fogbugz.com/f/cases/20732/Unused-temps-in-HistoryNodeTest