### PR TITLE
20729-Monticello-history-browser-should-enable-diffing-with-parent

### DIFF
--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -165,8 +165,12 @@ MCTool >> defaultAnnotationPaneHeight [
 { #category : #'morphic ui' }
 MCTool >> fillMenu: aMenu fromSpecs: anArray [
 	anArray do:
-		[:pair |
-		aMenu add: pair first target: self selector: pair second].
+		[:spec |
+		aMenu
+			add: spec first
+			target: self
+			selector: spec second
+			argumentList: (spec allButFirst: 2)].
 	^ aMenu
 ]
 

--- a/src/MonticelloGUI/MCVersionHistoryBrowser.class.st
+++ b/src/MonticelloGUI/MCVersionHistoryBrowser.class.st
@@ -30,11 +30,13 @@ MCVersionHistoryBrowser >> defaultLabel [
 
 { #category : #'morphic ui' }
 MCVersionHistoryBrowser >> getMenu: aMenu [
-	index < 2 ifTrue: [^ aMenu].
+	index < 1 ifTrue: [^ aMenu].
 	self fillMenu: aMenu fromSpecs: 
-		(Array
-			with: (Array with: 'view changes -> ', ancestry name with: #viewChanges)
-			with: #('spawn history' spawnHistory)).
+		(Array streamContents: [ :stream |
+			index > 1 ifTrue: [ stream nextPut: (Array with: 'view changes -> ', ancestry name with: #viewChanges) ].
+			self selectedInfo ancestors do: [:parent |
+				stream nextPut: {'view changes <- ', parent name . #viewChanges: . parent}].
+			stream nextPut: #('spawn history' spawnHistory)]).
 	^ aMenu
 ]
 

--- a/src/Tool-Diff/MCVersionHistoryBrowser.extension.st
+++ b/src/Tool-Diff/MCVersionHistoryBrowser.extension.st
@@ -11,6 +11,16 @@ MCVersionHistoryBrowser >> viewChanges [
 ]
 
 { #category : #'*Tool-Diff' }
+MCVersionHistoryBrowser >> viewChanges: otherInfo [
+	"View the changes between a prior version and this version."
+	
+	self
+		viewChanges: (self selectedSnapshot patchRelativeToBase: (self snapshotForInfo: otherInfo))
+		from: otherInfo name
+		to: self selectedInfo name
+]
+
+{ #category : #'*Tool-Diff' }
 MCVersionHistoryBrowser >> viewChanges: patch from: fromDescription to: toDescription [
 	"Open a browser on the patch."
 	


### PR DESCRIPTION
This is issue https://pharo.fogbugz.com/f/cases/20729/Monticello-history-browser-should-enable-diffing-with-parent
Such option is really handy when cherry picking changes from other branches
Pick the implementation from Squeak (fbs, eem) and adapt to Pharo