### PR TITLE
15473-Float-round-to-n-decimal-places-is-not-in-agreement-with-printShowingDecimalPlaces

### DIFF
--- a/src/Kernel-Tests/FractionTest.class.st
+++ b/src/Kernel-Tests/FractionTest.class.st
@@ -451,7 +451,7 @@ FractionTest >> testRounding [
         self debug: #testRounding
         "
 
-        self assert: ((6/90) round: 2) equals: 0.07
+        self assert: ((6/90) round: 2) equals: 7/100
 ]
 
 { #category : #'tests - mathematical functions' }

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -1344,11 +1344,9 @@ Float >> reduce [
 { #category : #'truncation and round off' }
 Float >> round: numberOfWishedDecimal [
 	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal"
-   < expr: 10.12345 round: 2 result: 10.12 >
+   "10.12345 round: 2 >>> 10.12 "
         
-	| v |
-	v := 10 raisedTo: numberOfWishedDecimal.
-	^ ((self * v) rounded / v) asFloat
+	^(self asFraction round: numberOfWishedDecimal) asFloat
 
 ]
 

--- a/src/Kernel/Fraction.class.st
+++ b/src/Kernel/Fraction.class.st
@@ -412,10 +412,10 @@ Fraction >> reduced [
 { #category : #'truncation and round off' }
 Fraction >> round: numberOfWishedDecimal [
 	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal"
-   < expr: '(1/3 round: 2)' result: 0.33 >      
-	< expr: '(111/100 round: 2)' result: 1.11 > 
+   "(1/3 round: 2) >>> (33/100) "   
+	"(111/100 round: 2) >>> (111/100) "
 	
-	^self asFloat round: numberOfWishedDecimal
+	^self roundTo: (10 raisedTo: numberOfWishedDecimal negated)
 ]
 
 { #category : #private }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -205,6 +205,16 @@ ScaledDecimal >> reciprocal [
 	^self class newFromNumber: super reciprocal scale: scale
 ]
 
+{ #category : #'truncation and round off' }
+ScaledDecimal >> round: numberOfWishedDecimal [
+	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal."
+	
+   "10.156s round: 2 >>> 10.160s3 "
+   "1/3.0s round: 4 >>> 0.3333s4 "
+
+	^(super round: numberOfWishedDecimal) asScaledDecimal: (scale max: numberOfWishedDecimal)
+]
+
 { #category : #accessing }
 ScaledDecimal >> scale [
 	^scale


### PR DESCRIPTION
This is issue:
https://pharo.fogbugz.com/f/cases/15473/Float-round-to-n-decimal-places-is-not-in-agreement-with-printShowingDecimalPlaces

It also fixes:
https://pharo.fogbugz.com/f/cases/15472/Fraction-rounding-to-n-decimal-places-is-inexact
https://pharo.fogbugz.com/f/cases/15471/Can-t-round-Float-fmax-to-2-decimal-places

Note: the new implementation does round exact tie away from zero exactly like #round do.
It is also in agreement with printShowingDecimalPlaces:

If you wish to roundToNearestTieToEven, then please open a new issue
(but it will be better to also modify printShowingDecimalPlaces: then)

The new implementation is a bit slower but it is correct.

It was proposed to deprecate round: in

I’m not so sure - round: can be useful for monetary apps and is available in other languages (Python, etc…)
banker rounding (tie to even) might be a better option though.

Last, I’ve replaced the `< expr: foo result: bar>` annotation with `“ foo >>> bar “`
The reason is that the expr:result: form only works for a literal result which is SEVERLY limited.