### PR TITLE
Fix the sign of FloatNegativeZero

### DIFF
--- a/src/Kernel-Tests/FloatTest.class.st
+++ b/src/Kernel-Tests/FloatTest.class.st
@@ -578,7 +578,7 @@ FloatTest >> testFractionAsFloatWithUnderflow [
 	underflowPower := Float emin - Float precision.
 	self assert: (2 raisedTo: underflowPower) asFloat = 0.0.	
 	self assert: (2 raisedTo: underflowPower) negated asFloat = 0.0.
-	self assert: (2 raisedTo: underflowPower) negated asFloat sign = -1 description: 'a negative underflow should return a negative zero'.
+	self assert: (2 raisedTo: underflowPower) negated asFloat signBit = 1 description: 'a negative underflow should return a negative zero'.
 ]
 
 { #category : #tests }
@@ -813,7 +813,8 @@ FloatTest >> testNegativeZeroAbs [
 
 { #category : #'tests - zero behavior' }
 FloatTest >> testNegativeZeroSign [
-	self assert: Float negativeZero sign = -1
+	self assert: Float negativeZero sign = 0. "Like any other zero, a negative zero has its sign being zero"
+	self assert: Float negativeZero signBit = 1 "But it can be distinguished with its signBit"
 ]
 
 { #category : #'tests - printing' }
@@ -926,7 +927,7 @@ FloatTest >> testSign [
 
       "The sign of zeros"
       self assert: zero sign = 0.
-      self assert: negz sign = -1. "remark though that negz >= 0.0, and is thus considered positive... Weird"
+      self assert: negz sign = 0.
 
       "Test the copy sign functions"
       positives do: [:aPositiveSign |
@@ -935,15 +936,19 @@ FloatTest >> testSign [
               negatives do: [:aNegative |
                       self assert: (aNegative sign: aPositiveSign) = aNegative negated].
               (zero sign: aPositiveSign) sign = 0.
-              (negz sign: aPositiveSign) sign = 0].
+              (negz sign: aPositiveSign) sign = 0.
+              (zero sign: aPositiveSign) signBit = 0.
+              (negz sign: aPositiveSign) signBit = 0].
 
       negatives do: [:aNegativeSign |
               positives do: [:aPositive |
                       self assert: (aPositive sign: aNegativeSign) = aPositive negated].
               negatives do: [:aNegative |
                       self assert: (aNegative sign: aNegativeSign) = aNegative].
-              (zero sign: aNegativeSign) sign = -1.
-              (negz sign: aNegativeSign) sign = -1].
+              (zero sign: aNegativeSign) sign = 0.
+              (negz sign: aNegativeSign) sign = 0.
+              (zero sign: aNegativeSign) signBit = 1.
+              (negz sign: aNegativeSign) signBit = 1].
 ]
 
 { #category : #'tests - printing' }

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -634,9 +634,9 @@ Float >> arcTan: denominator [
 	Implementation note: use sign in order to catch cases of negativeZero"
 
 	^self = 0.0
-		ifTrue: [denominator sign >= 0
+		ifTrue: [denominator signBit = 0
 			ifTrue: [ 0 ]
-			ifFalse: [ self sign >= 0
+			ifFalse: [ self signBit = 0
 				ifTrue: [ Pi ]
 				ifFalse: [ Pi negated ]]]
 		ifFalse: [denominator = 0.0
@@ -1003,15 +1003,6 @@ Float >> closeTo: num precision: aPrecision [
 ]
 
 { #category : #'mathematical functions' }
-Float >> copySignTo: aNumber [
-	"Return a number with same magnitude as aNumber and same sign as self.
-	Implementation note: take care of Float negativeZero, which is considered as having a negative sign."
-
-	(self > 0.0 or: [(self at: 1) = 0]) ifTrue: [^ aNumber abs].
-	^aNumber withNegativeSign
-]
-
-{ #category : #'mathematical functions' }
 Float >> cos [
 	"Answer the cosine of the receiver taken as an angle in radians."
 
@@ -1145,7 +1136,7 @@ Float >> isZero [
 { #category : #comparing }
 Float >> literalEqual: other [
 
-	^ (super literalEqual: other) and: [ self isZero not or: [ self sign = other sign ] ]
+	^ (super literalEqual: other) and: [ self isZero not or: [ self signBit = other signBit ] ]
 ]
 
 { #category : #'mathematical functions' }
@@ -1249,7 +1240,7 @@ Float >> printOn: stream base: base [
 	self > 0.0
 		ifTrue: [ FloatPrintPolicy absPrint: self on: stream base: base ]
 		ifFalse: [
-			self sign = -1 ifTrue: [ stream nextPut: $- ].
+			self signBit = 1 ifTrue: [ stream nextPut: $- ].
 			self = 0.0
 				ifTrue: [ stream nextPutAll: '0.0' ]
 				ifFalse: [ FloatPrintPolicy absPrint: self negated on: stream base: base ] ]
@@ -1379,13 +1370,11 @@ Float >> shallowCopy [
 ]
 
 { #category : #'mathematical functions' }
-Float >> sign [
-	"Answer 1 if the receiver is greater than 0, -1 if less than 0, else 0.
-	Handle IEEE-754 negative-zero by reporting a sign of -1"
+Float >> signBit [
+	"Answer 1 if the receiver has sign bit set (including case of IEEE-754 negative-zero).
+	Answer 0 otherwise"
 
-	self > 0 ifTrue: [^ 1].
-	(self < 0 or: [((self at: 1) bitShift: -31) = 1]) ifTrue: [^ -1].
-	^ 0
+	^((self at: 1) bitShift: -31)
 ]
 
 { #category : #'truncation and round off' }
@@ -1415,7 +1404,7 @@ Float >> storeOn: aStream [
 Float >> storeOn: aStream base: base [ 
 	"Print the Number exactly so it can be interpreted back unchanged"
 	self isFinite
-		ifTrue: [self sign = -1 ifTrue: [aStream nextPutAll: '-'].
+		ifTrue: [self signBit = 1 ifTrue: [aStream nextPutAll: '-'].
 			base = 10 ifFalse: [aStream print: base; nextPut: $r].
 			self = 0.0
 				ifTrue: [aStream nextPutAll: '0.0']
@@ -1467,12 +1456,4 @@ Float >> veryDeepCopyWith: deepCopier [
 	"Return self.  Do not record me."
 
 	^ self shallowCopy
-]
-
-{ #category : #converting }
-Float >> withNegativeSign [
-	"Same as super, but handle the subtle case of Float negativeZero"
-	
-	self = 0.0 ifTrue: [^self class negativeZero].  
-	^super withNegativeSign
 ]

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1713,7 +1713,7 @@ Integer >> printSeparatedBy: aDelimiter every: offset signed: printSigned base: 
 	| digits |
 	digits := self abs printStringBase: base.
 	
-	self sign = -1 
+	self signBit = 1 
 		ifTrue: [ aStream nextPut: $- ] 
 		ifFalse: [ printSigned ifTrue: [ aStream nextPut: $+ ] ].
 	

--- a/src/Kernel/LargeNegativeInteger.class.st
+++ b/src/Kernel/LargeNegativeInteger.class.st
@@ -148,6 +148,14 @@ LargeNegativeInteger >> sign [
 
 ]
 
+{ #category : #testing }
+LargeNegativeInteger >> signBit [
+	"Optimization."
+
+	^1
+
+]
+
 { #category : #'mathematical functions' }
 LargeNegativeInteger >> sqrt [
 	"Answer the square root of the receiver."

--- a/src/Kernel/LargePositiveInteger.class.st
+++ b/src/Kernel/LargePositiveInteger.class.st
@@ -188,6 +188,13 @@ LargePositiveInteger >> sign [
 
 ]
 
+{ #category : #testing }
+LargePositiveInteger >> signBit [
+	"Optimization."
+
+	^0
+]
+
 { #category : #'mathematical functions' }
 LargePositiveInteger >> sqrt [
 	"If we know for sure no exact solution exists, then just answer the cheap float approximation without wasting time."

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -411,9 +411,9 @@ Number >> closeTo: num precision: aPrecision [
 Number >> copySignTo: aNumber [
 	"Return a number with same magnitude as aNumber and same sign as self."
 
-	^ self positive
+	^ self signBit = 0
 		ifTrue: [aNumber abs]
-		ifFalse: [aNumber withNegativeSign].
+		ifFalse: [aNumber abs negated].
 ]
 
 { #category : #'mathematical functions' }
@@ -896,7 +896,7 @@ Number >> sign [
 
 	self > 0 ifTrue: [^1].
 	self < 0 ifTrue: [^-1].
-	^0
+	^self
 ]
 
 { #category : #'mathematical functions' }
@@ -904,6 +904,14 @@ Number >> sign: aNumber [
  	"Return a Number with the same sign as aNumber"
  
  	^ aNumber copySignTo: self.
+]
+
+{ #category : #'mathematical functions' }
+Number >> signBit [
+	"Answer 1 if the receiver is negative, zero otherwise."
+
+	self < 0 ifTrue: [^1].
+	^0
 ]
 
 { #category : #'mathematical functions' }
@@ -1043,12 +1051,6 @@ Number >> week [
 Number >> weeks [
  
  	^ Duration weeks: self
-]
-
-{ #category : #converting }
-Number >> withNegativeSign [
-	"Answer a number with same magnitude than receiver and negative sign."
-	^self abs negated
 ]
 
 { #category : #'*Kernel-Chronology' }


### PR DESCRIPTION
Like any other zero, the sign of Float negativeZero should be zero…
Introduce signBit to differentiate Float negativeZero from Float zero.

This is issue https://pharo.fogbugz.com/f/cases/19629/0-0-sign-answers-1-should-be-zero

Note that this PR does not implement isSignMinus which is not strictly necessary.
If it’s for ISO 10967 compliance, then there will be other functions missing.
Maybe open a new issue for this one?