### PR TITLE
20735-ComposablePresenter-classowneron-is-missing-the-initialization-call

### DIFF
--- a/src/Spec-Core/ComposablePresenter.class.st
+++ b/src/Spec-Core/ComposablePresenter.class.st
@@ -158,6 +158,7 @@ ComposablePresenter class >> owner: anOwningPresenter on: aDomainObject [
 	^ self basicNew
 		owner: anOwningPresenter;
 		setModelBeforeInitialization: aDomainObject;
+		initialize;
 		yourself
 ]
 


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20735/ComposablePresenter-class-owner-on-is-missing-the-initialization-call