### PR TITLE
20742 Unused temps in Morph, MalSccNodeDecomposition and MethodNode

### DIFF
--- a/src/Compiler/MethodNode.class.st
+++ b/src/Compiler/MethodNode.class.st
@@ -216,8 +216,6 @@ MethodNode >> generate: trailer using: aCompiledMethodClass ifQuick: methodBlock
 MethodNode >> generateWithSource [
 	"Answer a CompiledMethod with source encoded in trailer."
 	
-	| source |
-	
 	"for doits, we need to store the source pretty printed from the 
 	AST to get the return and methodName correct"
 	self selector isDoIt ifTrue: [sourceText := self printString].

--- a/src/Glamour-Morphic-Widgets/Morph.extension.st
+++ b/src/Glamour-Morphic-Widgets/Morph.extension.st
@@ -24,7 +24,6 @@ Morph >> glamourOptimalExtent [
 { #category : #'*glamour-morphic-widgets' }
 Morph >> returnToOldResizingStrategy: aCollection [
 
-	|tmpSubmorphResizing|
 	self submorphs with: aCollection third do: [:aMorph :resizingParameter |
 		aMorph returnToOldResizingStrategy: resizingParameter.
 		].

--- a/src/Moose-Algos-Graph/MalSccNodeDecomposition.class.st
+++ b/src/Moose-Algos-Graph/MalSccNodeDecomposition.class.st
@@ -15,7 +15,7 @@ MalSccNodeDecomposition >> nodeClass [
 { #category : #running }
 MalSccNodeDecomposition >> retrieveCircuit: aNode [
 
-	|c n i|
+	|c i|
 	c := OrderedCollection new.
 	i := aNode.
 	[ i notNil ] whileTrue: [


### PR DESCRIPTION
Fix unused temps in

Morph>>#returnToOldResizingStrategy:
MethodNode>>#generateWithSource
MalSccNodeDecomposition>>#retrieveCircuit:

https://pharo.fogbugz.com/f/cases/20742/Unused-temps-in-Morph-MalSccNodeDecomposition-and-MethodNode