### PR TITLE
20743 Unused temps in Versionner classes starting with MB

### DIFF
--- a/src/Versionner-Core-Commands/MBCopyBaselineCommand.class.st
+++ b/src/Versionner-Core-Commands/MBCopyBaselineCommand.class.st
@@ -11,7 +11,7 @@ Class {
 MBCopyBaselineCommand >> copyBaselineWithNumber: baselineNumberAsString [
 	"Copy myself into a new baseline, with a different number"
 
-	| sourceCode newSource newNumber newSelector comment |
+	| comment |
 	self 
 		assert: [ baselineNumberAsString ~= target versionString ] 
 		description: 'Cannot assign the same baseline number than me to my copy'.

--- a/src/Versionner-Core-Commands/MBLoadConfigurationCommand.class.st
+++ b/src/Versionner-Core-Commands/MBLoadConfigurationCommand.class.st
@@ -19,7 +19,7 @@ MBLoadConfigurationCommand >> documentation [
 
 { #category : #execute }
 MBLoadConfigurationCommand >> execute [
-	| projectRepository configRef configurationInfo versionInfos versionInfo version configRefMap configNames configName |
+	| projectRepository configRef configRefMap configNames configName |
 	projectRepository := self askForProjectName.
 	projectRepository ifNil: [ ^ self ].
 	configRefMap := self configurationReferencesFrom: projectRepository.

--- a/src/Versionner-Core-Model/MBConfigurationRoot.class.st
+++ b/src/Versionner-Core-Model/MBConfigurationRoot.class.st
@@ -66,7 +66,7 @@ MBConfigurationRoot >> announcer [
 MBConfigurationRoot >> categoryModified: anEvent [
 	"(anEvent itemClass name asString beginsWith: 'ConfigurationOf')
 		ifTrue: [  self respondToEventFor: anEvent itemClass withOperation: #modified ]"
-	| configName configClass configInfo |
+ 
 	self flag: 'update only needed configurations'.
 	"configName := 'ConfigurationOf' , (anEvent item).
 	configClass := Smalltalk at: (configName asSymbol).

--- a/src/Versionner-Core-Model/MBProjectInfo.class.st
+++ b/src/Versionner-Core-Model/MBProjectInfo.class.st
@@ -18,7 +18,7 @@ MBProjectInfo class >> helpLabel [
 
 { #category : #converting }
 MBProjectInfo >> buildStringOrText [
-	| string cv projectClass info attributes specVersion |
+	| string cv projectClass attributes specVersion |
 	string := super buildStringOrText.
 	attributes := OrderedCollection new.
 	self isDirty
@@ -92,7 +92,7 @@ MBProjectInfo >> interestedInConfigurationInfo: configInfo [
 
 { #category : #testing }
 MBProjectInfo >> interestedInPackageNamed: aString [
-	| projectClass version info |
+	| projectClass info |
 	(projectClass := self spec projectClass) == nil
 		ifTrue: [ ^ false ].
 	(aString beginsWith: projectClass name asString)

--- a/src/Versionner-Tests-Core-Model/MBConfigurationRootTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBConfigurationRootTest.class.st
@@ -200,7 +200,7 @@ MBConfigurationRootTest >> test0030BasicVersionLoad [
 		- load version 1.0
 		- check that that expected changes to the data structures occur ... in this case that the package is loaded"
 	
-	| configClass configClassName configInfo versions versionInfo packages packageInfo text x |
+	| configClass configClassName configInfo versions versionInfo packages packageInfo text |
 	gofer version: 'ConfigurationOfMBFooTests-dkh.1'.
 	gofer load.
 	configClassName := #ConfigurationOfMBFooTests.
@@ -612,7 +612,7 @@ MBConfigurationRootTest >> test0081BasicVersionLoad [
 		- validate package and configInfo state
 		- edit class
 		- validate #recalculate variant for currentVersion"
-	| configClass configClassName configInfo expected infos|
+	| configClass configClassName configInfo |
 	gofer version: 'ConfigurationOfMBFooTests-dkh.3'.
 	gofer load.
 	configClassName := #ConfigurationOfMBFooTests.
@@ -797,7 +797,7 @@ MBConfigurationRootTest >> test0091PackageMismatch [
 		- load MBFooTests-dkh.4
 		- validate package printString
 	"
-	| configClass configClassName configInfo expected infos revertGofer |
+	| configClass configClassName configInfo expected infos |
 	gofer version: 'ConfigurationOfMBFooTests-dkh.3'.
 	gofer load.
 	configClassName := #ConfigurationOfMBFooTests.
@@ -978,7 +978,7 @@ MBConfigurationRootTest >> test0120ConfigPackageSave [
 		- load version 1.2
 		- modify configuration and validate
 		- save configuration package and validate"
-	| configClass configClassName configInfo expected infos suggestedName signature |
+	| configClass configClassName configInfo suggestedName signature |
 	"load configuration dkh.3"
 	gofer version: 'ConfigurationOfMBFooTests-dkh.3'.
 	gofer load.

--- a/src/Versionner-Tests-Resources/MBMonticelloPackagesResource.class.st
+++ b/src/Versionner-Tests-Resources/MBMonticelloPackagesResource.class.st
@@ -80,7 +80,7 @@ MBMonticelloPackagesResource >> monticelloRepository [
 MBMonticelloPackagesResource >> project [
 	"self reset"
 
-	| constructor project |
+	| project |
 	"Construct Metacello project"
 	project := MetacelloMCProject new.
 	"Allow for customization of #projectAttributes"


### PR DESCRIPTION
Remove unused temp vars

MBMonticelloPackagesResource>>#project
MBConfigurationRootTest>>#test0030BasicVersionLoad
MBConfigurationRootTest>>#test0081BasicVersionLoad
MBConfigurationRootTest>>#test0091PackageMismatch
MBConfigurationRootTest>>#test0120ConfigPackageSave
MBConfigurationRoot>>#categoryModified:
MBConfigurationInfo>>#buildStringOrText
MBPackageInfo>>#versions
MBProjectInfo>>#buildStringOrText
MBProjectInfo>>#interestedInPackageNamed:
MBLoadConfigurationCommand>>#execute
MBCopyBaselineCommand>>#copyBaselineWithNumber:

https://pharo.fogbugz.com/f/cases/20743/Unused-temps-in-Versionner-classes-starting-with-MB