### PR TITLE
20746-error-handing-is-a-spelling-mistake

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -480,7 +480,7 @@ BlockClosure >> numArgs [
 	^numArgs
 ]
 
-{ #category : #'error handing' }
+{ #category : #'error handling' }
 BlockClosure >> numArgsError: numArgsForInvocation [
 
 	| printNArgs |

--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -16,7 +16,7 @@ Class {
 	#category : #'OSWindow-SDL2-Bindings'
 }
 
-{ #category : #'error handing' }
+{ #category : #'error handling' }
 SDL2 class >> checkForError [
 	| msg |
 	msg := self getErrorMessage.
@@ -122,7 +122,7 @@ SDL2 class >> gameControllerOpen: deviceIndex [
 	^ self nbCall: #( SDL_GameController SDL_GameControllerOpen ( int deviceIndex ) )
 ]
 
-{ #category : #'error handing' }
+{ #category : #'error handling' }
 SDL2 class >> getErrorMessage [
 	<primitive: #primitiveNativeCall module: #NativeBoostPlugin error: errorCode>
 	^ self nbCall: #( String SDL_GetError ( void ) )

--- a/src/Renraku/RePassExceptionStrategy.class.st
+++ b/src/Renraku/RePassExceptionStrategy.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Renraku-Utility'
 }
 
-{ #category : #'error handing' }
+{ #category : #'error handling' }
 RePassExceptionStrategy class >> handle: anException about: anEntity forProppertiesDo: aBlock [
 
 	anException pass

--- a/src/UIManager/DummyUIManager.class.st
+++ b/src/UIManager/DummyUIManager.class.st
@@ -70,7 +70,7 @@ DummyUIManager >> fontFromUser: priorFont [
 	self error: 'No user response possible'
 ]
 
-{ #category : #'error handing' }
+{ #category : #'error handling' }
 DummyUIManager >> handleError: anError log: shouldLog [
 
 	"NOOP"


### PR DESCRIPTION
Corrects the spelling mistake in the protocol name 'error handling'