### PR TITLE
20061-TBehaviorhasAbstractMethods-implementation-is-wrong

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -988,9 +988,9 @@ Behavior >> handleFailingFailingBasicNew: sizeRequested [
 
 { #category : #testing }
 Behavior >> hasAbstractMethods [
-	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+	"Tells whether the receiver defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	^ (self allMethods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/Traits/TBehavior.trait.st
+++ b/src/Traits/TBehavior.trait.st
@@ -746,9 +746,9 @@ TBehavior >> flushCache [
 
 { #category : #testing }
 TBehavior >> hasAbstractMethods [
-	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+	"Tells whether the receiver defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	^ (self allMethods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/Traits/TraitBehavior.class.st
+++ b/src/Traits/TraitBehavior.class.st
@@ -754,9 +754,9 @@ TraitBehavior >> flushCache [
 
 { #category : #testing }
 TraitBehavior >> hasAbstractMethods [
-	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+	"Tells whether the receiver defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	^ (self allMethods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
 ]
 
 { #category : #'testing method dictionary' }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20061hasAbstractMethods checks all class methods, not only the local ones