### PR TITLE
20741-SessionManagersnapshotandQuit-should-do-nothing-when-the-two-parameters-are-false-and-false

### DIFF
--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -497,7 +497,9 @@ SessionManager >> snapshot: save andQuit: quit [
 	| isImageStarting wait |
 	"We do the snapshot in a separate process in maximum priority to have always a clean startup.
 	This process will be interrupted by the fork, and will be resumed as soon as the snapshot finishes.
-	We synchronize these processes in case both are in the same priority"
+	We synchronize these processes in case both are in the same priority.
+	When both arguments are false, do nothing and return false."
+	(save or: [quit]) ifFalse: [ ^ false ]. 
 	wait := Semaphore new.
 	[
 		isImageStarting := self launchSnapshot: save andQuit: quit.


### PR DESCRIPTION
SessionManager>>#snapshot:andQuit: now just returns false when called with false and false as arguments