### PR TITLE
20176-Error-in-ByteArraybooleanAt

### DIFF
--- a/src/Collections-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Tests/ByteArrayTest.class.st
@@ -8,6 +8,20 @@ Class {
 }
 
 { #category : #tests }
+ByteArrayTest >> testBooleanAt [
+	"self run: #testBooleanAt"
+
+	| results |
+	results := Array new: 16.
+	1 to: 16 do: [ :inx | results at: inx put: (ByteArray readHexFrom: (inx - 1 printPaddedWith: $0 to: 2 base: 16)) ].
+	self deny: ((results at: 1) booleanAt: 1) description: 'booleanAt: 0 expected true'.
+	2 to: 16 do: [ :inx | 
+		self
+			assert: ((results at: inx) booleanAt: 1)
+			description: 'booleanAt: ' , (inx - 1) printString , ' expected false']
+]
+
+{ #category : #tests }
 ByteArrayTest >> testFallbackReplaceFromToWithForString [
 	| testString byteArray stringByteSize |
 	testString := 'Test string'.

--- a/src/Collections-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Tests/ByteArrayTest.class.st
@@ -11,14 +11,13 @@ Class {
 ByteArrayTest >> testBooleanAt [
 	"self run: #testBooleanAt"
 
-	| results |
-	results := Array new: 16.
-	1 to: 16 do: [ :inx | results at: inx put: (ByteArray readHexFrom: (inx - 1 printPaddedWith: $0 to: 2 base: 16)) ].
-	self deny: ((results at: 1) booleanAt: 1) description: 'booleanAt: 0 expected true'.
-	2 to: 16 do: [ :inx | 
-		self
-			assert: ((results at: inx) booleanAt: 1)
-			description: 'booleanAt: ' , (inx - 1) printString , ' expected false']
+	"Building a few instances of ByteArray and checking the result of ByteArray>>#booleanAt on their first position. The '00' case should be false (because it represents the 0 integer, which corresponds to false in the C convention), all other cases should be true (because they represent non-0 integers, which correspond to true in the C convention)"
+
+	self deny: ((ByteArray readHexFrom: '00') booleanAt: 1).
+	self assert: ((ByteArray readHexFrom: '01') booleanAt: 1).
+	self assert: ((ByteArray readHexFrom: '02') booleanAt: 1).
+	self assert: ((ByteArray readHexFrom: '15') booleanAt: 1).
+	self assert: ((ByteArray readHexFrom: 'FF') booleanAt: 1).
 ]
 
 { #category : #tests }

--- a/src/Collections-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Tests/ByteArrayTest.class.st
@@ -10,14 +10,14 @@ Class {
 { #category : #tests }
 ByteArrayTest >> testBooleanAt [
 	"self run: #testBooleanAt"
+	
+	"Checking the result of ByteArray>>#booleanAt on a few instances of ByteArray. It should return false on 0-valued bytes and true on all other bytes (according to the integer to boolean C convention)."
 
-	"Building a few instances of ByteArray and checking the result of ByteArray>>#booleanAt on their first position. The '00' case should be false (because it represents the 0 integer, which corresponds to false in the C convention), all other cases should be true (because they represent non-0 integers, which correspond to true in the C convention)"
-
-	self deny: ((ByteArray readHexFrom: '00') booleanAt: 1).
-	self assert: ((ByteArray readHexFrom: '01') booleanAt: 1).
-	self assert: ((ByteArray readHexFrom: '02') booleanAt: 1).
-	self assert: ((ByteArray readHexFrom: '15') booleanAt: 1).
-	self assert: ((ByteArray readHexFrom: 'FF') booleanAt: 1).
+	self deny: (#[0] booleanAt: 1).
+	self assert: (#[1] booleanAt: 1).
+	self assert: (#[255 2 3] booleanAt: 1).
+	self deny: (#[0 25] booleanAt: 1).
+	self assert: (#[255] booleanAt: 1).
 ]
 
 { #category : #tests }

--- a/src/FFI-Kernel/ByteArray.extension.st
+++ b/src/FFI-Kernel/ByteArray.extension.st
@@ -8,7 +8,10 @@ ByteArray >> asExternalPointer [
 
 { #category : #'*FFI-Kernel' }
 ByteArray >> booleanAt: byteOffset [
-	"Booleans are just integers in C word"
+	"Returns the boolean the byte at index byteOffset of this ByteArray represents in the C convention ( A byte representing the 0 integer corresponds to false, while all other integers corresponds to true).
+	Examples:
+	`(ByteArray readHexFrom: '00') booleanAt: 1` returns false
+	`(ByteArray readHexFrom: '01') booleanAt: 1` returns true"
 	^(self integerAt: byteOffset size: 1 signed: false) ~= 0
 ]
 

--- a/src/FFI-Kernel/ByteArray.extension.st
+++ b/src/FFI-Kernel/ByteArray.extension.st
@@ -10,8 +10,9 @@ ByteArray >> asExternalPointer [
 ByteArray >> booleanAt: byteOffset [
 	"Returns the boolean the byte at index byteOffset of this ByteArray represents in the C convention ( A byte representing the 0 integer corresponds to false, while all other integers corresponds to true).
 	Examples:
-	`(ByteArray readHexFrom: '00') booleanAt: 1` returns false
-	`(ByteArray readHexFrom: '01') booleanAt: 1` returns true"
+	(#[1 2 0 4] booleanAt: 2) >>> true.
+	(#[1 2 0 4] booleanAt: 3) >>> false."
+	
 	^(self integerAt: byteOffset size: 1 signed: false) ~= 0
 ]
 


### PR DESCRIPTION
Fix ByteArray>>#booleanAt: to actually return true when the byte at the querried position in the ByteArray is a non-zero integer