### PR TITLE
20756-Secondary-selections-are-dark-after-switch-to-the-white-theme-in-Pharo-7

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -89,7 +89,7 @@ BaselineOfIDE >> additionalInitialization [
 	
 	PharoLightTheme beCurrent.
 	
-	Smalltalk ui theme settings secondarySelectionColor: (Color r: 0.31 g: 0.31 b: 0.36 alpha: 1.0).
+	Smalltalk ui theme settings secondarySelectionColor: (Color r: 0.927 g: 0.962 b: 0.995 alpha: 1.0).
 	
 	SDL_Event initialize.
 	


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20756/Secondary-selections-are-dark-after-switch-to-the-white-theme-in-Pharo-7change default secondary selection color