### PR TITLE
20061-Explicit-isAbstract-is-needed-instead-of-using-hasAbstractMethods-in-tools2

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -133,6 +133,20 @@ BehaviorTest >> testHasAbstractMethods [
 ]
 
 { #category : #tests }
+BehaviorTest >> testIsAbstract [
+
+	self assert: Behavior isAbstract.	
+	self deny: Behavior class isAbstract.
+	self assert: ClassDescription isAbstract.
+	self deny: ClassDescription class isAbstract.
+	
+	self deny: Class isAbstract.
+	self deny: Class class isAbstract.
+	self deny: Object isAbstract.
+	self deny: Object class isAbstract.
+]
+
+{ #category : #tests }
 BehaviorTest >> testIsRootInEnvironment [
 	self assert: ProtoObject isRootInEnvironment.
 	self deny: Object isRootInEnvironment

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -990,7 +990,8 @@ Behavior >> handleFailingFailingBasicNew: sizeRequested [
 Behavior >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	self methodsDo: [:each | each isAbstract ifTrue: [ ^true ]].
+	^false
 ]
 
 { #category : #'testing method dictionary' }
@@ -1160,6 +1161,17 @@ Behavior >> instancesSizeInMemory [
 	bytes := 0.
 	self allInstancesDo: [:each | bytes := bytes + each sizeInMemory  ].
 	^ bytes
+]
+
+{ #category : #testing }
+Behavior >> isAbstract [
+	
+	self withAllSuperclassesDo: [ :eachClass | 
+		eachClass methodsDo: [ :eachMethod |
+			(eachMethod isAbstract and: [ (self lookupSelector: eachMethod selector) isAbstract ])
+				ifTrue: [ ^true ]]].
+	
+	^false
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -851,6 +851,13 @@ Class >> innerBindingOf: aSymbol [
 ]
 
 { #category : #testing }
+Class >> isAbstract [
+	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+
+	^ super isAbstract or: [ self theMetaClass isAbstract ]
+]
+
+{ #category : #testing }
 Class >> isAnonymous [
 	^self getName isNil
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -487,7 +487,13 @@ CompiledMethod >> hasSourcePointer [
 CompiledMethod >> isAbstract [
 	"Answer true if I am abstract"
 	
-	^ self markerOrNil == self class abstractMarker
+	| marker |
+	marker := self markerOrNil ifNil: [^false].
+	
+	^marker == self class subclassResponsibilityMarker 
+		or: [ marker == self class explicitRequirementMarker
+			or: [  marker == self class implicitRequirementMarker]]
+
 ]
 
 { #category : #testing }

--- a/src/Nautilus/ClassWidget.class.st
+++ b/src/Nautilus/ClassWidget.class.st
@@ -77,7 +77,7 @@ ClassWidget >> buildTabbedNameOf: anElement [
 			stringMorph color: self model extensionColor ] 
 	].
 	
-	anElement hasAbstractMethods ifTrue: [ 	
+	anElement isAbstract ifTrue: [ 	
 		stringMorph 
 		emphasis: 2; 
 		color: (self abstractColorAdjust: stringMorph color)

--- a/src/Traits/TBehavior.trait.st
+++ b/src/Traits/TBehavior.trait.st
@@ -748,7 +748,8 @@ TBehavior >> flushCache [
 TBehavior >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	self methodsDo: [:each | each isAbstract ifTrue: [ ^true ]].
+	^false
 ]
 
 { #category : #'testing method dictionary' }

--- a/src/Traits/Trait.class.st
+++ b/src/Traits/Trait.class.st
@@ -667,6 +667,13 @@ Trait >> innerBindingOf: aSymbol [
 ]
 
 { #category : #testing }
+Trait >> isAbstract [
+	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
+
+	^ super isAbstract or: [ self theMetaClass isAbstract ]
+]
+
+{ #category : #testing }
 Trait >> isAnonymous [
 	^self getName isNil
 ]

--- a/src/Traits/TraitBehavior.class.st
+++ b/src/Traits/TraitBehavior.class.st
@@ -756,7 +756,8 @@ TraitBehavior >> flushCache [
 TraitBehavior >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
 	
-	^ (self methods anySatisfy: [:cm | cm sendsSelector: #subclassResponsibility ])
+	self methodsDo: [:each | each isAbstract ifTrue: [ ^true ]].
+	^false
 ]
 
 { #category : #'testing method dictionary' }
@@ -922,6 +923,12 @@ TraitBehavior >> instancesSizeInMemory [
 	bytes := 0.
 	self allInstancesDo: [:each | bytes := bytes + each sizeInMemory  ].
 	^ bytes
+]
+
+{ #category : #testing }
+TraitBehavior >> isAbstract [
+	self methodsDo: [ :each | each isAbstract ifTrue: [ ^true ] ].
+	^false
 ]
 
 { #category : #'testing method dictionary' }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/20061/Explicit-isAbstract-is-needed-instead-of-using-hasAbstractMethods-in-toolsFew things are done:
- Behavior and friends define isAbstract method with optimized logic.
It gives 50 milliseconds for the test:
[50 timesRepeat: [ PluggableTextMorph isAbstract]] timeToRun.
50 items is much more then we able to see in browser class list. So it should not affect browser speed.
- BehaviorTest>>testIsAbstract 
- CompiledMethod>>isAbstract is now take into account traits explicit and implicit requirement.
- Nautilus uses #isAbstract instead of hasAbstractMethods to mark abstract classes