### PR TITLE
20758-Slot-should-have-explicit-property-definingClass2

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -587,20 +587,6 @@ ClassDescription >> copyMethodDictionaryFrom: donorClass [
 	self organization: donorClass organization deepCopy.
 ]
 
-{ #category : #slots }
-ClassDescription >> definesSlot: aSlot [
-	"Return true whether the receiver defines an instance variable named aString"
-	
-	^ self slots identityIncludes: aSlot
-]
-
-{ #category : #slots }
-ClassDescription >> definesSlotNamed: aString [
-	"Return true whether the receiver defines an instance variable named aString."
-	
-	^ self slotNames includes: aString
-]
-
 { #category : #'filein/out' }
 ClassDescription >> definition [
 	"Answer a String that defines the receiver."

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -416,6 +416,21 @@ SlotIntegrationTest >> testSlotScopeParallelism [
 ]
 
 { #category : #tests }
+SlotIntegrationTest >> testSlotsAreInitializedWithDefiningAnonimousClass [
+	"All slots should include reference to defining class"
+	aClass := self make: [ :builder |
+		builder 
+			name: self aClassName;
+			slots: #(x)
+		].
+	self assert: aClass slots first definingClass equals: aClass.
+	
+	aClass addInstVarNamed: 'y'.
+	self assert: aClass slots size equals: 2.
+	self assert: (aClass slots collect: #definingClass as: Set) equals: {aClass} asSet
+]
+
+{ #category : #tests }
 SlotIntegrationTest >> testSmallIntegerLayout [
 	self assert: (SmallInteger classLayout isKindOf: ImmediateLayout).
 ]

--- a/src/Slot/Behavior.extension.st
+++ b/src/Slot/Behavior.extension.st
@@ -14,3 +14,17 @@ Behavior >> classLayout [
 Behavior >> classLayout: aClassLayout [
 	layout := aClassLayout
 ]
+
+{ #category : #'*Slot' }
+Behavior >> definesSlot: aSlot [
+	"Return true whether the receiver defines an instance variable named aString"
+	
+	^ self slots identityIncludes: aSlot
+]
+
+{ #category : #'*Slot' }
+Behavior >> definesSlotNamed: aString [
+	"Return true whether the receiver defines an instance variable named aString."
+	
+	^ self slotNames includes: aString
+]

--- a/src/Slot/ClassDescription.extension.st
+++ b/src/Slot/ClassDescription.extension.st
@@ -3,6 +3,7 @@ Extension { #name : #ClassDescription }
 { #category : #'*Slot' }
 ClassDescription >> superclass: aSuperclass layout: aLayout [
 	layout := aLayout. 
+	layout slots do: [ :each | each definingClass: self ].
 	
 	self
 		superclass: aSuperclass

--- a/src/Slot/Slot.class.st
+++ b/src/Slot/Slot.class.st
@@ -14,7 +14,8 @@ Class {
 	#name : #Slot,
 	#superclass : #Object,
 	#instVars : [
-		'name'
+		'name',
+		'definingClass'
 	],
 	#classVars : [
 		'Properties'
@@ -113,9 +114,12 @@ Slot >> changingIn: aClass [
 
 { #category : #queries }
 Slot >> definingClass [
-	^(Smalltalk globals allClasses flatCollect: [:each | {each . each classSide} ]) 
-		detect: [ :class | class classLayout definesSlot: self] 
-		ifNone: [ nil ]
+	^definingClass
+]
+
+{ #category : #queries }
+Slot >> definingClass: aClass [
+	definingClass := aClass
 ]
 
 { #category : #printing }


### PR DESCRIPTION
definingClass is added to Slot.
It is initialized in ClassDescription>>superclass:layout:
SlotIntegrationTest>>testSlotsAreInitializedWithDefiningAnonimousClass covers that initialization is performed.
https://pharo.fogbugz.com/f/cases/20758/Slot-should-have-explicit-property-definingClass