### PR TITLE
20700-translateToUTC-does-not-work-on-Month-and-Year

### DIFF
--- a/src/Kernel-Tests/DateAndTimeLeapTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeLeapTest.class.st
@@ -54,7 +54,7 @@ DateAndTimeLeapTest >> testAsLocal [
 DateAndTimeLeapTest >> testAsMonth [
 	self
 		assert: aDateAndTime asMonth
-		equals: (Month year: 2004 month: 'February').
+		equals: ((Month year: 2004 month: 'February') translateTo: 2 hours).
 
 ]
 

--- a/src/Kernel-Tests/MonthTest.class.st
+++ b/src/Kernel-Tests/MonthTest.class.st
@@ -110,6 +110,17 @@ index) = item].
 ]
 
 { #category : #tests }
+MonthTest >> testOffset [
+	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
+
+	| dt newMonth |
+
+	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	newMonth := Month starting: dt duration: 0. "duration is ignored"
+	self assert: newMonth asDateAndTime offset equals: dt offset
+]
+
+{ #category : #tests }
 MonthTest >> testPreviousNext [
 	| n p |
 	n := month next.

--- a/src/Kernel-Tests/WeekTest.class.st
+++ b/src/Kernel-Tests/WeekTest.class.st
@@ -128,6 +128,17 @@ WeekTest >> testNameOfDay [
 ]
 
 { #category : #tests }
+WeekTest >> testOffset [
+	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
+
+	| dt newWeek |
+
+	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	newWeek := Week starting: dt duration: 0. "duration is ignored"
+	self assert: newWeek asDateAndTime offset equals: dt offset
+]
+
+{ #category : #tests }
 WeekTest >> testPreviousNext [
 	self
 		assert: week next = (Week starting: '6 July 1998' asDate);

--- a/src/Kernel-Tests/YearTest.class.st
+++ b/src/Kernel-Tests/YearTest.class.st
@@ -14,6 +14,17 @@ YearTest >> classToBeTested [
 ]
 
 { #category : #tests }
+YearTest >> testOffset [
+	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
+
+	| dt newYear |
+
+	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	newYear := Year starting: dt duration: 0. "duration is ignored"
+	self assert: newYear asDateAndTime offset equals: dt offset
+]
+
+{ #category : #tests }
 YearTest >> testPreviousInLeapYear [
 	"self debug: #testPreviousInLeapYear"
 	

--- a/src/Kernel/Month.class.st
+++ b/src/Kernel/Month.class.st
@@ -84,7 +84,8 @@ Month class >> starting: aDateAndTime duration: aDuration [
 	adjusted := DateAndTime
 				year: start year
 				month: start month
-				day: 1.
+				day: 1
+				offset: aDateAndTime offset.
 	days := self 
 		daysInMonth: adjusted month 
 		forYear: adjusted year.

--- a/src/Kernel/Year.class.st
+++ b/src/Kernel/Year.class.st
@@ -34,7 +34,7 @@ Year class >> starting: aDateAndTime duration: aDuration [
 	aYear := aDateAndTime asDateAndTime year.
 
 	^ super
-		starting: (DateAndTime year: aYear month: 1 day: 1)
+		starting: (DateAndTime year: aYear month: 1 day: 1 offset: aDateAndTime offset)
 		duration: (Duration days: (self daysInYear: aYear)).
 ]
 


### PR DESCRIPTION
20700 translateToUTC does not work on Month and YearUpdate Year>>starting:duration: and Month>>starting:duration: to keep the supplied DateAndTime's offset.Add automated tests to Year, Month and Week to confirm correct operation.