### PR TITLE
20772 - Unused temps in MBConfigurationInfo, MethodDictionaryTest,...

### DIFF
--- a/src/Collections-Tests/MethodDictionaryTest.class.st
+++ b/src/Collections-Tests/MethodDictionaryTest.class.st
@@ -190,7 +190,7 @@ MethodDictionaryTest >> testGrowDoublesCapacity [
 
 { #category : #'tests - others' }
 MethodDictionaryTest >> testGrowPreservesElements [
-	| methodDictionary oldCapacity growedMethodDictionary |
+	| methodDictionary growedMethodDictionary |
 	methodDictionary := self class methodDict copy.
 	growedMethodDictionary := methodDictionary copy; grow; yourself.
 
@@ -223,7 +223,7 @@ MethodDictionaryTest >> testIdentityKeyAtExistantValueReturnsOkKey [
 
 { #category : #'tests - others' }
 MethodDictionaryTest >> testIdentityKeyAtNonExistantValueReturnsFailBlock [
-	| methodSelector result aMethod error |
+	| methodSelector result error |
 	methodSelector := #testAssociationAtExistantKeyReturnsOkAssociation.
 	error := #error.
 	

--- a/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
@@ -75,7 +75,7 @@ MCFileTreeRepository class >> parseName: aString [
 MCFileTreeRepository class >> parseName: aString extension: extension [
     "picked up from GoferVersionReference>>parseName:"
 
-    | info basicName package branch author versionNumber packageName |
+    | basicName package branch author versionNumber packageName |
     basicName := aString last isDigit
         ifTrue: [ aString ]
         ifFalse: [ (aString copyUpToLast: $.) copyUpTo: $( ].

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -152,7 +152,7 @@ MCWorkingCopyBrowser >> addRepository: aRepository [
 
 { #category : #actions }
 MCWorkingCopyBrowser >> addRepositoryToPackage [
-	| selectedPackages |
+
 	self repository
 		ifNotNil: [ :repos | 
 			((SearchFacade mcPackageSearchRejectAll: [ :aPackage | aPackage repositoryGroup includes: repos ] withInitialFilter: nil)

--- a/src/Versionner-Core-Model/MBConfigurationInfo.class.st
+++ b/src/Versionner-Core-Model/MBConfigurationInfo.class.st
@@ -80,7 +80,7 @@ MBConfigurationInfo >> branch [
 
 { #category : #converting }
 MBConfigurationInfo >> buildStringOrText [
-	| string cv specVersion attributes wc |
+	| string attributes wc |
 	attributes := OrderedCollection new.
 	[ string := super buildStringOrText ]
 		on: Error

--- a/src/Versionner-Core-Model/MBPackageInfo.class.st
+++ b/src/Versionner-Core-Model/MBPackageInfo.class.st
@@ -161,11 +161,10 @@ MBPackageInfo >> typeLabel [
 	^'package'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 MBPackageInfo >> versions [
-	""
-	|wc v|
+	| wc |
 	(wc := self workingCopy) isNil
-                   ifTrue: [ ^ #() ].
-      ^ (wc ancestry breadthFirstAncestors) collect: [ : vi| vi].
+		ifTrue: [ ^#() ].
+	^ wc ancestry breadthFirstAncestors collect: [ :vi | vi ]
 ]


### PR DESCRIPTION
Fix unused temps in 

MethodDictionaryTest>>#testIdentityKeyAtNonExistantValueReturnsFailBlock
MBConfigurationInfo>>#buildStringOrText
MBPackageInfo>>#versions
MCFileTreeRepository class>>#parseName:extension:
MCWorkingCopyBrowser>>#addRepositoryToPackage
MethodDictionaryTest>>#testGrowPreservesElements