### PR TITLE
20782-CompiledCode-misses-an-abstract-sourcePointer-method

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -817,6 +817,11 @@ CompiledCode >> signFlag [
 ]
 
 { #category : #'source code management' }
+CompiledCode >> sourcePointer [
+	^ self subclassResponsibility 
+]
+
+{ #category : #'source code management' }
 CompiledCode >> stamp [
 
 	^ self timeStamp


### PR DESCRIPTION
introduced CompiledCode>>sourcePointer as an abstract method