### PR TITLE
Fix potential dangling reference to a released FT_Face

### DIFF
--- a/src/Athens-Cairo/CairoFontFace.class.st
+++ b/src/Athens-Cairo/CairoFontFace.class.st
@@ -12,15 +12,21 @@ Class {
 	#superclass : #FFIExternalObject,
 	#traits : 'TCairoLibrary',
 	#classTraits : 'TCairoLibrary classTrait',
-	#instVars : [
-		'ftFace'
-	],
 	#pools : [
 		'AthensCairoDefs',
 		'FT2Constants'
 	],
 	#category : #'Athens-Cairo-Text'
 }
+
+{ #category : #finalizing }
+CairoFontFace class >> countReferences: handle [
+"
+unsigned int  cairo_font_face_get_reference_count             (cairo_font_face_t *font_face);
+"
+	<primitive: #primitiveNativeCall module: #NativeBoostPlugin error: errorCode>
+	^ self nbCall: #( unsigned int cairo_font_face_get_reference_count (size_t handle)) 
+]
 
 { #category : #finalizing }
 CairoFontFace class >> finalizeResourceData: handle [
@@ -43,6 +49,12 @@ CairoFontFace class >> fromFreetypeFace: aFace [
 	^ cairoFace initializeWithFreetypeFace: aFace
 ]
 
+{ #category : #finalizing }
+CairoFontFace class >> hasSharedResourceData: handle [
+	"Answer wether the external cairo_font_face resource is shared (referenced) by other external objects."
+	^(self countReferences: handle) > 1
+]
+
 { #category : #'instance creation' }
 CairoFontFace class >> primFtFace: aFace loadFlags: flags [
 
@@ -63,9 +75,12 @@ CairoFontFace >> initialize [
 
 { #category : #'initialize-release' }
 CairoFontFace >> initializeWithFreetypeFace: aFace [
-	ftFace := aFace.
-	
-	self autoRelease.
+	FFIExternalResourceManager
+		addResource: self
+		executor:
+			(CairoFontFaceExecutor new
+				resourceClass: self class data: self resourceData;
+				ftFace: aFace)
 ]
 
 { #category : #private }

--- a/src/Athens-Cairo/CairoFontFaceExecutor.class.st
+++ b/src/Athens-Cairo/CairoFontFaceExecutor.class.st
@@ -1,0 +1,49 @@
+"
+A CairoFontFaceExecutor is reponsible of releasing the external 'cairo_font_face_t *' data structure when a corresponding CairoFontFace instance in Smalltalk object memory has been garbage collected.
+
+The external data structure may still be referenced from other cairo objects in the external heap as explained in cairo online documentation https://www.cairographics.org/manual/cairo-FreeType-Fonts.html .
+
+It is thus vital that we do not release the underlying FreeType face until the number of references drops to 1, meaning that we are the last reference, and that we can safely really finalize the external resource.
+
+In order to prevent the free type face to be garbage collected (and its associated FT_face resource to be released), we use an instance variable just for retaining a string reference to it.
+
+More details on the object graph can be found on Pharo issue tracker at
+https://pharo.fogbugz.com/f/cases/20776/Potential-dangling-ref-to-freed-FT_Face
+
+"
+Class {
+	#name : #CairoFontFaceExecutor,
+	#superclass : #FFIExternalResourceExecutor,
+	#instVars : [
+		'ftFace'
+	],
+	#category : #'Athens-Cairo-Text'
+}
+
+{ #category : #finalization }
+CairoFontFaceExecutor >> finalize [ 
+	session = Smalltalk session ifFalse: [ ^ self ].
+	(resourceClass hasSharedResourceData: data) ifFalse: [ ^self reallyFinalize].
+	
+	UIManager default inform: 'Attempt to release a shared cairo_font_face.
+Please report this on pharo-dev mailing list'.
+	
+	[ "Regularly poll for the right moment to release the resource"
+	[20 seconds wait.
+	session = Smalltalk session and: [ resourceClass hasSharedResourceData: data ] ] whileTrue.
+	self reallyFinalize] forkAt: Processor userBackgroundPriority.
+	
+]
+
+{ #category : #accessing }
+CairoFontFaceExecutor >> ftFace: aFace [
+	"Retain a strong reference to the FreeType face, until we really release the external cairo_font_face resource."
+	ftFace := aFace
+]
+
+{ #category : #finalization }
+CairoFontFaceExecutor >> reallyFinalize [ 
+	ftFace := nil.
+	session = Smalltalk session ifFalse: [ ^ self ].
+	resourceClass finalizeResourceData: data
+]


### PR DESCRIPTION
This is issue https://pharo.fogbugz.com/f/cases/20776/Potential-dangling-ref-to-freed-FT_Face

Technical details:

A cairo_font_face could still be referenced from external heap and further used.
Thus we must NOT release the FT_Face until the external reference count drops to 1.

Thus the CairoFontFace is not a good place for retaining a strong reference to the FT2Face, because the reference will vanish as soon as the Smalltalk object is garbage collected, while some external cairo_font_face still point on it.
It's better to have the strong reference in the executor, and avoid garbageCollecting the executor while there are external references to the resource data...

The solution is to use a specific CairoFontFaceExecutor.
If the resource is shared, then we have no other choice than regularly polling the ref count in a new Process.
This process must stop whenever the session change.

Please review carefully and pass some tests.