### PR TITLE
20786-halt-messages-are-not-highlighted-in-red-as-the-other-flavours-of-halt-messages

### DIFF
--- a/src/Reflectivity-Tools/HaltIconStyler.class.st
+++ b/src/Reflectivity-Tools/HaltIconStyler.class.st
@@ -24,5 +24,7 @@ HaltIconStyler >> iconLabelBlock: aNode [
 
 { #category : #testing }
 HaltIconStyler >> shouldStyleNode: aNode [
-	^aNode isMessage and: [ aNode selector = 'halt' or: [aNode selector = 'halt:' or: [aNode selector = 'haltIf:']]]
+	| selectorsToBeHighlighted |
+	selectorsToBeHighlighted := { 'halt'. 'halt:'. 'haltIf:'. 'haltIfNil' }.
+	^aNode isMessage and: [ selectorsToBeHighlighted anySatisfy: [ :sel| sel = aNode selector ]].
 ]


### PR DESCRIPTION
Added haltIfNil to the selectors to be highlighted by HaltIconStyler.
Changed the structure of the shouldStyleNode method's code to increase clarity.