### PR TITLE
20791-World-menu-help-not-shown-in-the-menu

### DIFF
--- a/src/Morphic-Base/PluggableMenuItemSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuItemSpec.extension.st
@@ -13,6 +13,7 @@ PluggableMenuItemSpec >> asMenuItemMorphFrom: parentMenu isLast: aBoolean [
 	it icon: self icon.
 	it keyText: self keyText.
 	it isEnabled: self enabled.
+	it balloonText: self help.
 	(act := self action) ifNotNil: [
 				it 
 					target: act receiver;


### PR DESCRIPTION
Set balloonText after the spec's help.