### PR TITLE
20821 Remove unused ivar from RBKeywordToken and RBIdentifierToken

### DIFF
--- a/src/AST-Core/RBIdentifierToken.class.st
+++ b/src/AST-Core/RBIdentifierToken.class.st
@@ -5,9 +5,6 @@ RBIdentifierToken is the first class representation of an identifier token (e.g.
 Class {
 	#name : #RBIdentifierToken,
 	#superclass : #RBValueToken,
-	#instVars : [
-		'stopPosition'
-	],
 	#category : #'AST-Core-Tokens'
 }
 

--- a/src/AST-Core/RBKeywordToken.class.st
+++ b/src/AST-Core/RBKeywordToken.class.st
@@ -4,9 +4,6 @@ RBKeywordToken is the first-class representation of a keyword token (e.g. add:)
 Class {
 	#name : #RBKeywordToken,
 	#superclass : #RBValueToken,
-	#instVars : [
-		'stopPosition'
-	],
 	#category : #'AST-Core-Tokens'
 }
 


### PR DESCRIPTION
Remove
- unused ivar stopPosition in RBIdentifierToken and 
 - unused ivar stopPosition in RBKeywordToken

https://pharo.fogbugz.com/f/cases/20821/Remove-unused-ivar-from-RBKeywordToken-and-RBIdentifierToken