### PR TITLE
20822 Cleanup AbstractKeymappingTest

### DIFF
--- a/src/Keymapping-Tests/AbstractKeymappingTest.class.st
+++ b/src/Keymapping-Tests/AbstractKeymappingTest.class.st
@@ -15,7 +15,7 @@ Class {
 		'default'
 	],
 	#category : #'Keymapping-Tests'
-}
+} 
 
 { #category : #testing }
 AbstractKeymappingTest class >> isAbstract [

--- a/src/Keymapping-Tests/AbstractKeymappingTest.class.st
+++ b/src/Keymapping-Tests/AbstractKeymappingTest.class.st
@@ -17,6 +17,12 @@ Class {
 	#category : #'Keymapping-Tests'
 }
 
+{ #category : #testing }
+AbstractKeymappingTest class >> isAbstract [
+
+	^self name = #AbstractKeymappingTest
+]
+
 { #category : #utilities }
 AbstractKeymappingTest >> eventKey: character [ 
 	^ self eventKey: character
@@ -91,11 +97,14 @@ AbstractKeymappingTest >> eventKey: character shift: aBoolean [
 
 { #category : #running }
 AbstractKeymappingTest >> setUp [
+	super setUp.
 	default := KMRepository default.
 	KMRepository default: KMRepository new
 ]
 
 { #category : #running }
 AbstractKeymappingTest >> tearDown [
-	KMRepository default: default
+	KMRepository default: default.
+	default := nil.
+	super tearDown 
 ]


### PR DESCRIPTION
- override #isAbstract as it is an abstract test superclass
- call super setUp
- call super tearDown
- set default to nil in tearDown to avoid further referencing