### PR TITLE
20825 Super setUp need to be called in Opal Compiler tests

### DIFF
--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
@@ -152,6 +152,7 @@ OCBytecodeDecompilerTest >> remoteTempNested [
 
 { #category : #running }
 OCBytecodeDecompilerTest >> setUp [
+	super setUp.
 	currentCompiler := SmalltalkImage compilerClass.
 	SmalltalkImage compilerClass: OpalCompiler.
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'currentCompiler'
 	],
 	#category : #'OpalCompiler-Tests-Bytecode'
-}
+} 
 
 { #category : #examples }
 OCBytecodeDecompilerTest >> pushClosureCopyNoCopied [

--- a/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
@@ -333,6 +333,7 @@ OCClosureCompilerTest >> evaluate: aString in: aContext to: anObject [
 
 { #category : #running }
 OCClosureCompilerTest >> setUp [
+	super setUp.
 	currentCompiler := SmalltalkImage compilerClass.
 	SmalltalkImage compilerClass: OpalCompiler.
 ]

--- a/src/OpalCompiler-Tests/OCCompilerExceptionsTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerExceptionsTest.class.st
@@ -52,7 +52,7 @@ OCCompilerExceptionsTest >> selectionInterval [
 
 { #category : #running }
 OCCompilerExceptionsTest >> setUp [
-
+	super setUp.
 	currentCompiler := SmalltalkImage compilerClass.
 	SmalltalkImage compilerClass: OpalCompiler.
 

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -102,6 +102,7 @@ OCCompilerNotifyingTest >> numberOfSelections [
 
 { #category : #running }
 OCCompilerNotifyingTest >> setUp [
+	super setUp.
 	failure := Object new.
 ]
 

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -58,6 +58,7 @@ OCCompilerTest >> runCase [
 
 { #category : #running }
 OCCompilerTest >> setUp [
+	super setUp.
 	Smalltalk globals at: #OCCompilerTestTestVar put: MockForCompilation.
 	
 	


### PR DESCRIPTION
- call super setUp in OCBytecodeDecompilerTest
- call super setUp in OCClosureCompilerTest
- call super setUp in OCCompilerExceptionTest
- call super setUp in OCCompilerNotifyingTest
- call super setUp in OCCompilerTest