### PR TITLE
20826 Super setup need to be called in DependencyAnalyser tests

### DIFF
--- a/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'checker'
 	],
 	#category : #'Tool-DependencyAnalyser-Test-Core'
-}
+} 
 
 { #category : #running }
 DADependencyCheckerTest >> setUp [

--- a/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'checker'
 	],
 	#category : #'Tool-DependencyAnalyser-Test-Core'
-} 
+}
 
 { #category : #running }
 DADependencyCheckerTest >> setUp [

--- a/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DADependencyCheckerTest.class.st
@@ -4,11 +4,12 @@ Class {
 	#instVars : [
 		'checker'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Core'
 }
 
 { #category : #running }
 DADependencyCheckerTest >> setUp [
+	super setUp.
 	checker := DADependencyChecker new
 ]
 

--- a/src/Tool-DependencyAnalyser-Test/DAMessageSendAnalyzerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAMessageSendAnalyzerTest.class.st
@@ -4,11 +4,12 @@ Class {
 	#instVars : [
 		'analyzer'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Core'
 }
 
 { #category : #running }
 DAMessageSendAnalyzerTest >> setUp [
+	super setUp.
 	analyzer := DAMessageSendAnalyzer on: 'Tool-DependencyAnalyser-Test-Data'
 ]
 

--- a/src/Tool-DependencyAnalyser-Test/DAPackageCycleDetectorTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageCycleDetectorTest.class.st
@@ -12,7 +12,7 @@ Class {
 		'cycleB',
 		'cycleC'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #utility }
@@ -42,12 +42,13 @@ DAPackageCycleDetectorTest >> queue [
 
 { #category : #running }
 DAPackageCycleDetectorTest >> setUp [
+	super setUp.
 	aPackageCycleDetection := DAPackageCycleDetector new.
-	packageA := (DAPackage on: (RPackageSet named: 'A')).
-	packageB := (DAPackage on: (RPackageSet named: 'B')).
-	packageC := (DAPackage on: (RPackageSet named: 'C')).
-	packageD := (DAPackage on: (RPackageSet named: 'D')).
-	packageE :=  (DAPackage on: (RPackageSet named: 'E')).
+	packageA := DAPackage on: (RPackageSet named: 'A').
+	packageB := DAPackage on: (RPackageSet named: 'B').
+	packageC := DAPackage on: (RPackageSet named: 'C').
+	packageD := DAPackage on: (RPackageSet named: 'D').
+	packageE := DAPackage on: (RPackageSet named: 'E').
 	cycleA := DAPackageCycle new.
 	cycleB := DAPackageCycle new.
 	cycleC := DAPackageCycle new.

--- a/src/Tool-DependencyAnalyser-Test/DAPackageCycleTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageCycleTest.class.st
@@ -7,11 +7,12 @@ Class {
 		'packageB',
 		'packageC'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #running }
 DAPackageCycleTest >> setUp [
+	super setUp.
 	aPDPackageCycle := DAPackageCycle new.
 	packageA := DAPackage on: (RPackageSet named:'A').
 	packageB := DAPackage on: (RPackageSet named:'B').

--- a/src/Tool-DependencyAnalyser-Test/DAPackageDependencyTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageDependencyTest.class.st
@@ -7,7 +7,7 @@ Class {
 		'packageA',
 		'packageB'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #running }
@@ -31,6 +31,7 @@ DAPackageDependencyTest >> referenceDependency: aClass [
 { #category : #running }
 DAPackageDependencyTest >> setUp [
 	| source target |
+	super setUp.
 	source := DAPackage on: (RPackageSet named:'Kernel').
 	target := DAPackage on: (RPackageSet named:'Collections-Abstract').
 	aPackageDependency := DAPackageDependency from:source to:target.

--- a/src/Tool-DependencyAnalyser-Test/DAPackageDependencyWrapperTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageDependencyWrapperTest.class.st
@@ -5,11 +5,12 @@ Class {
 		'packageA',
 		'aPDPackageDependencyWrapper'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #running }
 DAPackageDependencyWrapperTest >> setUp [
+	super setUp.
 	packageA := DAPackage on: (RPackageSet named:'A').
 ]
 

--- a/src/Tool-DependencyAnalyser-Test/DAPackageRelationGraphDiffTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageRelationGraphDiffTest.class.st
@@ -8,12 +8,13 @@ Class {
 		'packageA',
 		'packageB'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #running }
 DAPackageRelationGraphDiffTest >> setUp [
 	| packageCollectionsAbstract packageCollectionsString |
+	super setUp.
 	packageA := DAPackage on: (RPackageSet named: 'A').
 	packageB := DAPackage on: (RPackageSet named: 'B').
 	packageCollectionsAbstract := DAPackage on: (RPackageSet named: 'Collections-Abstract').
@@ -24,7 +25,6 @@ DAPackageRelationGraphDiffTest >> setUp [
 	oldRelationGraph build.
 	newRelationGraph build.
 	
-
 	packageRelationGraphDiff := DAPackageRelationGraphDiff new
 		oldRelationGraph: oldRelationGraph;
 		newRelationGraph: newRelationGraph

--- a/src/Tool-DependencyAnalyser-Test/DAPackageRelationGraphTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageRelationGraphTest.class.st
@@ -14,7 +14,7 @@ Class {
 		'packageC',
 		'packageD'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #utility }
@@ -24,17 +24,18 @@ DAPackageRelationGraphTest >> packageDependencyFrom: aPackage to: anOtherPackage
 
 { #category : #running }
 DAPackageRelationGraphTest >> setUp [
+	super setUp.
 	aPackageRelationGraph := DAPackageRelationGraph new.
-	packageCollectionAbstract := DAPackage on: (RPackageSet named:'Collections-Abstract').
-	packageStrings := (DAPackage on:(RPackageSet named: 'Collections-Strings')).
-	packageKernel := (DAPackage on:(RPackageSet named: 'Kernel')).
-	packageRegexCore := (DAPackage on:(RPackageSet named: 'Regex-Core')).
-	packageCollectionsSequenceable := (DAPackage on:(RPackageSet named: 'Collections-Sequenceable')).
-	packagePackageDependencies := (DAPackage on:(RPackageSet named:  #'Tool-DependencyAnalyser')).
-	packageA := (DAPackage on: (RPackageSet named: 'A')).
-	packageB := (DAPackage on: (RPackageSet named: 'B')).
-	packageC := (DAPackage on: (RPackageSet named: 'C')).
-	packageD := (DAPackage on: (RPackageSet named: 'D')).
+	packageCollectionAbstract := DAPackage on: (RPackageSet named: 'Collections-Abstract').
+	packageStrings := DAPackage on:(RPackageSet named: 'Collections-Strings').
+	packageKernel := DAPackage on:(RPackageSet named: 'Kernel').
+	packageRegexCore := DAPackage on:(RPackageSet named: 'Regex-Core').
+	packageCollectionsSequenceable := DAPackage on: (RPackageSet named: 'Collections-Sequenceable').
+	packagePackageDependencies := DAPackage on: (RPackageSet named:  #'Tool-DependencyAnalyser').
+	packageA := DAPackage on: (RPackageSet named: 'A').
+	packageB := DAPackage on: (RPackageSet named: 'B').
+	packageC := DAPackage on: (RPackageSet named: 'C').
+	packageD := DAPackage on: (RPackageSet named: 'D').
 ]
 
 { #category : #tests }

--- a/src/Tool-DependencyAnalyser-Test/DAPackageTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DAPackageTest.class.st
@@ -8,16 +8,17 @@ Class {
 		'packageB',
 		'packageC'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Packages'
 }
 
 { #category : #running }
 DAPackageTest >> setUp [
+	super setUp.
 	aPackage := DAPackage on: (RPackageSet named: 'Collections-Abstract'). 
 	aSecondPackage := DAPackage on: (RPackageSet named: 'Collections-Arithmetic').
-	packageA := (DAPackage on: (RPackageSet named: 'A')).
-	packageB := (DAPackage on: (RPackageSet named: 'B')).
-	packageC := (DAPackage on: (RPackageSet named: 'C')).
+	packageA := DAPackage on: (RPackageSet named: 'A').
+	packageB := DAPackage on: (RPackageSet named: 'B').
+	packageC := DAPackage on: (RPackageSet named: 'C').
 	aPackage add: (DAInheritanceDependency from:aPackage to:aSecondPackage).
 ]
 

--- a/src/Tool-DependencyAnalyser-Test/DATarjanAlgorithmTest.class.st
+++ b/src/Tool-DependencyAnalyser-Test/DATarjanAlgorithmTest.class.st
@@ -13,29 +13,30 @@ Class {
 		'packageH',
 		'anArray'
 	],
-	#category : #'Tool-DependencyAnalyser-Test'
+	#category : #'Tool-DependencyAnalyser-Test-Algorithm'
 }
 
 { #category : #running }
 DATarjanAlgorithmTest >> setUp [
+	super setUp.
 	tarjanPackage := DATarjanAlgorithm new.
 	anArray := Array new: 8.
-	packageA := DAPackage on: (RPackageSet named:'A').
-	packageB := (DAPackage on: (RPackageSet named: 'B')).
-	packageC := (DAPackage on: (RPackageSet named: 'C')).
-	packageD := (DAPackage on: (RPackageSet named: 'D')).
-	packageE :=  (DAPackage on: (RPackageSet named: 'E')).
-	packageF :=  (DAPackage on: (RPackageSet named: 'F')).
-	packageG :=  (DAPackage on: (RPackageSet named: 'G')).
-	packageH :=  (DAPackage on: (RPackageSet named: 'H')).
-	anArray at: 1 put:packageA.
-	anArray at: 2 put:packageB.
-	anArray at: 3 put:packageC.
-	anArray at: 4 put:packageD.
-	anArray at: 5 put:packageE.
-	anArray at: 6 put:packageF.
+	packageA := DAPackage on: (RPackageSet named: 'A').
+	packageB := DAPackage on: (RPackageSet named: 'B').
+	packageC := DAPackage on: (RPackageSet named: 'C').
+	packageD := DAPackage on: (RPackageSet named: 'D').
+	packageE := DAPackage on: (RPackageSet named: 'E').
+	packageF := DAPackage on: (RPackageSet named: 'F').
+	packageG := DAPackage on: (RPackageSet named: 'G').
+	packageH := DAPackage on: (RPackageSet named: 'H').
+	anArray at: 1 put: packageA.
+	anArray at: 2 put: packageB.
+	anArray at: 3 put: packageC.
+	anArray at: 4 put: packageD.
+	anArray at: 5 put: packageE.
+	anArray at: 6 put: packageF.
 	anArray at: 7 put: packageG.
-	anArray at:  8 put:packageH.
+	anArray at: 8 put:packageH.
 ]
 
 { #category : #utility }


### PR DESCRIPTION
- call super setUp in DADependencyCheckerTest
- call super setUp in DAMessageSendAnalyzerTest
- call super setUp in DAPackageCycleDetectorTest (with some formatting cleanups in setUp)
- call super setUp in DAPackageCycleTest
- call super setUp in DAPackageDependencyTest
- call super setUp in DAPackageDependencyWrapperTest
- call super setUp in DAPackageRelationGraphDiffTest
- call super setUp in DAPackageRelationGraphTest (with some formatting cleanups in setUp)
- call super setUp in DAPackageTest (with some formatting cleanups in setUp)
- call super setUp in DATarjanAlgorithmTest (with some formatting cleanups in setUp)
Also add some tags to to better categorize the test classes in package "Tool-Dependency-Analyse-Test"