### PR TITLE
20828 Super setup need to be called in Versionner tests

### DIFF
--- a/src/Versionner-Tests-Core-Model/MBAbstractTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBAbstractTest.class.st
@@ -31,7 +31,7 @@ MBAbstractTest >> removeClassIfExist: aSymbol [
 
 { #category : #running }
 MBAbstractTest >> setUp [
-
+	super setUp.
 	(Smalltalk globals includesKey: self configurationName asSymbol) 
 		ifFalse: [ 
 			MetacelloToolBox configurationNamed: self configurationName.

--- a/src/Versionner-Tests-Core-Model/MBPackageInfoTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBPackageInfoTest.class.st
@@ -13,6 +13,7 @@ Class {
 
 { #category : #running }
 MBPackageInfoTest >> setUp [
+	super setUp.
 "	(Smalltalk includesKey: #TMPClass)
 		ifTrue: [ (Smalltalk at: #TMPClass) removeFromSystem ].
 "		


### PR DESCRIPTION
- call super setUp in MBAbstractTest
- call super setUp in MBPackageInfoTest

https://pharo.fogbugz.com/f/cases/20828/Super-setup-need-to-be-called-in-Versionner