### PR TITLE
20829 Super setup need to be called in Spec tests

### DIFF
--- a/src/Spec-Tests/MorphicLabelAdapterTest.class.st
+++ b/src/Spec-Tests/MorphicLabelAdapterTest.class.st
@@ -14,6 +14,7 @@ MorphicLabelAdapterTest >> modelClass [
 
 { #category : #running }
 MorphicLabelAdapterTest >> setUp [
+	super setUp.
 	label := self modelClass new
 ]
 

--- a/src/Spec-Tests/MorphicTreeAdapterTest.class.st
+++ b/src/Spec-Tests/MorphicTreeAdapterTest.class.st
@@ -14,6 +14,7 @@ MorphicTreeAdapterTest >> modelClass [
 
 { #category : #running }
 MorphicTreeAdapterTest >> setUp [
+	super setUp.
 	treeWithItems := self modelClass new.
 	treeWithItems roots: #(#first #second #third #fourth #fifth)
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -15,6 +15,7 @@ Class {
 SpecInterpreterTest >> setUp [
 	"Setting up code for SpecInterpreterTest"
 
+	super setUp.
 	specInterpreterClass := SpecInterpreter.
 	specInterpreter := specInterpreterClass new.
 	specInterpreter model: TestingComposablePresenter new

--- a/src/Spec-Tests/SpecTestCase.class.st
+++ b/src/Spec-Tests/SpecTestCase.class.st
@@ -49,6 +49,7 @@ SpecTestCase >> openInstance: aLayoutSelector [
 
 { #category : #running }
 SpecTestCase >> setUp [
+	super setUp.
 	testedInstance := self classToTest new.
 	self initializeTestedInstance
 ]


### PR DESCRIPTION
- call super setUp in MorphicLabelAdapterTest
- call super setUp in MorphicTreeAdapterTest
- call super setUp in SpecInterpreterTest
- call super setUp in SpecTestCase

https://pharo.fogbugz.com/f/cases/20829/Super-setup-need-to-be-called-in-Spec-tests