### PR TITLE
20830 Super setup need to be called in Monticello tests and other cleanups (comments, tags)

### DIFF
--- a/src/Monticello-Tests/MCAncestryTest.class.st
+++ b/src/Monticello-Tests/MCAncestryTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCAncestryTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCAnnouncementTest.class.st
+++ b/src/Monticello-Tests/MCAnnouncementTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCAnnouncementTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCChangeNotificationTest.class.st
+++ b/src/Monticello-Tests/MCChangeNotificationTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'workingCopy'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #private }
@@ -25,7 +25,6 @@ MCChangeNotificationTest >> modifiedEventFor: aSelector ofClass: aClass [
 
 { #category : #running }
 MCChangeNotificationTest >> setUp [
-
        "FIXME: Unregister Monticellomocks if it got created in another test
        (for example MCMethodDefinitionTest may create it implicitly).
        This avoids a nasty failure of MCChangeNotificationTest due to
@@ -36,8 +35,8 @@ MCChangeNotificationTest >> setUp [
                removeKey: (MCPackage new name: 'MonticelloMocks')
                ifAbsent:[].
        PackageOrganizer default unregisterPackageNamed: 'MonticelloMocks'."
-
-       workingCopy := MCWorkingCopy forPackage: self mockPackage.
+		super setUp.	
+      workingCopy := MCWorkingCopy forPackage: self mockPackage.
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'previousChangeSet'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #'as yet unclassified' }
@@ -38,6 +38,7 @@ MCClassDefinitionTest >> creationMessage [
 
 { #category : #running }
 MCClassDefinitionTest >> setUp [
+	super setUp.
 	Smalltalk globals at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ]
 ]
 

--- a/src/Monticello-Tests/MCDataStreamTest.class.st
+++ b/src/Monticello-Tests/MCDataStreamTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCDataStreamTest,
 	#superclass : #BaseStreamTest,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCDependencySorterTest.class.st
+++ b/src/Monticello-Tests/MCDependencySorterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCDependencySorterTest,
 	#superclass : #TestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Dependencies'
 }
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCDictionaryRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCDictionaryRepositoryTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'dict'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Repository'
 }
 
 { #category : #actions }
@@ -24,5 +24,6 @@ MCDictionaryRepositoryTest >> dictionary [
 
 { #category : #running }
 MCDictionaryRepositoryTest >> setUp [
+	super setUp.
 	repository :=  MCDictionaryRepository new dictionary: self dictionary
 ]

--- a/src/Monticello-Tests/MCDirectoryRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCDirectoryRepositoryTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'directory'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Repository'
 }
 
 { #category : #actions }
@@ -25,6 +25,7 @@ MCDirectoryRepositoryTest >> directory [
 
 { #category : #running }
 MCDirectoryRepositoryTest >> setUp [
+	super setUp.
 	repository := MCDirectoryRepository new directory: self directory
 ]
 

--- a/src/Monticello-Tests/MCFileInTest.class.st
+++ b/src/Monticello-Tests/MCFileInTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'expected',
 		'diff'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #testing }
@@ -59,6 +59,7 @@ MCFileInTest >> assertSuccessfulLoadWith: aBlock [
 
 { #category : #running }
 MCFileInTest >> setUp [
+	super setUp.
 	expected := self mockSnapshot.
 	stream := RWBinaryOrTextStream on: String new.
 ]

--- a/src/Monticello-Tests/MCMczInstallerTest.class.st
+++ b/src/Monticello-Tests/MCMczInstallerTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'expected',
 		'diff'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #'as yet unclassified' }
@@ -63,6 +63,7 @@ MCMczInstallerTest >> fileStream [
 
 { #category : #running }
 MCMczInstallerTest >> setUp [
+	super setUp.
 	expected := self mockVersion.
 	self change: #one toReturn: 2.
 ]

--- a/src/Monticello-Tests/MCMergingTest.class.st
+++ b/src/Monticello-Tests/MCMergingTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'conflictBlock',
 		'conflicts'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #MCTestCase,
 	#instVars : [
 		'navigation',
-		'isModified'
+		'isModified',
+		'extensionPackage'
 	],
 	#category : #'Monticello-Tests-Base'
 }
@@ -20,6 +21,7 @@ MCMethodDefinitionTest >> ownPackage [
 { #category : #running }
 MCMethodDefinitionTest >> setUp [
 	super setUp.
+	extensionPackage := (MCWorkingCopy forPackage: (MCPackage named: 'FooBarBaz')).
 	navigation := (Smalltalk hasClassNamed: #SystemNavigation)
 		ifTrue: [ (Smalltalk globals at: #SystemNavigation) new ]
 		ifFalse: [ Smalltalk ].
@@ -29,7 +31,8 @@ MCMethodDefinitionTest >> setUp [
 { #category : #running }
 MCMethodDefinitionTest >> tearDown [
        self restoreMocks.
-       (MCWorkingCopy forPackage: (MCPackage named: 'FooBarBaz')) unregister.
+       extensionPackage unregister.
+		extensionPackage := nil.
        self class compile: 'override ^ 1' classified: 'mocks'.
        self ownPackage modified: isModified.
 

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'navigation',
 		'isModified'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #mocks }
@@ -19,6 +19,7 @@ MCMethodDefinitionTest >> ownPackage [
 
 { #category : #running }
 MCMethodDefinitionTest >> setUp [
+	super setUp.
 	navigation := (Smalltalk hasClassNamed: #SystemNavigation)
 		ifTrue: [ (Smalltalk globals at: #SystemNavigation) new ]
 		ifFalse: [ Smalltalk ].

--- a/src/Monticello-Tests/MCMockDependency.class.st
+++ b/src/Monticello-Tests/MCMockDependency.class.st
@@ -1,3 +1,6 @@
+"
+A test object mocking a dependency
+"
 Class {
 	#name : #MCMockDependency,
 	#superclass : #Object,
@@ -6,7 +9,7 @@ Class {
 		'children',
 		'hasResolution'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Dependencies'
 }
 
 { #category : #'instance creation' }

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCOrganizationTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCPackageManagerTest.class.st
+++ b/src/Monticello-Tests/MCPackageManagerTest.class.st
@@ -7,7 +7,7 @@ Class {
 		'mcPackage1',
 		'mcPackage2'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #running }
@@ -34,7 +34,7 @@ MCPackageManagerTest >> tearDown [
 		removeKey: mcPackage2 ifAbsent: [ ] 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 MCPackageManagerTest >> testClassAdded [
 
 	self assert: package1 mcWorkingCopy modified not.
@@ -46,7 +46,7 @@ MCPackageManagerTest >> testClassAdded [
 	self assert: package2 mcWorkingCopy modified
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 MCPackageManagerTest >> testClassRemoved [
 	
 	| class |
@@ -65,7 +65,7 @@ MCPackageManagerTest >> testClassRemoved [
 	
 ]
 
-{ #category : #running }
+{ #category : #tests }
 MCPackageManagerTest >> testManagersForCategoryDo [
 	"Consider the following package structure:
 		Renraku

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCPackageTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #private }

--- a/src/Monticello-Tests/MCPatchTest.class.st
+++ b/src/Monticello-Tests/MCPatchTest.class.st
@@ -4,12 +4,13 @@ Class {
 	#instVars : [
 		'patch'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #running }
 MCPatchTest >> setUp [
 	|rev1 rev2|
+	super setUp.
 	rev1 :=  MCSnapshotResource takeSnapshot.
 	self change: #one toReturn: 2.
 	rev2 :=  MCSnapshotResource takeSnapshot.

--- a/src/Monticello-Tests/MCRepositoryAuthorizationTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryAuthorizationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCRepositoryAuthorizationTest,
 	#superclass : #TestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Repository'
 }
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryTest.class.st
@@ -1,3 +1,6 @@
+"
+Abstract superclass for Repository tests
+"
 Class {
 	#name : #MCRepositoryTest,
 	#superclass : #MCTestCase,
@@ -5,7 +8,7 @@ Class {
 		'repository',
 		'ancestors'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Repository'
 }
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCScannerTest.class.st
+++ b/src/Monticello-Tests/MCScannerTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCScannerTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCSerializationTest.class.st
+++ b/src/Monticello-Tests/MCSerializationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCSerializationTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #asserting }

--- a/src/Monticello-Tests/MCSnapshotBrowserTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotBrowserTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'model',
 		'morph'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Snapshots'
 }
 
 { #category : #private }
@@ -192,6 +192,7 @@ MCSnapshotBrowserTest >> selectMockClassA [
 
 { #category : #running }
 MCSnapshotBrowserTest >> setUp [
+	super setUp.
 	model := MCSnapshotBrowser forSnapshot: MCSnapshotResource current snapshot.
 	morph := model buildWindow.
 ]

--- a/src/Monticello-Tests/MCSnapshotResource.class.st
+++ b/src/Monticello-Tests/MCSnapshotResource.class.st
@@ -1,10 +1,13 @@
+"
+A test resource mocking a snapshot
+"
 Class {
 	#name : #MCSnapshotResource,
 	#superclass : #TestResource,
 	#instVars : [
 		'snapshot'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Resources'
 }
 
 { #category : #accessing }
@@ -29,6 +32,7 @@ MCSnapshotResource >> definitions [
 
 { #category : #running }
 MCSnapshotResource >> setUp [
+	super setUp.
 	snapshot := self class takeSnapshot.
 ]
 

--- a/src/Monticello-Tests/MCSnapshotTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotTest.class.st
@@ -4,11 +4,12 @@ Class {
 	#instVars : [
 		'snapshot'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Snapshots'
 }
 
 { #category : #running }
 MCSnapshotTest >> setUp [
+	super setUp.
 	snapshot :=  self mockSnapshot.
 ]
 

--- a/src/Monticello-Tests/MCSortingTest.class.st
+++ b/src/Monticello-Tests/MCSortingTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCSortingTest,
 	#superclass : #TestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Sorting'
 }
 
 { #category : #testing }

--- a/src/Monticello-Tests/MCStReaderTest.class.st
+++ b/src/Monticello-Tests/MCStReaderTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MCStReaderTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #util }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'stream',
 		'writer'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-IO'
 }
 
 { #category : #asserting }
@@ -154,6 +154,7 @@ MCMethodDeclaration className: #MCMockClassD selector: #one category: #''as yet 
 
 { #category : #running }
 MCStWriterTest >> setUp [
+	super setUp.
 	stream := String new writeStream.
 	writer := MCStWriter on: stream.
 

--- a/src/Monticello-Tests/MCSubDirectoryRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCSubDirectoryRepositoryTest.class.st
@@ -4,7 +4,7 @@ I am not a subclass of MCRepositoryTest because my purpose was to show that a bu
 Class {
 	#name : #MCSubDirectoryRepositoryTest,
 	#superclass : #MCTestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -1,7 +1,10 @@
+"
+Abstract superclass for monticello tests
+"
 Class {
 	#name : #MCTestCase,
 	#superclass : #TestCase,
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Monticello-Tests/MCVersionTest.class.st
+++ b/src/Monticello-Tests/MCVersionTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'version',
 		'visited'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #asserting }
@@ -37,6 +37,7 @@ MCVersionTest >> dependencyFromTree: sexpr [
 
 { #category : #running }
 MCVersionTest >> setUp [
+	super setUp.
 	visited := OrderedCollection new.
 ]
 

--- a/src/Monticello-Tests/MCWorkingCopyTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'versions2',
 		'savedName'
 	],
-	#category : #'Monticello-Tests'
+	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #asserting }
@@ -72,6 +72,7 @@ MCWorkingCopyTest >> packageName [
 { #category : #running }
 MCWorkingCopyTest >> setUp [
 	| repos1 repos2 |
+	super setUp.
 	self clearPackageCache.
 	repositoryGroup := MCRepositoryGroup new.
 	repositoryGroup disableCache.


### PR DESCRIPTION
- call super setUp in MCChangeNotificationTest
- call super setUp in MCClassDefinitionTest
- call super setUp in MCDictionaryRepositoryTest
- call super setUp in MCDirectoryRepositoryTest
- call super setUp in MCFileInTest
- call super setUp in MCMczInstallerTest
- call super setUp in MCMethodDefinitionTest
- call super setUp in MCPatchTest
- call super setUp in MCSnapshotBrowserTest
- call super setUp in MCSnapshotTest
- call super setUp in MCStWriterTest
- call super setUp in MCVersionTest
- call super setUp in MCSnapshotResource (test resource)

- categorize the three test methods in MCPackageManagerTest
- Add a comment to uncommented MCTestCase
- Add a comment to uncommented MCRepositoryTest
- Add a comment to uncommented MCSnapshotResource
- Add a comment to uncommented MCMockDependency

- add some tags to structure the many test classes in the package better


https://pharo.fogbugz.com/f/cases/20830/Super-setup-need-to-be-called-in-Monticello-tests-and-other-cleanups-comments-tags