### PR TITLE
20838 Super setUp need to be called in System-SessionManager package tests

### DIFF
--- a/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
+++ b/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
@@ -17,7 +17,7 @@ SessionErrorHandlingTest >> newTestSessionfor: aManager [
 
 { #category : #running }
 SessionErrorHandlingTest >> setUp [
-	super setup.
+	super setUp.
 	manager := SessionManager new.
 	session := self newTestSessionfor: manager.
 	manager installSession: session.

--- a/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
+++ b/src/System-SessionManager-Tests/SessionErrorHandlingTest.class.st
@@ -17,6 +17,7 @@ SessionErrorHandlingTest >> newTestSessionfor: aManager [
 
 { #category : #running }
 SessionErrorHandlingTest >> setUp [
+	super setup.
 	manager := SessionManager new.
 	session := self newTestSessionfor: manager.
 	manager installSession: session.

--- a/src/System-SessionManager-Tests/SessionManagerRegistrationTest.class.st
+++ b/src/System-SessionManager-Tests/SessionManagerRegistrationTest.class.st
@@ -9,6 +9,7 @@ Class {
 
 { #category : #running }
 SessionManagerRegistrationTest >> setUp [
+	super setUp.
 	manager := SessionManager new
 ]
 

--- a/src/System-SessionManager-Tests/SessionManagerUnregistrationTest.class.st
+++ b/src/System-SessionManager-Tests/SessionManagerUnregistrationTest.class.st
@@ -9,6 +9,7 @@ Class {
 
 { #category : #running }
 SessionManagerUnregistrationTest >> setUp [
+	super setUp.
 	sessionManager := SessionManager new
 ]
 


### PR DESCRIPTION
- call super setUp in SessionErrorHandlingTest
- call super setUp in SessionManagerRegistrationTest
- call super setUp in SessionManagerUnregistrationTest

https://pharo.fogbugz.com/f/cases/20838/Super-setUp-need-to-be-called-in-System-SessionManager-package-tests