### PR TITLE
20840 Super setUp need to be called in various test classes (Part 1)

### DIFF
--- a/src/Athens-Cairo/CairoUTF8ConverterTest.class.st
+++ b/src/Athens-Cairo/CairoUTF8ConverterTest.class.st
@@ -12,6 +12,7 @@ Class {
 
 { #category : #running }
 CairoUTF8ConverterTest >> setUp [
+	super setUp.
 	encoder := CairoUTF8Converter new.
 ]
 

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -447,7 +447,7 @@ ArrayTest >> selectorToAccessValuePutIn [
 { #category : #running }
 ArrayTest >> setUp [
 
-	
+	super setUp.
 	literalArray := #(1 true 3 #four).
 	selfEvaluatingArray := { 1. true. (3/4). String loremIpsum. (2 to: 4) . 5 }.
 	nonSEArray1 := { 1 . Set with: 1 }.

--- a/src/Collections-Tests/AssociationTest.class.st
+++ b/src/Collections-Tests/AssociationTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #running }
 AssociationTest >> setUp [
-
+	super setUp.
 	a := 1 -> 'one'.
 	b := 1 -> 'een'.
 ]

--- a/src/Collections-Tests/BagTest.class.st
+++ b/src/Collections-Tests/BagTest.class.st
@@ -253,6 +253,7 @@ BagTest >> selectedNumber [
 
 { #category : #running }
 BagTest >> setUp [
+	super setUp.
 	empty := self speciesClass new.
 	nonEmpty := self speciesClass new
 		add: 13;

--- a/src/Collections-Tests/FloatArrayTest.class.st
+++ b/src/Collections-Tests/FloatArrayTest.class.st
@@ -307,15 +307,31 @@ FloatArrayTest >> secondIndex [
 
 { #category : #running }
 FloatArrayTest >> setUp [
-
-empty := FloatArray new.
-elementInNonEmpty := 7.0.
-nonEmpty5ElementsNoDuplicate := (FloatArray new:5)  at: 1 put: 1.5 ; at: 2 put: 2.5 ; at: 3 put: elementInNonEmpty  ; at: 4 put: 4.5 ; at: 5 put: 5.5 ; yourself.
-elementNotIn := 999.0.
-elementTwiceIn := 2.3 .
-collectionWithEqualElements := (FloatArray new: 3)  at: 1 put: 2.0 ; at: 2 put: 2.0 ; at: 3 put: 3.5 ; yourself.
-nonEmpty1Element := ( FloatArray new: 1) at:1 put: 1.2 ; yourself.
-collectionWithSameAtEndAndBegining := (FloatArray new: 3)  at: 1 put: 2.0 ; at: 2 put: 1.0 ; at: 3 put: 2.0 copy ; yourself.
+	super setUp.
+	empty := FloatArray new.
+	elementInNonEmpty := 7.0.
+	nonEmpty5ElementsNoDuplicate := (FloatArray new: 5)
+		at: 1 put: 1.5;
+		at: 2 put: 2.5;
+		at: 3 put: elementInNonEmpty;
+		at: 4 put: 4.5;
+		at: 5 put: 5.5;
+		yourself.
+	elementNotIn := 999.0.
+	elementTwiceIn := 2.3.
+	collectionWithEqualElements := (FloatArray new: 3)
+		at: 1 put: 2.0;
+		at: 2 put: 2.0;
+		at: 3 put: 3.5;
+		yourself.
+	nonEmpty1Element := (FloatArray new: 1)
+		at: 1 put: 1.2;
+		yourself.
+	collectionWithSameAtEndAndBegining := (FloatArray new: 3)
+		at: 1 put: 2.0;
+		at: 2 put: 1.0;
+		at: 3 put: 2.0 copy;
+		yourself
 ]
 
 { #category : #requirements }

--- a/src/Collections-Tests/HeapTest.class.st
+++ b/src/Collections-Tests/HeapTest.class.st
@@ -420,6 +420,7 @@ HeapTest >> secondIndex [
 
 { #category : #running }
 HeapTest >> setUp [
+	super setUp.
 	element := 33.
 	elementNotIn := 666.
 	elementTwiceIn := 3.

--- a/src/Collections-Tests/IntervalTest.class.st
+++ b/src/Collections-Tests/IntervalTest.class.st
@@ -264,7 +264,7 @@ IntervalTest >> secondCollection [
 
 { #category : #running }
 IntervalTest >> setUp [
-
+	super setUp.
 	empty := (1 to: 0).
 	one := (1 to:1).
 	nonEmpty := -5 to: 10 by: 3.

--- a/src/Collections-Tests/MatrixTest.class.st
+++ b/src/Collections-Tests/MatrixTest.class.st
@@ -15,6 +15,7 @@ Class {
 
 { #category : #running }
 MatrixTest >> setUp [
+	super setUp.
 	matrix1 := Matrix new: 2.
 	matrix1 at:1 at:1 put: 1.
 	matrix1 at:1 at:2 put: 3.

--- a/src/Collections-Tests/OrderedCollectionTest.class.st
+++ b/src/Collections-Tests/OrderedCollectionTest.class.st
@@ -448,7 +448,7 @@ OrderedCollectionTest >> selectorToAccessValuePutIn [
 { #category : #running }
 OrderedCollectionTest >> setUp [
 
-	
+	super setUp.
 	nonEmpty := OrderedCollection new  add: self valuePutIn; add: self elementTwiceIn; add: self elementTwiceIn; yourself.
 	empty := OrderedCollection new. 
 	elementNotIn := 99.

--- a/src/Collections-Tests/SetTest.class.st
+++ b/src/Collections-Tests/SetTest.class.st
@@ -215,6 +215,7 @@ SetTest >> selectedNumber [
 
 { #category : #running }
 SetTest >> setUp [
+	super setUp.
 	empty := self classToBeTested  new.
 	full := self classToBeTested  with: 1 with: 2 with: 3 with: 4.
 	collectionIncluded := self classToBeTested  with: 2 with: 3 .

--- a/src/Collections-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Tests/SortedCollectionTest.class.st
@@ -352,7 +352,7 @@ SortedCollectionTest >> result [
 
 { #category : #running }
 SortedCollectionTest >> setUp [
-
+	super setUp.
 	nonEmpty := SortedCollection new.
 	elementExistsTwice := 12332312321.
 	nonEmpty add: 2.

--- a/src/Collections-Tests/StackTest.class.st
+++ b/src/Collections-Tests/StackTest.class.st
@@ -30,7 +30,7 @@ StackTest >> nonEmpty [
 
 { #category : #running }
 StackTest >> setUp [
-
+	super setUp.
 	empty := Stack new.
 	nonEmpty := Stack new.
 	nonEmpty push: 1.

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -331,6 +331,7 @@ StringTest >> secondIndex [
 
 { #category : #running }
 StringTest >> setUp [
+	super setUp.
 	string := 'Hi, I am a String'.
 	emptyString := ''.
 	subcollection3ElementsSorted := 'bcd'.

--- a/src/Collections-Tests/SymbolTest.class.st
+++ b/src/Collections-Tests/SymbolTest.class.st
@@ -248,6 +248,7 @@ SymbolTest >> secondCollection [
 
 { #category : #running }
 SymbolTest >> setUp [
+	super setUp.
 	emptySymbol := #''.
 	collectionSize4 := #abcd.
 	collection1Element := #a.

--- a/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/CopyVisitorTest.class.st
@@ -23,6 +23,7 @@ CopyVisitorTest >> createFile: aString [
 
 { #category : #running }
 CopyVisitorTest >> setUp [
+	super setUp.
 	source := FileSystem memory.
 	dest := FileSystem memory.
 	

--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -23,7 +23,7 @@ Class {
 
 { #category : #running }
 FreeTypeCacheTest >> setUp [
-
+	super setUp.
 	cache := FreeTypeCache new.
 	font1 := FreeTypeFont basicNew.
 	font2 := FreeTypeFont basicNew.

--- a/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
+++ b/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
@@ -10,6 +10,7 @@ Class {
 
 { #category : #running }
 LazyTabGroupTest >> setUp [
+	super setUp.
 	tabs := LazyTabGroupMorph new.
 	tabs addLazyPage: (PanelMorph new fillStyle: (SolidFillStyle color: Color red)) label: 'one'.
 	tabs addLazyPage: (PanelMorph new fillStyle: (SolidFillStyle color: Color yellow)) label: (GLMLabelBrick new text: 'two').

--- a/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
@@ -33,7 +33,7 @@ SendsDeprecatedMethodToGlobalRuleTest >> nonDeprecatedMethodName [
 { #category : #running }
 SendsDeprecatedMethodToGlobalRuleTest >> setUp [
 	| deprClass |
-	
+	super setUp.
 	deprClass := Object newAnonymousSubclass. 
 	Smalltalk globals at: self globalName put: deprClass new.
 	

--- a/src/Kernel-Tests/ClassTest.class.st
+++ b/src/Kernel-Tests/ClassTest.class.st
@@ -49,6 +49,7 @@ ClassTest >> referencingMethod3 [
 
 { #category : #running }
 ClassTest >> setUp [
+	super setUp.
 	className := #TUTU.
 	self deleteClass.
 	Object subclass: className

--- a/src/Kernel-Tests/DateAndTimeEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeEpochTest.class.st
@@ -14,7 +14,7 @@ My fixtures are:
 aDateAndTime = January 01, 1901 midnight (the start of the Squeak epoch) with localTimeZone = Grenwhich Meridian (local offset = 0 hours)
 aDuration = 1 day, 2 hours, 3, minutes, 4 seconds and 5 nano seconds.
 aTimeZone =  'Epoch Test Time Zone', 'ETZ' , offset: 12 hours, 15 minutes. 
-" 
+"
 Class {
 	#name : #DateAndTimeEpochTest,
 	#superclass : #TestCase,

--- a/src/Kernel-Tests/ScheduleTest.class.st
+++ b/src/Kernel-Tests/ScheduleTest.class.st
@@ -39,6 +39,7 @@ ScheduleTest >> setUp [
 	The duration of each occurence of the event is not specified. 
 	Nor are any other attributes such as name"
 
+	super setUp.
 	restoredTimeZone := DateAndTime localTimeZone.
 	DateAndTime localTimeZone: (TimeZone timeZones detect: [:tz | tz abbreviation = 'GMT']).
 

--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -11,6 +11,7 @@ Class {
 BuilderManifestTest >> setUp [
 	
 	| cl |
+	super setUp.
 	cl := Smalltalk globals at: #ManifestManifestResourcesTests ifAbsent: [ nil ].
 	cl
 		ifNotNil: [ 

--- a/src/Morphic-Tests/CircleMorphTest.class.st
+++ b/src/Morphic-Tests/CircleMorphTest.class.st
@@ -12,5 +12,6 @@ Class {
 
 { #category : #running }
 CircleMorphTest >> setUp [
+	super setUp.
 	morph := CircleMorph new
 ]

--- a/src/Morphic-Tests/MorphTest.class.st
+++ b/src/Morphic-Tests/MorphTest.class.st
@@ -16,6 +16,7 @@ Class {
 
 { #category : #running }
 MorphTest >> setUp [
+	super setUp.
 	morph := Morph new
 ]
 

--- a/src/Morphic-Tests/MorphicEventHandlerTest.class.st
+++ b/src/Morphic-Tests/MorphicEventHandlerTest.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #running }
 MorphicEventHandlerTest >> setUp [
-
+	super setUp.
 	morph := Morph new.
 	morph eventHandler: MorphicEventHandler new
 ]

--- a/src/Morphic-Tests/MorphicUIBugTest.class.st
+++ b/src/Morphic-Tests/MorphicUIBugTest.class.st
@@ -24,7 +24,7 @@ Class {
 { #category : #running }
 MorphicUIBugTest >> setUp [
 	"default. tests will add morphs to list. Teardown will delete."
-
+	super setUp.
 	cases := #()
 ]
 

--- a/src/Nautilus-Tests/AbstractNautilusUITest.class.st
+++ b/src/Nautilus-Tests/AbstractNautilusUITest.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #running }
 AbstractNautilusUITest >> setUp [
 	"Setting up code for AbstractNautilusUITest"
-
+	super setUp.
 	model := AbstractNautilusUI new.
 ]
 

--- a/src/Nautilus-Tests/SortHierarchicallyTests.class.st
+++ b/src/Nautilus-Tests/SortHierarchicallyTests.class.st
@@ -22,7 +22,7 @@ SortHierarchicallyTests >> nodes: nodes shouldBe: correctNodes [
 
 { #category : #running }
 SortHierarchicallyTests >> setUp [
-
+	super setUp.
 	completeTree := {String . ByteString . Symbol . ByteSymbol . WideSymbol . WideString} .
 	partialTree := {String . ByteString . ByteSymbol . WideString}.
 	unrelatedClasses :=  {ArrayedCollection . BlockClosure . Class  . Morph . Point}.

--- a/src/NautilusRefactoring/ChangesBrowserTest.class.st
+++ b/src/NautilusRefactoring/ChangesBrowserTest.class.st
@@ -12,6 +12,7 @@ Class {
 
 { #category : #running }
 ChangesBrowserTest >> setUp [
+	super setUp.
 	browser := ChangesBrowser new
 ]
 

--- a/src/Network-Tests/Base64MimeConverterTest.class.st
+++ b/src/Network-Tests/Base64MimeConverterTest.class.st
@@ -15,6 +15,7 @@ Class {
 
 { #category : #running }
 Base64MimeConverterTest >> setUp [
+	super setUp.
 	message := 'Hi There!' readStream.
 ]
 

--- a/src/NewValueHolder/CollectionValueHolderTest.class.st
+++ b/src/NewValueHolder/CollectionValueHolderTest.class.st
@@ -11,6 +11,7 @@ Class {
 
 { #category : #running }
 CollectionValueHolderTest >> setUp [
+	super setUp.
 	empty := OrderedCollection new asValueHolder.
 	withItems := #(1 2 3) asOrderedCollection asValueHolder.
 	fired := false

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -142,7 +142,7 @@ RPackageTestCase >> runCase [
 
 { #category : #running }
 RPackageTestCase >> setUp [
-	
+	super setUp.
 	createdClasses := OrderedCollection new.
 	createdPackages := OrderedCollection new.
 	createdCategories := Set new.

--- a/src/Reflectivity-Tests/ASTCacheResetTest.class.st
+++ b/src/Reflectivity-Tests/ASTCacheResetTest.class.st
@@ -22,6 +22,7 @@ ASTCacheResetTest >> increment [
 
 { #category : #running }
 ASTCacheResetTest >> setUp [
+	super setUp.
 	cache := ASTCache default copy.
 	counter := 0.
 	link := MetaLink new

--- a/src/SUnit-Core/HashAndEqualsTestCase.class.st
+++ b/src/SUnit-Core/HashAndEqualsTestCase.class.st
@@ -15,6 +15,7 @@ Class {
 { #category : #running }
 HashAndEqualsTestCase >> setUp [
 	"subclasses will add their prototypes into this collection"
+	super setUp.
 	prototypes := OrderedCollection new 
 ]
 

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -2,7 +2,7 @@
 This is a Composite of Tests, either TestCases or other TestSuites. The top-level protocol is #run.  This creates aTestResult and sends
 	self run: aTestResult.
 then ensures that any TestResources made available during the run are reset.  These, and the dependencies protocol, are common between this and TestCase.
-" 
+"
 Class {
 	#name : #TestSuite,
 	#superclass : #Model,

--- a/src/Shout-Tests/SHStyleElementTest.class.st
+++ b/src/Shout-Tests/SHStyleElementTest.class.st
@@ -12,6 +12,7 @@ Class {
 
 { #category : #running }
 SHStyleElementTest >> setUp [
+	super setUp.
 	element := SHStyleElement withTokens: #(#self #super #true #false).
 ]
 

--- a/src/System-History-Tests/HistoryIteratorTest.class.st
+++ b/src/System-History-Tests/HistoryIteratorTest.class.st
@@ -9,6 +9,7 @@ Class {
 
 { #category : #running }
 HistoryIteratorTest >> setUp [
+	super setUp.
 	historyList := HistoryIterator new.
 ]
 

--- a/src/Tests/ChangeSetClassChangesTest.class.st
+++ b/src/Tests/ChangeSetClassChangesTest.class.st
@@ -52,6 +52,7 @@ ChangeSetClassChangesTest >> isDefinition: firstString equivalentTo: secondStrin
 
 { #category : #running }
 ChangeSetClassChangesTest >> setUp [
+	super setUp.
 	className := #TUTU.
 	renamedName := #RenamedTUTU.
 	self deleteClass.

--- a/src/Tests/ClassRenameFixTest.class.st
+++ b/src/Tests/ClassRenameFixTest.class.st
@@ -59,7 +59,7 @@ ClassRenameFixTest >> renameClassUsing: aBlock [
 
 { #category : #running }
 ClassRenameFixTest >> setUp [
-
+	super setUp.
 	previousChangeSet := ChangeSet current.
 	testsChangeSet := ChangeSet new.
 	ChangeSet newChanges: testsChangeSet.

--- a/src/Tests/CommandLineArgumentsTest.class.st
+++ b/src/Tests/CommandLineArgumentsTest.class.st
@@ -22,6 +22,7 @@ CommandLineArgumentsTest >> parameters [
 
 { #category : #running }
 CommandLineArgumentsTest >> setUp [
+	super setUp.
 	commandLine := CommandLineArguments withArguments: self parameters.
 ]
 

--- a/src/Tests/TraitsResource.class.st
+++ b/src/Tests/TraitsResource.class.st
@@ -188,6 +188,7 @@ TraitsResource >> setUp [
 	classes - and that especially the order of the definitions matters."
 	"SetUpCount := SetUpCount + 1."
 
+	super setUp.
 	dirty := false.
 	SystemAnnouncer uniqueInstance suspendAllWhile: 
 			[self t1: (self createTraitNamed: #T1

--- a/src/Tools-Test/AndreasSystemProfilerTest.class.st
+++ b/src/Tools-Test/AndreasSystemProfilerTest.class.st
@@ -12,6 +12,7 @@ Class {
 
 { #category : #running }
 AndreasSystemProfilerTest >> setUp [
+	super setUp.
 	tally := QSystemTally new.
 	tally class: self class method: self class >> #testPrintingTally	
 	"tally class: Object method: Object >> #printString."


### PR DESCRIPTION
- call super setUp in AbstractNautilusUITest
- call super setUp in AndreasSystemProfilerTest
- call super setUp in ArrayTest
- call super setUp in AssociationTest
- call super setUp in ASTCacheResetTest
- call super setUp in BagTest
- call super setUp in Base64MimeConverterTest
- call super setUp in BuilderManifestTest
- call super setUp in CairoUTF8ConverterTest
- call super setUp in ChangesBrowserTest
- call super setUp in ChangeSetClassChangesTest
- call super setUp in ClassRenameFixTest
- call super setUp in ClassTest
- call super setUp in TraitsResource
- call super setUp in CollectionValueHolderTest
- call super setUp in CommandLineArgumentsTest
- call super setUp in CopyVisitorTest
- call super setUp in FreeTypeCacheTest
- call super setUp in HashAndEqualsTestCase
- call super setUp in HeapTest
- call super setUp in SortedCollectionTest
- call super setUp in SortHierarchicallyTest
- call super setUp in SetTest
- call super setUp in StackTest
- call super setUp in StringTest
- call super setUp in SymbolTest
- call super setUp in FloatArrayTest
- call super setUp in SHStyleElementTest
- call super setUp in HistoryIteratorTest
- call super setUp in IntervalTest
- call super setUp in OrderedCollectionTest
- call super setUp in LazyTabGroupTest
- call super setUp in MatrixTest
- call super setUp in RPackageTestCase
- call super setUp in ScheduleTest
- call super setUp in SendsDeprecatedMethodToGlobalRuleTest
- call super setUp in MorphTest
- call super setUp in MorphicEventHandlerTest
- call super setUp in MorphicAdapterTest
- call super setUp in MorphicUIBugTest
- call super setUp in CircleMorphTest