### PR TITLE
20860-Cursor-webLink-is-initialized-wrongly-and-transparent

### DIFF
--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -61,7 +61,7 @@ BaselineOfDisplay >> postload: loader package: packageSpec [
 	display beDisplay.
 
 	Cursor classPool at: #CurrentCursor put: Cursor new.
-	Cursor classPool at: #WebLinkCursor put: Cursor new.
+	Cursor webLink. "set the webLink cursor shape"
 					
 	Cursor initialize.
 	DisplayScreen initialize.


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/20860set weblink cursor shape