### PR TITLE
20684-Categorizer-should-categorize-reset-methods-in-initialization-protocol

### DIFF
--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -83,6 +83,7 @@ MethodClassifier class >> buildPrefixMapping [
 		at: 'remove' put: 'removing';
 		at: 'render' put: 'rendering';
 		at: 'requires' put: 'testing';
+		at: 'reset' put: 'initialization';
 		at: 'set' put: 'initialization';
 		at: 'should' put: 'asserting';
 		at: 'shouldnt' put: 'asserting';


### PR DESCRIPTION
Categorizer should categorize #reset methods in 'initialization' protocol.

ML subject: http://forum.world.st/Convention-for-quot-reset-quot-methods-td5019493.html

Resolve case 20684 : Categorizer should categorize #reset methods in 'initialization' protocol