### PR TITLE
20796-String-should-understand-readStreamDowriteStreamDo-to-be-polymorph-with-FileReference

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -1607,6 +1607,15 @@ SequenceableCollection >> readStream [
 	^ ReadStream on: self
 ]
 
+{ #category : #streaming }
+SequenceableCollection >> readStreamDo: aBlock [
+	"Evaluates the argument with the read stream of the collection. Answers the result."
+	
+	"#(3 4 5) readStreamDo: [ :stream | stream contents ] >>> #(3 4 5)"
+
+	^ aBlock value: self readStream
+]
+
 { #category : #enumerating }
 SequenceableCollection >> reduce: aBlock [
 	"Fold the result of the receiver into aBlock. The argument aBlock must take two or more arguments. It applies the argument, binaryBlock cumulatively to the elements of the receiver. For sequenceable collections the elements will be used in order, for unordered collections the order is unspecified."
@@ -2044,4 +2053,13 @@ SequenceableCollection >> withIndexDo: elementAndIndexBlock [
 { #category : #converting }
 SequenceableCollection >> writeStream [
 	^ WriteStream on: self
+]
+
+{ #category : #streaming }
+SequenceableCollection >> writeStreamDo: aBlock [
+	"Evaluates the argument with the write stream of the collection. Answers the result."
+	
+	"#() writeStreamDo: [ :stream | stream nextPut: '4'; space; nextPutAll: '34'. stream contents ] >>> {'4'. Character space. $3. $4}"
+
+	^ aBlock value: self writeStream
 ]

--- a/src/Collections-Tests/StringTest.class.st
+++ b/src/Collections-Tests/StringTest.class.st
@@ -1673,6 +1673,11 @@ StringTest >> testReadFrom [
 		equals: 'this '' is embedded'
 ]
 
+{ #category : #'tests - streaming' }
+StringTest >> testReadStreamDo [
+	string readStreamDo: [ :stream | self assert: stream contents equals: string ]
+]
+
 { #category : #'tests - converting' }
 StringTest >> testRepeat [
 
@@ -2038,6 +2043,15 @@ StringTest >> testWriteStreamConvertsToWideString [
 	ws := newString writeStream.
 	oldWideString do: [:each | ws nextPut: each].
 	self assert: (newString = oldWideString).
+]
+
+{ #category : #'tests - streaming' }
+StringTest >> testWriteStreamDo [
+	emptyString
+		writeStreamDo: [ :stream | 
+			stream nextPutAll: string.
+			self assert: stream contents equals: string ].
+	self assert: (emptyString writeStreamDo: [ :stream | true ])
 ]
 
 { #category : #'tests - lines' }


### PR DESCRIPTION
Add #readStreamDo: and #writeStreamDo: to SequeanceableCollection with a comment and a test in StringTest

Case 20796 : String should understand #readStreamDo:/#writeStreamDo: to be polymorph with FileReference