### PR TITLE
20864-add-examples-to-SequenceableCollectionaggregateRuns

### DIFF
--- a/src/Deprecated70/SequenceableCollection.extension.st
+++ b/src/Deprecated70/SequenceableCollection.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SequenceableCollection }
+
+{ #category : #'*Deprecated70' }
+SequenceableCollection >> aggregateRuns: aBlock [
+
+	self
+		deprecated: 'Please use #groupByRuns: instead'
+		transformWith: '`@receiver aggregateRuns: `@statements' -> '`@receiver groupByRuns: `@statements'.
+		
+	^ self groupByRuns: aBlock
+]

--- a/src/Tool-Diff/JoinSection.class.st
+++ b/src/Tool-Diff/JoinSection.class.st
@@ -154,7 +154,7 @@ JoinSection >> createHighlightsFrom: srcPara to: dstPara [
 		ifFalse: [ ^ self ].
 	s := self src highlights.
 	d := self dst highlights.
-	diffs := (InlineTextDiffBuilder from: srcText to: dstText) buildPatchSequence aggregateRuns: [ :e | e key ].
+	diffs := (InlineTextDiffBuilder from: srcText to: dstText) buildPatchSequence groupByRuns: [ :e | e key ].
 	diffs
 		do: [ :c | 
 			c first key = #match

--- a/src/Tool-Diff/SequenceableCollection.extension.st
+++ b/src/Tool-Diff/SequenceableCollection.extension.st
@@ -7,10 +7,10 @@ SequenceableCollection >> groupByRuns: aBlock [
 	(#(1 2 3 4 4 1 2 3 5 6 ) groupByRuns:  [ :each | each = 4]) 
 		>>> #(#(1 2 3) #(4 4) #(1 2 3 5 6)).
 
-	(#(1 2 3 4 1 2 3 4 5 6 ) aggregateRuns:  [ :each | each = 4]) 
+	(#(1 2 3 4 1 2 3 4 5 6 ) groupByRuns:  [ :each | each = 4]) 
 		>>> #(#(1 2 3) #(4) #(1 2 3) #(4) #(5 6)).
 
-	((1 to: 12) aggregateRuns:  [ :each | (each \\ 3) = 0]) 
+	((1 to: 12) groupByRuns:  [ :each | (each \\ 3) = 0]) 
 		>>> #(#(1 2) #(3) #(4 5) #(6) #(7 8) #(9) #(10 11) #(12)).
 	"
 

--- a/src/Tool-Diff/SequenceableCollection.extension.st
+++ b/src/Tool-Diff/SequenceableCollection.extension.st
@@ -1,12 +1,18 @@
 Extension { #name : #SequenceableCollection }
 
 { #category : #'*Tool-Diff' }
-SequenceableCollection >> aggregateRuns: aBlock [
-	"Answer a new collection of the same species as the
-	receiver with elements being collections (of the receiver
-	species) containing those elements of the receiver
-	for which the given block consecutively evaluates to
-	the same object."
+SequenceableCollection >> groupByRuns: aBlock [
+	"Answer a new collection of the same species as the receiver with elements being collections (of the receiver species) containing those elements of the receiver for which the given block consecutively evaluates to the same object.
+	
+	(#(1 2 3 4 4 1 2 3 5 6 ) groupByRuns:  [ :each | each = 4]) 
+		>>> #(#(1 2 3) #(4 4) #(1 2 3 5 6)).
+
+	(#(1 2 3 4 1 2 3 4 5 6 ) aggregateRuns:  [ :each | each = 4]) 
+		>>> #(#(1 2 3) #(4) #(1 2 3) #(4) #(5 6)).
+
+	((1 to: 12) aggregateRuns:  [ :each | (each \\ 3) = 0]) 
+		>>> #(#(1 2) #(3) #(4 5) #(6) #(7 8) #(9) #(10 11) #(12)).
+	"
 
 	| str eStr r|
 	str := Array new writeStream.

--- a/src/Tool-Diff/SequenceableCollection.extension.st
+++ b/src/Tool-Diff/SequenceableCollection.extension.st
@@ -4,13 +4,13 @@ Extension { #name : #SequenceableCollection }
 SequenceableCollection >> groupByRuns: aBlock [
 	"Answer a new collection of the same species as the receiver with elements being collections (of the receiver species) containing those elements of the receiver for which the given block consecutively evaluates to the same object.
 	
-	(#(1 2 3 4 4 1 2 3 5 6 ) groupByRuns:  [ :each | each = 4]) 
+	(#(1 2 3 4 4 1 2 3 5 6 ) groupByRuns: [ :each | each = 4]) 
 		>>> #(#(1 2 3) #(4 4) #(1 2 3 5 6)).
 
-	(#(1 2 3 4 1 2 3 4 5 6 ) groupByRuns:  [ :each | each = 4]) 
+	(#(1 2 3 4 1 2 3 4 5 6 ) groupByRuns: [ :each | each = 4]) 
 		>>> #(#(1 2 3) #(4) #(1 2 3) #(4) #(5 6)).
 
-	((1 to: 12) groupByRuns:  [ :each | (each \\ 3) = 0]) 
+	((1 to: 12) groupByRuns: [ :each | (each \\ 3) = 0]) 
 		>>> #(#(1 2) #(3) #(4 5) #(6) #(7 8) #(9) #(10 11) #(12)).
 	"
 


### PR DESCRIPTION
rename aggregateRuns: to groupByRuns: and add some examples. Deprecate the coriginal methodhttps://pharo.fogbugz.com/f/cases/20864/add-examples-to-SequenceableCollection-aggregateRuns