### PR TITLE
20879-ZnCrPortableWriteStreamnextPut-swallows-LFs

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
@@ -32,16 +32,16 @@ ZnCrPortableWriteStream >> newLine [
 
 { #category : #accessing }
 ZnCrPortableWriteStream >> nextPut: aCharacter [
+	"Write aCharacter to the receivers stream.
+	Convert all line end combinations, i.e cr, lf, crlf, to the platform convention"
 
-	(String crlf includes: aCharacter )
-		ifFalse: [ 
-			previous ifNotNil: [ self newLine ].
-			^ stream nextPut: aCharacter ].
+	(aCharacter = Character lf and: [ previous = Character cr ]) ifFalse: [
+		(String crlf includes: aCharacter) ifTrue: 
+			[ self newLine ]
+		ifFalse:
+			[ stream nextPut: aCharacter ] ].
+	previous := aCharacter.
 
-	previous = Character cr
-		ifTrue: [ self newLine ].
-	aCharacter ~= Character lf
-		ifTrue: [ previous := aCharacter ].
 ]
 
 { #category : #accessing }

--- a/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCrPortableWriteStream.class.st
@@ -11,6 +11,8 @@ Class {
 	#superclass : #WriteStream,
 	#instVars : [
 		'stream',
+		'cr',
+		'lf',
 		'previous'
 	],
 	#category : #'Zinc-Character-Encoding-Core'
@@ -20,8 +22,17 @@ Class {
 ZnCrPortableWriteStream class >> on: aStream [
 
 	^ self basicNew
+		initialize;
 		stream: aStream;
 		yourself
+]
+
+{ #category : #initialize }
+ZnCrPortableWriteStream >> initialize [
+
+	super initialize.
+	cr := Character cr.
+	lf := Character lf.
 ]
 
 { #category : #accessing }
@@ -35,8 +46,8 @@ ZnCrPortableWriteStream >> nextPut: aCharacter [
 	"Write aCharacter to the receivers stream.
 	Convert all line end combinations, i.e cr, lf, crlf, to the platform convention"
 
-	(aCharacter = Character lf and: [ previous = Character cr ]) ifFalse: [
-		(String crlf includes: aCharacter) ifTrue: 
+	(previous == cr and: [ aCharacter == lf ]) ifFalse: [
+		(aCharacter == cr or: [ aCharacter == lf ]) ifTrue: 
 			[ self newLine ]
 		ifFalse:
 			[ stream nextPut: aCharacter ] ].

--- a/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTests.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCrPortableWriteStreamTests.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #ZnCrPortableWriteStreamTests,
+	#superclass : #TestCase,
+	#category : #'Zinc-Character-Encoding-Tests'
+}
+
+{ #category : #tests }
+ZnCrPortableWriteStreamTests >> testNextPut [
+	"Ensure that the line ends are written correctly"
+
+	| expectedString stream crStream |
+
+	expectedString := 'a', OSPlatform current lineEnding, 'b'.
+	{ String cr.
+		String lf.
+		String crlf. } do: [ :lineEnd |
+			stream := String new writeStream.
+			crStream := ZnCrPortableWriteStream on: stream.
+			crStream
+				<< 'a';
+				<< lineEnd;
+				<< 'b'.
+			self assert: stream contents equals: expectedString ]
+]


### PR DESCRIPTION
20879 ZnCrPortableWriteStream>>nextPut: swallows LFs

- Fix ZnCrPortableWriteStream>>nextPut: so that Character lf is correctly written.
- Add ZnCrPortableWriteStreamTests to confirm fix.

Fogbugz: https://pharo.fogbugz.com/f/cases/20879