### PR TITLE
20876-Drag-and-drop-of-methods-is-broken

### DIFF
--- a/src/Nautilus/AbstractWidget.class.st
+++ b/src/Nautilus/AbstractWidget.class.st
@@ -58,6 +58,15 @@ AbstractWidget >> takeKeyboardFocus [
 	^ self subclassResponsibility
 ]
 
+{ #category : #'drag and drop' }
+AbstractWidget >> transferFor: passenger from: aMorph [
+
+	^ TransferPresenter new
+		transfer: passenger;
+		from: aMorph;
+		yourself
+]
+
 { #category : #updating }
 AbstractWidget >> update: aSymbol [
 

--- a/src/Spec-Core/AbstractWidgetPresenter.class.st
+++ b/src/Spec-Core/AbstractWidgetPresenter.class.st
@@ -309,7 +309,8 @@ AbstractWidgetPresenter >> wantDropBlock: aBlock [
 
 { #category : #'drag and drop' }
 AbstractWidgetPresenter >> wantsDroppedMorph: draggedMorph event: anEvent inMorph: source [
-
+	draggedMorph isTransferable ifFalse: [ ^false ].
+	
 	^wantDropBlock value cull: draggedMorph passenger cull: anEvent cull:source
 ]
 


### PR DESCRIPTION
Nautilus widgets should return TransferPresenter instead of TransferMorph because Nautilus uses data source of Spec component which supposed to work with presenters.
It fixes drag and drop in Nautilus.

AbstractWidgetPresenter fix in wants  drop check. It allow only #isTransferable draggedMorphs. It fixes general drag of windows over spec based fast tables .https://pharo.manuscript.com/f/cases/20876/Drag-and-drop-of-methods-is-broken