### PR TITLE
20823-sumNumbers-without-block-is-missing-for-collections

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1250,6 +1250,20 @@ Collection >> sum: aBlock [
 ]
 
 { #category : #'math functions' }
+Collection >> sumNumbers [
+	"This is implemented using a variant of the normal inject:into: pattern
+	that is specific to handling numbers. The receiver should include only numbers.
+	
+	Different from the sum implementation, the default value is zero. While sum is 
+	more general, sumNumbers is meant to support the most often encountered use case of
+	dealing with numbers."
+
+	^ self 
+		inject: 0 
+		into: [ :sum :each |  sum + each ]
+]
+
+{ #category : #'math functions' }
 Collection >> sumNumbers: aBlock [
 	"This is implemented using a variant of the normal inject:into: pattern
 	that is specific to handling numbers. aBlock is expected to return a number

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -792,7 +792,7 @@ ArrayTest >> testPrinting [
 ]
 
 { #category : #'tests - arithmetic' }
-ArrayTest >> testSumNumbersWithoutArgument [
+ArrayTest >> testSumNumberItemsWithoutBlock [
 	
 	self assert: #() sumNumbers equals: 0.
 	

--- a/src/Collections-Tests/ArrayTest.class.st
+++ b/src/Collections-Tests/ArrayTest.class.st
@@ -791,6 +791,14 @@ ArrayTest >> testPrinting [
 
 ]
 
+{ #category : #'tests - arithmetic' }
+ArrayTest >> testSumNumbersWithoutArgument [
+	
+	self assert: #() sumNumbers equals: 0.
+	
+	self assert: #(1 2 3) sumNumbers equals: 6
+]
+
 { #category : #requirements }
 ArrayTest >> unsortedCollection [
 	^unsortedCollection .


### PR DESCRIPTION
sumNumbers is added as missing handy function to sum array items which are numbers