### PR TITLE
20694-Do-we-need-Objecthead-and-Objecttail-

### DIFF
--- a/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
+++ b/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
@@ -249,11 +249,11 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 	aClass := classFactory newClass.
 	aClass compile: 'fortyTwo ^42'.
 
-	headBeforeRecompiling := monitor head.
+	headBeforeRecompiling := monitor log head.
 
 	aClass compile: 'fortyTwo ^42'.
 	
-	self assert: monitor head == headBeforeRecompiling
+	self assert: monitor log head == headBeforeRecompiling
 ]
 
 { #category : #tests }

--- a/src/Morphic-Base/Association.extension.st
+++ b/src/Morphic-Base/Association.extension.st
@@ -1,17 +1,17 @@
 Extension { #name : #Association }
 
 { #category : #'*Morphic-Base' }
-Association >> head [
+Association >> treeNodeHead [
 
 	^ (key isKindOf: Association)
-		ifTrue: [ key head ]
+		ifTrue: [ key treeNodeHead ]
 		ifFalse: [ key ]
 ]
 
 { #category : #'*Morphic-Base' }
-Association >> tail [
+Association >> treeNodeTail [
 
 	^ (key isKindOf: Association)
-		ifTrue: [ key tail -> value ]
+		ifTrue: [ key treeNodeTail -> value ]
 		ifFalse: [ value ]
 ]

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -93,12 +93,6 @@ Object >> hasModelYellowButtonMenuItems [
 ]
 
 { #category : #'*Morphic-Base' }
-Object >> head [
-
-	^ self
-]
-
-{ #category : #'*Morphic-Base' }
 Object >> iconOrThumbnailOfSize: aNumberOrPoint [ 
 	"Answer an appropiate form to represent the receiver"
 	^ nil
@@ -108,12 +102,6 @@ Object >> iconOrThumbnailOfSize: aNumberOrPoint [
 Object >> isTransferable [
 
 	^ false
-]
-
-{ #category : #'*Morphic-Base' }
-Object >> tail [
-
-	^ nil
 ]
 
 { #category : #'*Morphic-Base' }
@@ -142,6 +130,18 @@ Object class >> taskbarIconName [
 Object >> transferFor: passenger from: aMorph [
 
 	^ TransferMorph withPassenger: passenger from: aMorph
+]
+
+{ #category : #'*Morphic-Base' }
+Object >> treeNodeHead [
+
+	^ self
+]
+
+{ #category : #'*Morphic-Base' }
+Object >> treeNodeTail [
+
+	^ nil
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -442,14 +442,14 @@ MorphTreeNodeMorph >> expandItemPath: anArray [
 MorphTreeNodeMorph >> expandPath: anAssociation [
 
 	anAssociation ifNil: [ ^ false ].
-	^ anAssociation head = self complexContents withoutListWrapper
+	^ anAssociation treeNodeHead = self complexContents withoutListWrapper
 		ifFalse: [ false ]
 		ifTrue: [
-			anAssociation tail ifNil: [ ^ true ].
+			anAssociation treeNodeTail ifNil: [ ^ true ].
 			(self isExpanded not and: [ self canExpand ]) ifTrue: [
 				self toggleExpandedState.
 				container innerWidgetChanged ].
-			self children anySatisfy: [:child | child expandPath: anAssociation tail ]]
+			self children anySatisfy: [:child | child expandPath: anAssociation treeNodeTail ]]
 ]
 
 { #category : #accessing }
@@ -674,11 +674,11 @@ MorphTreeNodeMorph >> lineColor [
 MorphTreeNodeMorph >> matchPath: anAssociation [
 
 	anAssociation ifNil: [ ^ nil ].
-	^ anAssociation head = self complexContents withoutListWrapper
+	^ anAssociation treeNodeHead = self complexContents withoutListWrapper
 		ifFalse: [ nil ]
 		ifTrue: [ | matchingChildren |
-			anAssociation tail ifNil: [ ^ { self } ].
-			matchingChildren := self children collect: [:child | child matchPath: anAssociation tail ].
+			anAssociation treeNodeTail ifNil: [ ^ { self } ].
+			matchingChildren := self children collect: [:child | child matchPath: anAssociation treeNodeTail ].
 			^ matchingChildren select: [ :e | e notNil ] ]
 ]
 


### PR DESCRIPTION
Renamed the #head and #tail methods injected by the Morphic-Base package into the Object and Association class to #treeNodeHead and #treeNodeTail.
Reflected the change to  the code of the MorphTreeNodeMorph class that was using these two methods.