### PR TITLE
Re-proposing Andrew's code modifying SUnit 

### DIFF
--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -65,6 +65,7 @@ TestAsserter class >> suiteClass [
 
 { #category : #asserting }
 TestAsserter >> assert: aBoolean [
+	assertionMade := true.
 	aBoolean ifFalse:
 		[self logFailure: 'Assertion failed'.
 		self defaultTestFailure signal: 'Assertion failed'].
@@ -79,6 +80,7 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 
 { #category : #asserting }
 TestAsserter >> assert: aBooleanOrBlock description: aStringOrBlock [
+	assertionMade := true.
 	aBooleanOrBlock value ifFalse: [
 		| aString |
 		aString := aStringOrBlock value.
@@ -241,6 +243,11 @@ TestAsserter >> defaultTestError [
 TestAsserter >> defaultTestFailure [
 
 	^ self classForTestResult failure
+]
+
+{ #category : #asserting }
+TestAsserter >> deliberatelyDidNotAssert [
+	self assert: true
 ]
 
 { #category : #asserting }
@@ -464,6 +471,17 @@ TestAsserter >> skip [
 TestAsserter >> skip: aComment [
 	"Don't run this test, and don't mark it as failure"
 	TestSkip signal: aComment
+]
+
+{ #category : #asserting }
+TestAsserter >> smokeTest [
+	"A smoke test is a test that make sure that the basic functions complete without error but does not make any assertion.
+	
+	This message should be sent at the beginning of smoke test cases.
+	Example: 
+		(ClassTestCase>>#testNew) browse
+	"
+	self deliberatelyDidNotAssert
 ]
 
 { #category : #private }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -24,7 +24,7 @@ Class {
 	#category : #'SUnit-Core-Kernel'
 }
 
-{ #category : #adding }
+{ #category : #'building suites' }
 TestCase class >> addTestsFor: classNameString toSuite: suite [
 	| cls |
 	cls := Smalltalk globals at: classNameString ifAbsent: [ ^ suite ].
@@ -38,21 +38,21 @@ TestCase class >> addTestsFor: classNameString toSuite: suite [
 		ifFalse: [ cls addToSuiteFromSelectors: suite ]
 ]
 
-{ #category : #adding }
+{ #category : #'building suites' }
 TestCase class >> addToSuite: suite fromMethods: testMethods [ 
 	testMethods do:  [ :selector | 
 			suite addTest: (self selector: selector) ].
 	^suite
 ]
 
-{ #category : #adding }
+{ #category : #'building suites' }
 TestCase class >> addToSuiteFromSelectors: suite [
 	^self addToSuite: suite fromMethods: (self shouldInheritSelectors
 		ifTrue: [ self allTestSelectors ]
 		ifFalse: [self testSelectors ])
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> allTestSelectors [
 	| answer pivotClass lookupRoot |
 	answer := Set withAll: self testSelectors.
@@ -67,17 +67,17 @@ TestCase class >> allTestSelectors [
 	^answer asSortedCollection asOrderedCollection
 ]
 
-{ #category : #accessing }
+{ #category : #events }
 TestCase class >> announcer [ 
 	^ self announcers at: self ifAbsentPut: [ Announcer new ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #events }
 TestCase class >> announcers [
 	^ Announcers ifNil: [ Announcers := Dictionary new ] 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> assertionlessTestsShouldFail [
 	"By default, a test that makes no assertion is regarded as not failing.  This behaviour can be changed
 	setting the value of the class inst. var.  If a single method makes no assertions deliberatley, then
@@ -89,12 +89,12 @@ TestCase class >> assertionlessTestsShouldFail [
 	^ AssertionlessTestsShouldFail ifNil: [ AssertionlessTestsShouldFail := false ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> assertionlessTestsShouldFail: aBoolean [
 	AssertionlessTestsShouldFail := aBoolean
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #settings }
 TestCase class >> assertionlessTestsShouldFailSettingOn: aBuilder [
 	<systemsettings>
 	
@@ -105,7 +105,7 @@ TestCase class >> assertionlessTestsShouldFailSettingOn: aBuilder [
 		description: 'Whether tests without assertion should fail or not.'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'building suites' }
 TestCase class >> buildSuite [
 	| suite |
 	^self isAbstract
@@ -117,21 +117,21 @@ TestCase class >> buildSuite [
 		ifFalse: [self buildSuiteFromSelectors]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'building suites' }
 TestCase class >> buildSuiteFromAllSelectors [
 
 	^self buildSuiteFromMethods: self allTestSelectors
 			
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'building suites' }
 TestCase class >> buildSuiteFromLocalSelectors [
 
 	^self buildSuiteFromMethods: self testSelectors
 			
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'building suites' }
 TestCase class >> buildSuiteFromMethods: testMethods [
 
 	^testMethods
@@ -142,12 +142,12 @@ TestCase class >> buildSuiteFromMethods: testMethods [
 				yourself]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'building suites' }
 TestCase class >> buildSuiteFromSelectors [
 	^self buildSuiteFromMethods: self allTestSelectors
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> coverage [
 	"returns the coverage determined by a simple static analysis of test coverage 
 	made by the receiver on a class that is identified by the name of the receiver.
@@ -163,7 +163,7 @@ TestCase class >> coverage [
 	^ self coverageForClass: cls
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> coverageAsString [
 	| cov className |
 	cov := self coverage first asInteger. 
@@ -173,13 +173,13 @@ TestCase class >> coverageAsString [
 	^ self name asString, ' covers ', cov asString, '% of ', className.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> coverageForClass: cls [
 	"returns the test coverage of all the methods included inherited ones"
 	^ self coverageForClass: cls until: ProtoObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> coverageForClass: cls until: aRootClass [
 	"returns the test coverage of all the methods included inherited ones but stopping at aRootClass included"
 	
@@ -196,12 +196,12 @@ TestCase class >> coverageForClass: cls until: aRootClass [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> coveragePercentage [
 	^ self coverage first
 ]
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
 TestCase class >> debug: aSymbol [
 
 	^(self selector: aSymbol) debug
@@ -213,22 +213,22 @@ TestCase class >> defaultTimeLimit [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> defaultTimeLimit: aDuration [
 	DefaultTimeLimit := aDuration
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #settings }
 TestCase class >> defaultTimeLimitSecs [
 	^self defaultTimeLimit asMilliSeconds / 1000.0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #settings }
 TestCase class >> defaultTimeLimitSecs: aNumber [
 	self defaultTimeLimit: aNumber seconds
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #settings }
 TestCase class >> defaultTimeLimitSettingOn: aBuilder [
 	<systemsettings>
 	
@@ -239,7 +239,7 @@ TestCase class >> defaultTimeLimitSettingOn: aBuilder [
 		description: 'Detault time limit in seconds for test execution'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #history }
 TestCase class >> generateLastStoredRunMethod [
 
 	self shouldGenerateLastStoredRunMethod ifTrue: [
@@ -273,24 +273,24 @@ TestCase class >> hasTestSelectors [
 	
 ]
 
-{ #category : #accessing }
+{ #category : #history }
 TestCase class >> history [
 	^ history ifNil: [ history := self newTestDictionary ]
 ]
 
-{ #category : #accessing }
+{ #category : #history }
 TestCase class >> history: aDictionary [
 
 	history := aDictionary.
 	self historyAnnouncer announce: (TestSuiteEnded result: self)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> historyAnnouncer [
 	^ HistoryAnnouncer ifNil: [  HistoryAnnouncer := Announcer new ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : #'initialize - event' }
 TestCase class >> initialize [
 	super initialize.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
@@ -327,12 +327,12 @@ TestCase class >> isUsed [
 		ifFalse: [ true ]
 ]
 
-{ #category : #accessing }
+{ #category : #history }
 TestCase class >> lastRun [
 	^ self classForTestResult historyFor: self
 ]
 
-{ #category : #accessing }
+{ #category : #history }
 TestCase class >> lastRunMethodNamed: aSelector [
 	
 	^ String streamContents: [:str |
@@ -341,12 +341,12 @@ TestCase class >> lastRunMethodNamed: aSelector [
 
 ]
 
-{ #category : #accessing }
+{ #category : #history }
 TestCase class >> lastStoredRun [
 	^ ((Dictionary new) add: (#failures->#()); add: (#passed->#()); add: (#errors->#()); yourself)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> localCoverage [
 	"returns the coverage determined by a simple static analysis of test coverage 
 	made by the receiver on a class that is identified by the name of the receiver.
@@ -364,7 +364,7 @@ TestCase class >> localCoverage [
 	^ self localCoverageForClass: cls
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> localCoverageAsString [
 	| cov className |
 	cov := self localCoverage first asInteger. 
@@ -374,7 +374,7 @@ TestCase class >> localCoverageAsString [
 	^ self name asString, ' covers ', cov asString, '% of ', className.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> localCoverageForClass: cls [
 	
 	| definedMethods testedMethods untestedMethods |
@@ -396,17 +396,17 @@ TestCase class >> localCoverageForClass: cls [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #coverage }
 TestCase class >> localCoveragePercentage [
 	^ self localCoverage first
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> lookupHierarchyRoot [
 	^TestCase
 ]
 
-{ #category : #events }
+{ #category : #'initialize - event' }
 TestCase class >> methodChanged: anEvent [
 	"Remove the changed method from the known test results."
 	
@@ -421,34 +421,34 @@ TestCase class >> methodChanged: anEvent [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> methodFailed: aSelector [
 	^ (self lastRun at: #failures) includes: aSelector
 ]
 
-{ #category : #factory }
+{ #category : #testing }
 TestCase class >> methodPassed: aSelector [
 	^ (self lastRun at: #passed) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> methodProgressed: aSelector [
 	^ ((self storedMethodRaisedError: aSelector) or: [self storedMethodFailed: aSelector])
 		and: [self methodPassed: aSelector]
 		
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> methodRaisedError: aSelector [
 	^ (self lastRun at: #errors) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> methodRegressed: aSelector [
 	^ (self storedMethodPassed: aSelector) and: [(self methodFailed: aSelector) or: [self methodRaisedError: aSelector]]
 ]
 
-{ #category : #'instance creation' }
+{ #category : #history }
 TestCase class >> newTestDictionary [
 
 	^ Dictionary new at: #timeStamp put: DateAndTime now;
@@ -459,12 +459,12 @@ TestCase class >> newTestDictionary [
 		
 ]
 
-{ #category : #initialization }
+{ #category : #events }
 TestCase class >> resetAnnouncer [
 	self announcers removeKey: self ifAbsent: []
 ]
 
-{ #category : #initialization }
+{ #category : #history }
 TestCase class >> resetHistory [
 	history := nil
 ]
@@ -475,13 +475,13 @@ TestCase class >> resources [
 	^#()
 ]
 
-{ #category : #running }
+{ #category : #'instance creation' }
 TestCase class >> run: aSymbol [
 
 	^(self selector: aSymbol) run
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #utility }
 TestCase class >> runAllAndLogResult [
 
 	"runs all tests in the image"
@@ -489,18 +489,18 @@ TestCase class >> runAllAndLogResult [
 	TestCase suite run logCr
 ]
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
 TestCase class >> selector: aSymbol [
 
 	^self new setTestSelector: aSymbol
 ]
 
-{ #category : #asserting }
+{ #category : #events }
 TestCase class >> shouldAnnounce [
 	^ self announcers includesKey: self
 ]
 
-{ #category : #asserting }
+{ #category : #history }
 TestCase class >> shouldGenerateLastStoredRunMethod [
 	| sameRun |
 	
@@ -512,7 +512,7 @@ TestCase class >> shouldGenerateLastStoredRunMethod [
 
 ]
 
-{ #category : #asserting }
+{ #category : #testing }
 TestCase class >> shouldInheritSelectors [
 	"I should inherit from an Abstract superclass but not from a concrete one by default, unless I have no testSelectors in which case I must be expecting to inherit them from my superclass.  If a test case with selectors wants to inherit selectors from a concrete superclass, override this to true in that subclass."
 	
@@ -520,33 +520,33 @@ TestCase class >> shouldInheritSelectors [
 		and: [self superclass isAbstract or: [self testSelectors isEmpty]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> storedMethodFailed: aSelector [
 	^ (self lastStoredRun at: #failures) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> storedMethodPassed: aSelector [
 	^ (self lastStoredRun at: #passed) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> storedMethodRaisedError: aSelector [
 	^ (self lastStoredRun at: #errors) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 TestCase class >> suite [
 
 	^self buildSuite
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> sunitVersion [
 	^'4.0'
 ]
 
-{ #category : #tests }
+{ #category : #accessing }
 TestCase class >> testSelectors [
 	^(self selectors select: [ :each | (each beginsWith: 'test') and: [each numArgs isZero]])
 ]

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -14,6 +14,7 @@ Class {
 	],
 	#classVars : [
 		'Announcers',
+		'AssertionlessTestsShouldFail',
 		'DefaultTimeLimit',
 		'HistoryAnnouncer'
 	],
@@ -23,7 +24,7 @@ Class {
 	#category : #'SUnit-Core-Kernel'
 }
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> addTestsFor: classNameString toSuite: suite [
 	| cls |
 	cls := Smalltalk globals at: classNameString ifAbsent: [ ^ suite ].
@@ -37,21 +38,21 @@ TestCase class >> addTestsFor: classNameString toSuite: suite [
 		ifFalse: [ cls addToSuiteFromSelectors: suite ]
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> addToSuite: suite fromMethods: testMethods [ 
 	testMethods do:  [ :selector | 
 			suite addTest: (self selector: selector) ].
 	^suite
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> addToSuiteFromSelectors: suite [
 	^self addToSuite: suite fromMethods: (self shouldInheritSelectors
 		ifTrue: [ self allTestSelectors ]
 		ifFalse: [self testSelectors ])
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> allTestSelectors [
 	| answer pivotClass lookupRoot |
 	answer := Set withAll: self testSelectors.
@@ -66,17 +67,45 @@ TestCase class >> allTestSelectors [
 	^answer asSortedCollection asOrderedCollection
 ]
 
-{ #category : #events }
+{ #category : #'as yet unclassified' }
 TestCase class >> announcer [ 
 	^ self announcers at: self ifAbsentPut: [ Announcer new ]
 ]
 
-{ #category : #events }
+{ #category : #'as yet unclassified' }
 TestCase class >> announcers [
 	^ Announcers ifNil: [ Announcers := Dictionary new ] 
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
+TestCase class >> assertionlessTestsShouldFail [
+	"By default, a test that makes no assertion is regarded as not failing.  This behaviour can be changed
+	setting the value of the class inst. var.  If a single method makes no assertions deliberatley, then
+	rather than overriding this method, it should send the message
+	
+		self  deliberatelyDidNotAssert
+		
+	"
+	^ AssertionlessTestsShouldFail ifNil: [ AssertionlessTestsShouldFail := false ]
+]
+
+{ #category : #'as yet unclassified' }
+TestCase class >> assertionlessTestsShouldFail: aBoolean [
+	AssertionlessTestsShouldFail := aBoolean
+]
+
+{ #category : #'as yet unclassified' }
+TestCase class >> assertionlessTestsShouldFailSettingOn: aBuilder [
+	<systemsettings>
+	
+	(aBuilder setting: #assertionlessTestsShouldFail)
+		target: self;
+		parent: #pharoSystem ;
+		label: 'Should assertionless tests fail?' ;
+		description: 'Whether tests without assertion should fail or not.'
+]
+
+{ #category : #'as yet unclassified' }
 TestCase class >> buildSuite [
 	| suite |
 	^self isAbstract
@@ -88,21 +117,21 @@ TestCase class >> buildSuite [
 		ifFalse: [self buildSuiteFromSelectors]
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> buildSuiteFromAllSelectors [
 
 	^self buildSuiteFromMethods: self allTestSelectors
 			
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> buildSuiteFromLocalSelectors [
 
 	^self buildSuiteFromMethods: self testSelectors
 			
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> buildSuiteFromMethods: testMethods [
 
 	^testMethods
@@ -113,12 +142,12 @@ TestCase class >> buildSuiteFromMethods: testMethods [
 				yourself]
 ]
 
-{ #category : #'building suites' }
+{ #category : #'as yet unclassified' }
 TestCase class >> buildSuiteFromSelectors [
 	^self buildSuiteFromMethods: self allTestSelectors
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> coverage [
 	"returns the coverage determined by a simple static analysis of test coverage 
 	made by the receiver on a class that is identified by the name of the receiver.
@@ -134,7 +163,7 @@ TestCase class >> coverage [
 	^ self coverageForClass: cls
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> coverageAsString [
 	| cov className |
 	cov := self coverage first asInteger. 
@@ -144,13 +173,13 @@ TestCase class >> coverageAsString [
 	^ self name asString, ' covers ', cov asString, '% of ', className.
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> coverageForClass: cls [
 	"returns the test coverage of all the methods included inherited ones"
 	^ self coverageForClass: cls until: ProtoObject
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> coverageForClass: cls until: aRootClass [
 	"returns the test coverage of all the methods included inherited ones but stopping at aRootClass included"
 	
@@ -167,39 +196,39 @@ TestCase class >> coverageForClass: cls until: aRootClass [
 
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> coveragePercentage [
 	^ self coverage first
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'as yet unclassified' }
 TestCase class >> debug: aSymbol [
 
 	^(self selector: aSymbol) debug
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> defaultTimeLimit [
 	^DefaultTimeLimit ifNil: [DefaultTimeLimit := 10 seconds]
 
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> defaultTimeLimit: aDuration [
 	DefaultTimeLimit := aDuration
 ]
 
-{ #category : #settings }
+{ #category : #'as yet unclassified' }
 TestCase class >> defaultTimeLimitSecs [
 	^self defaultTimeLimit asMilliSeconds / 1000.0
 ]
 
-{ #category : #settings }
+{ #category : #'as yet unclassified' }
 TestCase class >> defaultTimeLimitSecs: aNumber [
 	self defaultTimeLimit: aNumber seconds
 ]
 
-{ #category : #settings }
+{ #category : #'as yet unclassified' }
 TestCase class >> defaultTimeLimitSettingOn: aBuilder [
 	<systemsettings>
 	
@@ -210,7 +239,7 @@ TestCase class >> defaultTimeLimitSettingOn: aBuilder [
 		description: 'Detault time limit in seconds for test execution'
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> generateLastStoredRunMethod [
 
 	self shouldGenerateLastStoredRunMethod ifTrue: [
@@ -219,7 +248,7 @@ TestCase class >> generateLastStoredRunMethod [
 			classified: 'history' ]
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> hasMethodBeenRun: aSelector [
 	^ ((self lastRun at: #errors),
 		(self lastRun at: #failures),
@@ -227,7 +256,7 @@ TestCase class >> hasMethodBeenRun: aSelector [
 			includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> hasTestSelectors [
 
 	^(self selectors anySatisfy: [ :each | 
@@ -244,24 +273,24 @@ TestCase class >> hasTestSelectors [
 	
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> history [
 	^ history ifNil: [ history := self newTestDictionary ]
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> history: aDictionary [
 
 	history := aDictionary.
 	self historyAnnouncer announce: (TestSuiteEnded result: self)
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> historyAnnouncer [
 	^ HistoryAnnouncer ifNil: [  HistoryAnnouncer := Announcer new ]
 ]
 
-{ #category : #'initialize - event' }
+{ #category : #'as yet unclassified' }
 TestCase class >> initialize [
 	super initialize.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
@@ -271,7 +300,7 @@ TestCase class >> initialize [
 		to: self.
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> isAbstract [
 	"Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
@@ -280,17 +309,17 @@ TestCase class >> isAbstract [
 			
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> isTestCase [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> isUnitTest [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> isUsed [
 	"all my subclasses are used by me"
 	^self name = 'TestCase'
@@ -298,12 +327,12 @@ TestCase class >> isUsed [
 		ifFalse: [ true ]
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> lastRun [
 	^ self classForTestResult historyFor: self
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> lastRunMethodNamed: aSelector [
 	
 	^ String streamContents: [:str |
@@ -312,12 +341,12 @@ TestCase class >> lastRunMethodNamed: aSelector [
 
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> lastStoredRun [
 	^ ((Dictionary new) add: (#failures->#()); add: (#passed->#()); add: (#errors->#()); yourself)
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> localCoverage [
 	"returns the coverage determined by a simple static analysis of test coverage 
 	made by the receiver on a class that is identified by the name of the receiver.
@@ -335,7 +364,7 @@ TestCase class >> localCoverage [
 	^ self localCoverageForClass: cls
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> localCoverageAsString [
 	| cov className |
 	cov := self localCoverage first asInteger. 
@@ -345,7 +374,7 @@ TestCase class >> localCoverageAsString [
 	^ self name asString, ' covers ', cov asString, '% of ', className.
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> localCoverageForClass: cls [
 	
 	| definedMethods testedMethods untestedMethods |
@@ -367,17 +396,17 @@ TestCase class >> localCoverageForClass: cls [
 
 ]
 
-{ #category : #coverage }
+{ #category : #'as yet unclassified' }
 TestCase class >> localCoveragePercentage [
 	^ self localCoverage first
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> lookupHierarchyRoot [
 	^TestCase
 ]
 
-{ #category : #'initialize - event' }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodChanged: anEvent [
 	"Remove the changed method from the known test results."
 	
@@ -392,34 +421,34 @@ TestCase class >> methodChanged: anEvent [
 
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodFailed: aSelector [
 	^ (self lastRun at: #failures) includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodPassed: aSelector [
 	^ (self lastRun at: #passed) includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodProgressed: aSelector [
 	^ ((self storedMethodRaisedError: aSelector) or: [self storedMethodFailed: aSelector])
 		and: [self methodPassed: aSelector]
 		
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodRaisedError: aSelector [
 	^ (self lastRun at: #errors) includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> methodRegressed: aSelector [
 	^ (self storedMethodPassed: aSelector) and: [(self methodFailed: aSelector) or: [self methodRaisedError: aSelector]]
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> newTestDictionary [
 
 	^ Dictionary new at: #timeStamp put: DateAndTime now;
@@ -430,29 +459,29 @@ TestCase class >> newTestDictionary [
 		
 ]
 
-{ #category : #events }
+{ #category : #'as yet unclassified' }
 TestCase class >> resetAnnouncer [
 	self announcers removeKey: self ifAbsent: []
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> resetHistory [
 	history := nil
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> resources [
 
 	^#()
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'as yet unclassified' }
 TestCase class >> run: aSymbol [
 
 	^(self selector: aSymbol) run
 ]
 
-{ #category : #utility }
+{ #category : #'as yet unclassified' }
 TestCase class >> runAllAndLogResult [
 
 	"runs all tests in the image"
@@ -460,18 +489,18 @@ TestCase class >> runAllAndLogResult [
 	TestCase suite run logCr
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'as yet unclassified' }
 TestCase class >> selector: aSymbol [
 
 	^self new setTestSelector: aSymbol
 ]
 
-{ #category : #events }
+{ #category : #'as yet unclassified' }
 TestCase class >> shouldAnnounce [
 	^ self announcers includesKey: self
 ]
 
-{ #category : #history }
+{ #category : #'as yet unclassified' }
 TestCase class >> shouldGenerateLastStoredRunMethod [
 	| sameRun |
 	
@@ -483,7 +512,7 @@ TestCase class >> shouldGenerateLastStoredRunMethod [
 
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> shouldInheritSelectors [
 	"I should inherit from an Abstract superclass but not from a concrete one by default, unless I have no testSelectors in which case I must be expecting to inherit them from my superclass.  If a test case with selectors wants to inherit selectors from a concrete superclass, override this to true in that subclass."
 	
@@ -491,33 +520,33 @@ TestCase class >> shouldInheritSelectors [
 		and: [self superclass isAbstract or: [self testSelectors isEmpty]]
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> storedMethodFailed: aSelector [
 	^ (self lastStoredRun at: #failures) includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> storedMethodPassed: aSelector [
 	^ (self lastStoredRun at: #passed) includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : #'as yet unclassified' }
 TestCase class >> storedMethodRaisedError: aSelector [
 	^ (self lastStoredRun at: #errors) includes: aSelector
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'as yet unclassified' }
 TestCase class >> suite [
 
 	^self buildSuite
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> sunitVersion [
 	^'4.0'
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TestCase class >> testSelectors [
 	^(self selectors select: [ :each | (each beginsWith: 'test') and: [each numArgs isZero]])
 ]
@@ -642,7 +671,10 @@ TestCase >> openDebuggerOnFailingTestMethod [
 
 { #category : #private }
 TestCase >> performTest [
-	self perform: testSelector asSymbol
+	assertionMade := false.
+	self perform: testSelector asSymbol.
+	assertionMade
+		ifFalse: [ TestResult makesNoAssertion signal: 'This test method made no assertion.' ]
 ]
 
 { #category : #running }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -24,7 +24,7 @@ Class {
 	#category : #'SUnit-Core-Kernel'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #adding }
 TestCase class >> addTestsFor: classNameString toSuite: suite [
 	| cls |
 	cls := Smalltalk globals at: classNameString ifAbsent: [ ^ suite ].
@@ -38,14 +38,14 @@ TestCase class >> addTestsFor: classNameString toSuite: suite [
 		ifFalse: [ cls addToSuiteFromSelectors: suite ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #adding }
 TestCase class >> addToSuite: suite fromMethods: testMethods [ 
 	testMethods do:  [ :selector | 
 			suite addTest: (self selector: selector) ].
 	^suite
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #adding }
 TestCase class >> addToSuiteFromSelectors: suite [
 	^self addToSuite: suite fromMethods: (self shouldInheritSelectors
 		ifTrue: [ self allTestSelectors ]
@@ -67,7 +67,7 @@ TestCase class >> allTestSelectors [
 	^answer asSortedCollection asOrderedCollection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> announcer [ 
 	^ self announcers at: self ifAbsentPut: [ Announcer new ]
 ]
@@ -201,13 +201,13 @@ TestCase class >> coveragePercentage [
 	^ self coverage first
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> debug: aSymbol [
 
 	^(self selector: aSymbol) debug
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> defaultTimeLimit [
 	^DefaultTimeLimit ifNil: [DefaultTimeLimit := 10 seconds]
 
@@ -248,7 +248,7 @@ TestCase class >> generateLastStoredRunMethod [
 			classified: 'history' ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> hasMethodBeenRun: aSelector [
 	^ ((self lastRun at: #errors),
 		(self lastRun at: #failures),
@@ -256,7 +256,7 @@ TestCase class >> hasMethodBeenRun: aSelector [
 			includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> hasTestSelectors [
 
 	^(self selectors anySatisfy: [ :each | 
@@ -273,12 +273,12 @@ TestCase class >> hasTestSelectors [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> history [
 	^ history ifNil: [ history := self newTestDictionary ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> history: aDictionary [
 
 	history := aDictionary.
@@ -290,7 +290,7 @@ TestCase class >> historyAnnouncer [
 	^ HistoryAnnouncer ifNil: [  HistoryAnnouncer := Announcer new ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'class initialization' }
 TestCase class >> initialize [
 	super initialize.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
@@ -300,7 +300,7 @@ TestCase class >> initialize [
 		to: self.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> isAbstract [
 	"Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
@@ -309,17 +309,17 @@ TestCase class >> isAbstract [
 			
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> isTestCase [
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> isUnitTest [
 	^true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TestCase class >> isUsed [
 	"all my subclasses are used by me"
 	^self name = 'TestCase'
@@ -327,12 +327,12 @@ TestCase class >> isUsed [
 		ifFalse: [ true ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> lastRun [
 	^ self classForTestResult historyFor: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> lastRunMethodNamed: aSelector [
 	
 	^ String streamContents: [:str |
@@ -341,7 +341,7 @@ TestCase class >> lastRunMethodNamed: aSelector [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> lastStoredRun [
 	^ ((Dictionary new) add: (#failures->#()); add: (#passed->#()); add: (#errors->#()); yourself)
 ]
@@ -406,7 +406,7 @@ TestCase class >> lookupHierarchyRoot [
 	^TestCase
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #events }
 TestCase class >> methodChanged: anEvent [
 	"Remove the changed method from the known test results."
 	
@@ -426,7 +426,7 @@ TestCase class >> methodFailed: aSelector [
 	^ (self lastRun at: #failures) includes: aSelector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #factory }
 TestCase class >> methodPassed: aSelector [
 	^ (self lastRun at: #passed) includes: aSelector
 ]
@@ -448,7 +448,7 @@ TestCase class >> methodRegressed: aSelector [
 	^ (self storedMethodPassed: aSelector) and: [(self methodFailed: aSelector) or: [self methodRaisedError: aSelector]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 TestCase class >> newTestDictionary [
 
 	^ Dictionary new at: #timeStamp put: DateAndTime now;
@@ -459,23 +459,23 @@ TestCase class >> newTestDictionary [
 		
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 TestCase class >> resetAnnouncer [
 	self announcers removeKey: self ifAbsent: []
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 TestCase class >> resetHistory [
 	history := nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> resources [
 
 	^#()
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #running }
 TestCase class >> run: aSymbol [
 
 	^(self selector: aSymbol) run
@@ -489,18 +489,18 @@ TestCase class >> runAllAndLogResult [
 	TestCase suite run logCr
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TestCase class >> selector: aSymbol [
 
 	^self new setTestSelector: aSymbol
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #asserting }
 TestCase class >> shouldAnnounce [
 	^ self announcers includesKey: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #asserting }
 TestCase class >> shouldGenerateLastStoredRunMethod [
 	| sameRun |
 	
@@ -512,7 +512,7 @@ TestCase class >> shouldGenerateLastStoredRunMethod [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #asserting }
 TestCase class >> shouldInheritSelectors [
 	"I should inherit from an Abstract superclass but not from a concrete one by default, unless I have no testSelectors in which case I must be expecting to inherit them from my superclass.  If a test case with selectors wants to inherit selectors from a concrete superclass, override this to true in that subclass."
 	
@@ -546,7 +546,7 @@ TestCase class >> sunitVersion [
 	^'4.0'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 TestCase class >> testSelectors [
 	^(self selectors select: [ :each | (each beginsWith: 'test') and: [each numArgs isZero]])
 ]

--- a/src/SUnit-Core/TestMakesNoAssertion.class.st
+++ b/src/SUnit-Core/TestMakesNoAssertion.class.st
@@ -1,0 +1,17 @@
+"
+This error is raised when a test case did not make any assertion.
+"
+Class {
+	#name : #TestMakesNoAssertion,
+	#superclass : #TestFailure,
+	#category : #'SUnit-Core-Kernel'
+}
+
+{ #category : #'camp smalltalk' }
+TestMakesNoAssertion >> sunitAnnounce: aTestCase toResult: aTestResult [
+	"First, add the assertless test case to the set of test cases making no assertion."
+	aTestResult addMakesNoAssertion: aTestCase.
+	"Then, if assertless tests should fail, also add it to failures set."
+	aTestCase class assertionlessTestsShouldFail
+		ifTrue: [ aTestResult addFailure: aTestCase ]
+]

--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -59,6 +59,11 @@ TestResult class >> historyFor: aTestCaseClass [
 "	^ self history at: aTestCaseClass ifAbsent: [ self newTestDictionary ]"
 ]
 
+{ #category : #exceptions }
+TestResult class >> makesNoAssertion [
+	^ TestMakesNoAssertion
+]
+
 { #category : #history }
 TestResult class >> newTestDictionary [
 
@@ -134,6 +139,12 @@ TestResult >> addFailure: aTestCase [
 ]
 
 { #category : #adding }
+TestResult >> addMakesNoAssertion: aTestCase [
+	
+	^assertionless add: aTestCase
+]
+
+{ #category : #adding }
 TestResult >> addPass: aTestCase [
 	"We cannot use self passed as that incorporates test expectations and so does not return the stored collection."
 
@@ -144,6 +155,16 @@ TestResult >> addPass: aTestCase [
 TestResult >> addSkip: aTestCase [
 
 	^skipped add: aTestCase
+]
+
+{ #category : #accessing }
+TestResult >> assertionless [
+	^ assertionless
+]
+
+{ #category : #accessing }
+TestResult >> assertionlessCount [
+	^ self assertionless size
 ]
 
 { #category : #accessing }
@@ -273,7 +294,8 @@ TestResult >> initialize [
 	failures := Set new.
 	errors := OrderedCollection new.
 	skipped := OrderedCollection new.
-	timeStamp := DateAndTime now
+	assertionless := OrderedCollection new.
+	timeStamp := DateAndTime now.
 ]
 
 { #category : #testing }
@@ -331,11 +353,19 @@ TestResult >> printOn: aStream [
 		nextPutAll: self expectedDefectCount printString;
 		nextPutAll:' expected failures, ';
 		nextPutAll: self unexpectedFailureCount printString;
-		nextPutAll: ' failures, ';
+		nextPutAll: ' failures'.
+	
+	TestCase assertionlessTestsShouldFail
+		ifTrue: [ aStream nextPutAll: ' including ' ]
+		ifFalse: [ aStream nextPutAll: ', ' ].
+
+	aStream
+		nextPutAll: self assertionlessCount printString;
+		nextPutAll: ' tests making no assertion, ';
 		nextPutAll: self unexpectedErrorCount printString;
 		nextPutAll:' errors, ';
 		nextPutAll: self unexpectedPassCount printString;
-		nextPutAll:' unexpected passes'.
+		nextPutAll:' unexpected passes.'
 ]
 
 { #category : #running }
@@ -345,7 +375,7 @@ TestResult >> runCase: aTestCase [
 	aTestCase runCaseManaged.
 	aTestCase announce: TestCaseEnded  withResult: self.
 	self addPass: aTestCase]
-		on: self class failure , self class skip, self class warning, self class error
+		on: self class failure , self class skip, self class warning, self class error , self class makesNoAssertion
 		do: [:ex | ex sunitAnnounce: aTestCase toResult: self]
 ]
 


### PR DESCRIPTION
Re-proposing Andrew's code modifying SUnit  to check dynamically if #assert: was call during execution or not.

This pull-request proposes to do the check depending on a setting that is unset by default.

To summarize, this should not break the CI.