### PR TITLE
Cleanup of SimpleButtonMorph newWithLabel to have a yourself

### DIFF
--- a/src/Morphic-Widgets-Basic/SimpleButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/SimpleButtonMorph.class.st
@@ -48,7 +48,9 @@ Class {
 { #category : #'instance creation' }
 SimpleButtonMorph class >> newWithLabel: labelString [
 
-	^ self new label:  labelString
+	^(self new) 
+		label: labelString;
+		yourself
 
 ]
 


### PR DESCRIPTION
add missing yourself
(the brace is not necessary but for better readability according to BPP)


https://pharo.fogbugz.com/f/cases/20909/SimpleButtonMorph-newWithLabel-should-include-yourself