### PR TITLE
20925 Super setUp need to be called in UnifiedFFI tests

### DIFF
--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
@@ -16,6 +16,7 @@ FFICalloutMethodBuilderTest >> builder [
 
 { #category : #running }
 FFICalloutMethodBuilderTest >> setUp [
+	super setUp.
 	architecture := FFIArchitecture forCurrentArchitecture
 ]
 

--- a/src/UnifiedFFI-Tests/FFICalloutObjectForTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutObjectForTest.class.st
@@ -1,3 +1,6 @@
+"
+A callout object for testing purposes
+"
 Class {
 	#name : #FFICalloutObjectForTest,
 	#superclass : #Object,

--- a/src/UnifiedFFI-Tests/FFICalloutTests.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutTests.class.st
@@ -41,6 +41,7 @@ FFICalloutTests >> ffiBindingOf: aName [
 
 { #category : #running }
 FFICalloutTests >> setUp [
+	super setUp.
 	architecture := FFIArchitecture forCurrentArchitecture
 ]
 

--- a/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTests.class.st
@@ -14,6 +14,7 @@ FFIExternalStructureFieldParserTests >> newParser [
 
 { #category : #running }
 FFIExternalStructureFieldParserTests >> setUp [
+	super setUp.
 	architecture := FFIArchitecture forCurrentArchitecture
 ]
 

--- a/src/UnifiedFFI-Tests/FFITestArrayStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestArrayStructure.class.st
@@ -1,3 +1,6 @@
+"
+An array  structure for test purposes
+"
 Class {
 	#name : #FFITestArrayStructure,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestEnumeration.class.st
+++ b/src/UnifiedFFI-Tests/FFITestEnumeration.class.st
@@ -1,3 +1,6 @@
+"
+An enumeration for test purposes
+"
 Class {
 	#name : #FFITestEnumeration,
 	#superclass : #FFIExternalEnumeration,

--- a/src/UnifiedFFI-Tests/FFITestNestingStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestNestingStructure.class.st
@@ -1,3 +1,6 @@
+"
+A nesting structure for test purposes
+"
 Class {
 	#name : #FFITestNestingStructure,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestNestingStructureWithArray.class.st
+++ b/src/UnifiedFFI-Tests/FFITestNestingStructureWithArray.class.st
@@ -1,3 +1,6 @@
+"
+A nesting structure with an array for test purposes
+"
 Class {
 	#name : #FFITestNestingStructureWithArray,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestPackedStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestPackedStructure.class.st
@@ -1,3 +1,6 @@
+"
+A packaged structure for test purposes
+"
 Class {
 	#name : #FFITestPackedStructure,
 	#superclass : #FFIExternalPackedStructure,

--- a/src/UnifiedFFI-Tests/FFITestPointerStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestPointerStructure.class.st
@@ -1,3 +1,6 @@
+"
+A pointer structure for test purposes
+"
 Class {
 	#name : #FFITestPointerStructure,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestStructure.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructure.class.st
@@ -1,3 +1,6 @@
+"
+A structure for test purposes
+"
 Class {
 	#name : #FFITestStructure,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestStructureByPlatform.class.st
+++ b/src/UnifiedFFI-Tests/FFITestStructureByPlatform.class.st
@@ -1,3 +1,6 @@
+"
+A structure for test purposes
+"
 Class {
 	#name : #FFITestStructureByPlatform,
 	#superclass : #FFIExternalStructure,

--- a/src/UnifiedFFI-Tests/FFITestUnion.class.st
+++ b/src/UnifiedFFI-Tests/FFITestUnion.class.st
@@ -1,3 +1,6 @@
+"
+A union for test purposes
+"
 Class {
 	#name : #FFITestUnion,
 	#superclass : #FFIExternalUnion,


### PR DESCRIPTION
call super setUp in
- FFICalloutMethodBuilderTest>>setUp
- FFICalloutTests>>setUp
- FFIExternalStructureFieldParserTests>>setUp

and add some more class comments

https://pharo.fogbugz.com/f/cases/20925/Super-setUp-need-to-be-called-in-UnifiedFFI-tests