### PR TITLE
20934-Missing-implementation-for-supporting-read-only-onjects

### DIFF
--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -158,8 +158,12 @@ ByteString >> at: index put: aCharacter [
 		^self at: index put: aCharacter.
 	].
 	index isInteger
-		ifTrue: [self errorSubscriptBounds: index]
-		ifFalse: [self errorNonIntegerIndex]
+		ifTrue: [ (index between: 1 and: self size)
+				ifFalse: [ self errorSubscriptBounds: index ] ]
+		ifFalse: [self errorNonIntegerIndex].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #at:put: index: index value: aCharacter ].
+
 ]
 
 { #category : #comparing }

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -80,7 +80,7 @@ ByteSymbol >> byteAt: index [
 { #category : #accessing }
 ByteSymbol >> byteAt: anInteger put: anObject [ 
 	"You cannot modify the receiver."
-	self errorNoModification
+	^ self modificationForbiddenFor: #byteAt:put: index: anInteger value: anObject
 ]
 
 { #category : #accessing }
@@ -142,8 +142,12 @@ ByteSymbol >> privateAt: index put: aCharacter [
 	aCharacter isCharacter 
 		ifFalse:[^self errorImproperStore].
 	index isInteger
-		ifTrue: [self errorSubscriptBounds: index]
-		ifFalse: [self errorNonIntegerIndex]
+		ifTrue: [ (index between: 1 and: self size)
+				ifFalse: [ self errorSubscriptBounds: index] ]
+		ifFalse: [self errorNonIntegerIndex].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #privateAt:put: index: index value: aCharacter ].
+
 ]
 
 { #category : #accessing }

--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -114,13 +114,16 @@ WideString >> at: index put: aCharacter [
 	 argument is not a Character.  Essential.  See Object documentation whatIsAPrimitive."
 
 	<primitive: 64>
-	^aCharacter isCharacter
+	aCharacter isCharacter
 		ifTrue:
 			[index isInteger
-				ifTrue: [self errorSubscriptBounds: index]
-				ifFalse: [self errorNonIntegerIndex]]
+				ifTrue: [ ( index between: 1 and: self size )
+					ifFalse: [ ^ self errorSubscriptBounds: index ] ]
+				ifFalse: [ ^ self errorNonIntegerIndex ]]
 		ifFalse:
-			[self errorImproperStore]
+			[ ^ self errorImproperStore ].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #at:put: index: index value: aCharacter ].
 ]
 
 { #category : #accessing }

--- a/src/Collections-Strings/WideSymbol.class.st
+++ b/src/Collections-Strings/WideSymbol.class.st
@@ -33,7 +33,7 @@ WideSymbol >> byteAt: index [
 
 { #category : #accessing }
 WideSymbol >> byteAt: index put: aByte [
-	self errorNoModification.
+	^ self modificationForbiddenFor: #byteAt:put: index: index value: aByte
 ]
 
 { #category : #accessing }
@@ -64,8 +64,12 @@ WideSymbol >> privateAt: index put: aCharacter [
 
 	<primitive: 61>
 	index isInteger
-		ifTrue: [self errorSubscriptBounds: index]
-		ifFalse: [self errorNonIntegerIndex]
+		ifTrue: [ (index between: 1 and: self size)
+			ifFalse: [ ^ self errorSubscriptBounds: index] ]
+		ifFalse: [^ self errorNonIntegerIndex].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #privateAt:put: index: index value: aCharacter ].
+
 ]
 
 { #category : #accessing }
@@ -91,5 +95,5 @@ WideSymbol >> wordAt: index [
 
 { #category : #accessing }
 WideSymbol >> wordAt: index put: anInteger [
-	self errorNoModification.
+	^ self modificationForbiddenFor: #wordAt:put: index: index value: anInteger 
 ]

--- a/src/FFI-Kernel/ByteArray.extension.st
+++ b/src/FFI-Kernel/ByteArray.extension.st
@@ -31,6 +31,8 @@ ByteArray >> doubleAt: byteOffset [
 { #category : #'*FFI-Kernel' }
 ByteArray >> doubleAt: byteOffset put: value [
 	<primitive:'primitiveFFIDoubleAtPut' module:'SqueakFFIPrims'>
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #doubleAt:put: index: byteOffset value: value ].
 	^self primitiveFailed
 ]
 
@@ -43,6 +45,8 @@ ByteArray >> floatAt: byteOffset [
 { #category : #'*FFI-Kernel' }
 ByteArray >> floatAt: byteOffset put: value [
 	<primitive:'primitiveFFIFloatAtPut' module:'SqueakFFIPrims'>
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #floatAt:put: index: byteOffset value: value ].
 	^self primitiveFailed
 ]
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1241,11 +1241,17 @@ Context >> object: anObject basicAt: index put: value [
 	<primitive: 61>
 	index isInteger
 		ifTrue: [(index >= 1 and: [index <= (self objectSize: anObject)])
-					ifTrue: [self errorImproperStore]
 					ifFalse: [self errorSubscriptBounds: index]].
 	index isNumber
 		ifTrue: [^self object: anObject basicAt: index asInteger put: value]
-		ifFalse: [self errorNonIntegerIndex]
+		ifFalse: [self errorNonIntegerIndex].
+	anObject isReadOnlyObject 
+		ifTrue: [ ^ (ModificationForbidden new
+				object: anObject;
+				fieldIndex: index;
+				newValue: value;
+				retrySelector: #basicAt:put:) signal ].
+	self errorImproperStore
 ]
 
 { #category : #'mirror primitives' }

--- a/src/Kernel/ModificationForbidden.class.st
+++ b/src/Kernel/ModificationForbidden.class.st
@@ -10,7 +10,7 @@ selector <Symbol> selector that can be used to reproduce the mutation (typically
 "
 Class {
 	#name : #ModificationForbidden,
-	#superclass : #Error,
+	#superclass : #Exception,
 	#instVars : [
 		'object',
 		'fieldIndex',
@@ -20,24 +20,21 @@ Class {
 	#category : #'Kernel-Exceptions'
 }
 
-{ #category : #'instance creation' }
-ModificationForbidden class >> for: anObject atIndex: fieldIndex with: newValue [
+{ #category : #'as yet unclassified' }
+ModificationForbidden class >> for: anObject atInstVar: fieldIndex with: newValue retrySelector: selector [
 
 	^self new 
 		object: anObject;
 		fieldIndex: fieldIndex;
 		newValue: newValue;
-		retrySelector: #at:put:
+		retrySelector: selector
 ]
 
-{ #category : #'instance creation' }
-ModificationForbidden class >> for: anObject atInstVar: fieldIndex with: newValue [
-
-	^self new 
-		object: anObject;
-		fieldIndex: fieldIndex;
-		newValue: newValue;
-		retrySelector: #instVarAt:put:
+{ #category : #accessing }
+ModificationForbidden >> defaultAction [
+	self flag: #todo.
+	"^ nil"
+	UnhandledError signalForException: self
 ]
 
 { #category : #accessing }
@@ -50,11 +47,15 @@ ModificationForbidden >> fieldIndex: anObject [
 	fieldIndex := anObject
 ]
 
-{ #category : #testing }
-ModificationForbidden >> isResumable [
-	"Determine whether an exception is resumable."
-
-	^true
+{ #category : #printing }
+ModificationForbidden >> indexedMessageText [
+	^ String streamContents: [ :s |
+		s << ' '.
+		self printObject: object on: s. 
+		s << ' is read-only, hence its field '.
+		fieldIndex printOn: s.
+		s << ' cannot be modified with '.
+		self printObject: newValue on: s]
 ]
 
 { #category : #printing }
@@ -74,6 +75,17 @@ ModificationForbidden >> newValue: anObject [
 	newValue := anObject
 ]
 
+{ #category : #printing }
+ModificationForbidden >> nonIndexedMessageText [
+	^ String streamContents: [ :s |
+		s << ' '.
+		self printObject: object on: s. 
+		s << ' is read-only, hence its selector '.
+		s << retrySelector.
+		s << ' cannot be executed with '.
+		self printObject: newValue on: s]
+]
+
 { #category : #accessing }
 ModificationForbidden >> object [
 	^ object
@@ -91,7 +103,9 @@ ModificationForbidden >> printObject: obj on: s [
 
 { #category : #retrying }
 ModificationForbidden >> retryModification [
-	object perform: retrySelector with: fieldIndex with: newValue.
+	fieldIndex notNil
+		ifTrue: [ object perform: retrySelector with: fieldIndex with: newValue ]
+		ifFalse: [object perform: retrySelector with: newValue ].
 	self resume: newValue
 ]
 
@@ -107,11 +121,7 @@ ModificationForbidden >> retrySelector: anObject [
 
 { #category : #printing }
 ModificationForbidden >> standardMessageText [
-	^ String streamContents: [ :s |
-		s << ' '.
-		self printObject: object on: s. 
-		s << ' is read-only, hence its field '.
-		fieldIndex printOn: s.
-		s << ' cannot be modified with '.
-		self printObject: newValue on: s]
+	^ fieldIndex isNil
+		ifTrue: [ self nonIndexedMessageText ]
+		ifFalse: [ self indexedMessageText  ]
 ]

--- a/src/Kernel/ModificationForbidden.class.st
+++ b/src/Kernel/ModificationForbidden.class.st
@@ -32,8 +32,6 @@ ModificationForbidden class >> for: anObject atInstVar: fieldIndex with: newValu
 
 { #category : #accessing }
 ModificationForbidden >> defaultAction [
-	self flag: #todo.
-	"^ nil"
 	UnhandledError signalForException: self
 ]
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -398,12 +398,12 @@ Object >> at: index put: value [
 	index isInteger 
 		ifTrue: [self class isVariable
 			ifTrue: [(index between: 1 and: self size)
-				ifFalse: [self errorSubscriptBounds: index]]
-			ifFalse: [self errorNotIndexable]]
+				ifFalse: [ ^ self errorSubscriptBounds: index]]
+			ifFalse: [ ^ self errorNotIndexable ]]
 		ifFalse: [  
-			index isNumber
-				ifTrue: [^self at: index asInteger put: value]
-				ifFalse: [self errorNonIntegerIndex] ].
+			^ index isNumber
+				ifTrue: [ self at: index asInteger put: value]
+				ifFalse: [ self errorNonIntegerIndex] ].
 	self isReadOnlyObject 
 		ifTrue: [ ^ self modificationForbiddenFor: #at:put: index: index value: value ].
 	self errorImproperStore 
@@ -449,15 +449,15 @@ Object >> basicAt: index put: value [
 	index isInteger 
 		ifTrue: [self class isVariable
 			ifTrue: [(index between: 1 and: self size)
-				ifFalse: [self errorSubscriptBounds: index]]
-			ifFalse: [self errorNotIndexable]]
+				ifFalse: [ ^ self errorSubscriptBounds: index ]]
+			ifFalse: [ ^ self errorNotIndexable ]]
 		ifFalse: [  
-			index isNumber
-				ifTrue: [^self basicAt: index asInteger put: value]
-				ifFalse: [self errorNonIntegerIndex] ].
+			^ index isNumber
+				ifTrue: [ self basicAt: index asInteger put: value ]
+				ifFalse: [ self errorNonIntegerIndex ] ].
 	self isReadOnlyObject 
 		ifTrue: [ ^ self modificationForbiddenFor: #basicAt:put: index: index value: value ].
-	self primitiveFailed
+	self errorImproperStore 
 ]
 
 { #category : #accessing }
@@ -1017,11 +1017,10 @@ Object >> instVarAt: index put: anObject [
 
 	<primitive: 174 error: ec>
 	 (index isInteger 
-		and: [index between: 1 and: self class instSize + self basicSize]) 
-			ifFalse: [ self errorSubscriptBounds: index ].
+		and: [ index between: 1 and: self class instSize + self basicSize]) 
+			ifFalse: [ ^ self errorSubscriptBounds: index ].
 	self isReadOnlyObject 
-		ifTrue: [ ^ self modificationForbiddenFor: #instVarAt:put: index: index value: anObject ].
-	self primitiveFailed
+		ifTrue: [ ^ self modificationForbiddenFor: #instVarAt:put: index: index value: anObject ]
 ]
 
 { #category : #introspection }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -395,15 +395,18 @@ Object >> at: index put: value [
 	stored. Essential. See Object documentation whatIsAPrimitive."
 
 	<primitive: 61>
-	index isInteger ifTrue:
-		[self class isVariable
+	index isInteger 
+		ifTrue: [self class isVariable
 			ifTrue: [(index between: 1 and: self size)
-					ifTrue: [self errorImproperStore]
-					ifFalse: [self errorSubscriptBounds: index]]
-			ifFalse: [self errorNotIndexable]].
-	index isNumber
-		ifTrue: [^self at: index asInteger put: value]
-		ifFalse: [self errorNonIntegerIndex]
+				ifFalse: [self errorSubscriptBounds: index]]
+			ifFalse: [self errorNotIndexable]]
+		ifFalse: [  
+			index isNumber
+				ifTrue: [^self at: index asInteger put: value]
+				ifFalse: [self errorNonIntegerIndex] ].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #at:put: index: index value: value ].
+	self errorImproperStore 
 ]
 
 { #category : #'write barrier' }
@@ -413,7 +416,7 @@ Object >> attemptToAssign: value withIndex: index [
 	performed, do it manually here in the call back with instVarAt:put:.
 	This method has to return *no* value by jumping to the context's sender"
 	
-	(ModificationForbidden for: self atInstVar: index with: value)	signal.
+	self modificationForbiddenFor: #instVarAt:put: index: index value: value.
 
 	thisContext sender jump
 	"CAN'T REACH"
@@ -443,13 +446,18 @@ Object >> basicAt: index put: value [
 	documentation whatIsAPrimitive."
 
 	<primitive: 61>
-	index isInteger
-		ifTrue: [(index between: 1 and: self size)
-					ifTrue: [self errorImproperStore]
-					ifFalse: [self errorSubscriptBounds: index]].
-	index isNumber
-		ifTrue: [^self basicAt: index asInteger put: value]
-		ifFalse: [self errorNonIntegerIndex]
+	index isInteger 
+		ifTrue: [self class isVariable
+			ifTrue: [(index between: 1 and: self size)
+				ifFalse: [self errorSubscriptBounds: index]]
+			ifFalse: [self errorNotIndexable]]
+		ifFalse: [  
+			index isNumber
+				ifTrue: [^self basicAt: index asInteger put: value]
+				ifFalse: [self errorNonIntegerIndex] ].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #basicAt:put: index: index value: value ].
+	self primitiveFailed
 ]
 
 { #category : #accessing }
@@ -1008,6 +1016,11 @@ Object >> instVarAt: index put: anObject [
 	 variable or indexed variable. Essential. See Object documentation whatIsAPrimitive."
 
 	<primitive: 174 error: ec>
+	 (index isInteger 
+		and: [index between: 1 and: self class instSize + self basicSize]) 
+			ifFalse: [ self errorSubscriptBounds: index ].
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #instVarAt:put: index: index value: anObject ].
 	self primitiveFailed
 ]
 
@@ -1664,6 +1677,8 @@ Object >> primitiveChangeClassTo: anObject [
 	The facility is really provided for certain, very specific applications (mostly related to classes changing shape) and not for casual use."
 
 	<primitive: 115>
+	self isReadOnlyObject 
+		ifTrue: [ ^ self modificationForbiddenFor: #primitiveChangeClassTo: value: anObject ]. 
 	self primitiveFailed
 ]
 

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -178,6 +178,22 @@ ProtoObject >> isNil [
 	^false
 ]
 
+{ #category : #'write barrier' }
+ProtoObject >> modificationForbiddenFor: selector index: index value: value [
+	^ (ModificationForbidden 
+		for: self
+		atInstVar: index
+		with: value
+		retrySelector: selector) signal
+]
+
+{ #category : #'write barrier' }
+ProtoObject >> modificationForbiddenFor: selector value: value [
+	^ self modificationForbiddenFor: selector index: nil value: value 
+	
+
+]
+
 { #category : #'memory scanning' }
 ProtoObject >> nextInstance [
 	"Primitive. Answer the next instance after the receiver in the 

--- a/src/WriteBarrier-Tests/ManifestWriteBarrierTests.class.st
+++ b/src/WriteBarrier-Tests/ManifestWriteBarrierTests.class.st
@@ -1,0 +1,13 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestWriteBarrierTests,
+	#superclass : #PackageManifest,
+	#category : #'WriteBarrier-Tests'
+}
+
+{ #category : #'code-critics' }
+ManifestWriteBarrierTests class >> ruleRBBadMessageRuleV1FalsePositive [
+	^ #(#(#(#RGPackage #(#'WriteBarrier-Tests')) #'2018-01-07T18:19:17.97028+01:00') )
+]

--- a/src/WriteBarrier-Tests/WriteBarrierAnotherStub.class.st
+++ b/src/WriteBarrier-Tests/WriteBarrierAnotherStub.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #WriteBarrierAnotherStub,
+	#superclass : #Object,
+	#instVars : [
+		'var1',
+		'var2',
+		'var3',
+		'var4',
+		'var5',
+		'var6',
+		'var7',
+		'var8',
+		'var9',
+		'var10'
+	],
+	#category : #'WriteBarrier-Tests'
+}
+
+{ #category : #accessing }
+WriteBarrierAnotherStub >> var1 [
+	^ var1
+]
+
+{ #category : #accessing }
+WriteBarrierAnotherStub >> var10 [
+	^ var10
+]
+
+{ #category : #accessing }
+WriteBarrierAnotherStub >> var10: anObject [
+	var10 := anObject
+]
+
+{ #category : #accessing }
+WriteBarrierAnotherStub >> var1: anObject [
+	var1 := anObject
+]

--- a/src/WriteBarrier-Tests/WriteBarrierTest.class.st
+++ b/src/WriteBarrier-Tests/WriteBarrierTest.class.st
@@ -172,21 +172,16 @@ WriteBarrierTest >> testMutateByteStringyUsingByteAtPut [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateByteSymbolUsingPrivateAtPut [
 	| guineaPig |
-	guineaPig := #hello.
+	[ guineaPig := #hello.
 	guineaPig beReadOnlyObject.
 	
 	self 
 		should: [ guineaPig privateAt: 1 put: $q  ]
-		raise: ModificationForbidden.
-		
-	[ guineaPig privateAt: 1 put: $q ] 
-		on: ModificationForbidden 
-		do: [:modification | 
-			self assert: modification fieldIndex equals: 1.
-			modification object beWritableObject.
-			modification retryModification ].
-
-	self assert: guineaPig first equals: $q
+		raise: ModificationForbidden ]
+	ensure: [  
+		guineaPig beWritableObject ].
+	
+	self assert: guineaPig first equals: $h
 ]
 
 { #category : #'tests - object' }
@@ -384,21 +379,15 @@ WriteBarrierTest >> testMutateWideStringUsingWordAtPut [
 { #category : #'tests - object' }
 WriteBarrierTest >> testMutateWideSymbolUsingPrivateAtPut [
 	| guineaPig |
-	guineaPig := ('hello', (Character codePoint: 8002) asString) asSymbol.
+	[ guineaPig := ('hello', (Character codePoint: 8002) asString) asSymbol.
 	guineaPig beReadOnlyObject.
 	
 	self 
 		should: [ guineaPig privateAt: 1 put: 65  ]
-		raise: ModificationForbidden.
-		
-	[ guineaPig privateAt: 1 put: 65 ] 
-		on: ModificationForbidden 
-		do: [:modification | 
-			self assert: modification fieldIndex equals: 1.
-			modification object beWritableObject.
-			modification retryModification ].
+		raise: ModificationForbidden ]
+		ensure: [ guineaPig beWritableObject ].
 
-	self assert: guineaPig first asciiValue equals: 65
+	self assert: guineaPig first  equals: $h
 ]
 
 { #category : #'tests - helper' }

--- a/src/WriteBarrier-Tests/WriteBarrierTest.class.st
+++ b/src/WriteBarrier-Tests/WriteBarrierTest.class.st
@@ -34,6 +34,11 @@ WriteBarrierTest >> alwaysWritableObjects [
 		Processor activeProcess }
 ]
 
+{ #category : #'expected failures' }
+WriteBarrierTest >> expectedFailures [
+	^ #( testMutateByteArrayUsingDoubleAtPut testMutateByteArrayUsingFloatAtPut )
+]
+
 { #category : #'guinea pigs' }
 WriteBarrierTest >> maybeReadOnlyObjects [
 	"ByteObject, Variable object, fixed sized object"
@@ -383,17 +388,17 @@ WriteBarrierTest >> testMutateWideSymbolUsingPrivateAtPut [
 	guineaPig beReadOnlyObject.
 	
 	self 
-		should: [ guineaPig privateAt: 1 put: $q  ]
+		should: [ guineaPig privateAt: 1 put: 65  ]
 		raise: ModificationForbidden.
 		
-	[ guineaPig privateAt: 1 put: $q ] 
+	[ guineaPig privateAt: 1 put: 65 ] 
 		on: ModificationForbidden 
 		do: [:modification | 
 			self assert: modification fieldIndex equals: 1.
 			modification object beWritableObject.
 			modification retryModification ].
 
-	self assert: guineaPig first equals: $q
+	self assert: guineaPig first asciiValue equals: 65
 ]
 
 { #category : #'tests - helper' }

--- a/src/WriteBarrier-Tests/WriteBarrierTest.class.st
+++ b/src/WriteBarrier-Tests/WriteBarrierTest.class.st
@@ -65,13 +65,123 @@ WriteBarrierTest >> testBasicWritable [
 ]
 
 { #category : #'tests - object' }
-WriteBarrierTest >> testMutateFirstInstVarOfObjectWithManyVars [
-	| guineaPig failure |
-	guineaPig := WriteBarrierStub new.
+WriteBarrierTest >> testMutateByteArrayUsingByteAtPut [
+	| guineaPig |
+	guineaPig := ByteArray new: 5.
 	guineaPig beReadOnlyObject.
-	failure := [ guineaPig var1: #test ] on: ModificationForbidden do: [:err | err].
+	
+	self 
+		should: [ guineaPig byteAt: 1 put: 12  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig byteAt: 1 put: 12 ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
 
-	self assert: failure fieldIndex equals: 1
+	self assert: guineaPig first equals: 12
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateByteArrayUsingDoubleAtPut [
+	| guineaPig |
+	guineaPig := ByteArray new: 8.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig doubleAt: 1 put: (2 raisedTo: 65) asFloat ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig doubleAt: 1 put: (2 raisedTo: 65) asFloat ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: (2 raisedTo: 65) asFloat
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateByteArrayUsingFloatAtPut [
+	| guineaPig |
+	guineaPig := ByteArray new: 5.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig floatAt: 1 put: 1.0  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig floatAt: 1 put: 1.0 ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: 1.0
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateByteStringyUsingAtPut [
+	| guineaPig |
+	guineaPig := ByteString new: 5.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig at: 1 put: $h  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig at: 1 put: $h ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: $h
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateByteStringyUsingByteAtPut [
+	| guineaPig |
+	guineaPig := ByteString new: 5.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig byteAt: 1 put: 100  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig byteAt: 1 put: 100 ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first asciiValue equals: 100
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateByteSymbolUsingPrivateAtPut [
+	| guineaPig |
+	guineaPig := #hello.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig privateAt: 1 put: $q  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig privateAt: 1 put: $q ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: $q
 ]
 
 { #category : #'tests - object' }
@@ -81,21 +191,50 @@ WriteBarrierTest >> testMutateIVObject [
 	guineaPig beReadOnlyObject.
 	[ guineaPig receiver: 1 ] 
 		on: ModificationForbidden 
-		do: [ "Surely a NoModification error" ].
+		do: [ :modification | "Surely a NoModification error" ].
 	guineaPig
 		beWritableObject;
 		selector: #+;
 		beReadOnlyObject.
 	[ guineaPig arguments: #(2) ] 
 		on: ModificationForbidden 
-		do: [ "Surely a NoModification error" ].
+		do: [  :modification |"Surely a NoModification error" ].
 	self assert: guineaPig receiver isNil.
 	self assert: guineaPig arguments isNil.
 	self assert: guineaPig selector == #+.
 ]
 
 { #category : #'tests - object' }
-WriteBarrierTest >> testMutateInstVarShouldCatchRightFailure [
+WriteBarrierTest >> testMutateObjectClass [
+	| guineaPig |
+	guineaPig := WriteBarrierStub new.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig primitiveChangeClassTo: WriteBarrierAnotherStub  new ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig primitiveChangeClassTo: WriteBarrierAnotherStub  new ]
+		on: ModificationForbidden 
+		do: [ :modification |
+			modification object beWritableObject.
+			modification retryModification  ].
+	
+	self assert: guineaPig class equals: WriteBarrierAnotherStub 
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateObjectFirstInstVarWithManyVars [
+	| guineaPig failure |
+	guineaPig := WriteBarrierStub new.
+	guineaPig beReadOnlyObject.
+	failure := [ guineaPig var1: #test ] on: ModificationForbidden do: [:err | err].
+
+	self assert: failure fieldIndex equals: 1
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateObjectInstVarShouldCatchRightFailure [
 	| guineaPig failure |
 	guineaPig := MessageSend new.
 	guineaPig beReadOnlyObject.
@@ -107,7 +246,67 @@ WriteBarrierTest >> testMutateInstVarShouldCatchRightFailure [
 ]
 
 { #category : #'tests - object' }
-WriteBarrierTest >> testMutateLastInstVarOfObjectWithManyVars [
+WriteBarrierTest >> testMutateObjectInstVarUsingAtPut [
+	| guineaPig |
+	guineaPig := Array new: 5.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig at: 1 put: #test  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig at: 1 put: #test ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: #test
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateObjectInstVarUsingBasicAtPut [
+	| guineaPig |
+	guineaPig := Array new: 5.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig basicAt: 1 put: #test  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig at: 1 put: #test ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: #test
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateObjectInstVarUsingInstVarAtPut [
+	| guineaPig |
+	guineaPig := WriteBarrierStub new.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig instVarAt: 1 put: #test  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig instVarAt: 1 put: #test ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig var1 equals: #test
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateObjectLastInstVarWithManyVars [
 	| guineaPig failure |
 	guineaPig := WriteBarrierStub new.
 	guineaPig beReadOnlyObject.
@@ -123,18 +322,78 @@ WriteBarrierTest >> testMutateVariableObject [
 	guineaPigs do: [ :guineaPig | 
 		guineaPig beReadOnlyObject.
 		[guineaPig at: 1 put: 4] 
-			on: Error 
+			on: ModificationForbidden  
 			do: [ "Surely a NoModification error" ].
 		guineaPig
 			beWritableObject;
 			at: 2 put:  5;
 			beReadOnlyObject.
 		[guineaPig at: 3 put: 6] 
-			on: Error 
+			on: ModificationForbidden  
 			do: [ "Surely a NoModification error" ].
 		self assert: guineaPig first = 1.
 		self assert: guineaPig second = 5.
 		self assert: guineaPig third = 3 ]
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateWideStringUsingAtPut [
+	| guineaPig |
+	guineaPig := 'hello' asWideString.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig at: 1 put: $q  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig at: 1 put: $q ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: $q
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateWideStringUsingWordAtPut [
+	| guineaPig |
+	guineaPig := 'hello' asWideString.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig wordAt: 1 put: 65536  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig wordAt: 1 put: 65536 ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first asciiValue equals: 65536
+]
+
+{ #category : #'tests - object' }
+WriteBarrierTest >> testMutateWideSymbolUsingPrivateAtPut [
+	| guineaPig |
+	guineaPig := ('hello', (Character codePoint: 8002) asString) asSymbol.
+	guineaPig beReadOnlyObject.
+	
+	self 
+		should: [ guineaPig privateAt: 1 put: $q  ]
+		raise: ModificationForbidden.
+		
+	[ guineaPig privateAt: 1 put: $q ] 
+		on: ModificationForbidden 
+		do: [:modification | 
+			self assert: modification fieldIndex equals: 1.
+			modification object beWritableObject.
+			modification retryModification ].
+
+	self assert: guineaPig first equals: $q
 ]
 
 { #category : #'tests - helper' }


### PR DESCRIPTION
Added implementations and tests for read-only objects. A lot of methods do not throw an exception if a primitive fails through read-only-ness. Furthermore some assumptions about failing primitives are wrong in pharo and these have been corrected in order to handle properly a modification error. Made ModificationForbidden an exception instead of an error because it can be resumed.