### PR TITLE
20936-64bit-primitiveFailure-for-1-0-largeIdentityHash

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -443,7 +443,9 @@ Behavior >> basicAddSelector: selector withMethod: compiledMethod [
 
 { #category : #'reflective operations' }
 Behavior >> basicIdentityHash [
-	"Answer a SmallInteger whose value is related to the receiver's identity.
+	"Answer a 22 bits unsigned SmallInteger, whose value is related to the receiver's identity
+	 and unique among the behaviors (i.e. 2 different Behaviors cannot have the same identityHash).
+	
 	 Behavior implements identityHash to allow the VM to use an object representation which
 	 does not include a direct reference to an object's class in an object.  If the VM is using
 	 this implementation then classes are held in a class table and instances contain the index

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -379,6 +379,16 @@ Character >> asciiValue [
 	^self primitiveFailed
 ]
 
+{ #category : #comparing }
+Character >> basicIdentityHash [
+	"Answer the receiver's character code.
+	 The value answered is unsigned. It can in theory be in the full
+	 poisitive SmallInteger range, but based on Unicode, it is fair
+	 to assume that the value is in the range [ 0 ; 16r3FFFFF ]"
+	<primitive: 171>
+	^self primitiveFailed
+]
+
 { #category : #converting }
 Character >> basicSqueakToIso [
 	| tmp1 |
@@ -451,13 +461,6 @@ Character >> hash [
 { #category : #printing }
 Character >> hex [
 	^ self asInteger hex
-]
-
-{ #category : #comparing }
-Character >> identityHash [
-	"Answer the receiver's character code."
-	<primitive: 171>
-	^self primitiveFailed
 ]
 
 { #category : #testing }

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -24,12 +24,12 @@ ProtoObject >> == anObject [
 
 { #category : #'reflective operations' }
 ProtoObject >> basicIdentityHash [
-	"Answer a SmallInteger whose value is related to the receiver's identity.
-	This method must not be overridden, except by SmallInteger.
-	Primitive. Fails if the receiver is a SmallInteger. Essential.
+	"Answer a 22 bits unsigned SmallInteger whose value is related to the receiver's identity.
+	
+	Primitive. Fails if the receiver is an immediate. Essential.
 	See Object documentation whatIsAPrimitive.
-
-	Do not override. Use #identityHash unless you really know what you're doing.'"
+	
+	Do not override, use #identityHash instead"
 
 	<primitive: 75>
 	self primitiveFailed

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -140,6 +140,15 @@ SmallFloat64 >> arcTan [
 	^ theta
 ]
 
+{ #category : #comparing }
+SmallFloat64 >> basicIdentityHash [
+	"Answer an integer unique to the receiver. 
+	 The value answered is signed, within the full 
+	 SmallInteger range, on the contrary to normal objects."
+	<primitive: 171>
+	^self primitiveFailed
+]
+
 { #category : #copying }
 SmallFloat64 >> clone [
 	"Answer the receiver, because SmallFloat64s are unique."
@@ -224,9 +233,9 @@ SmallFloat64 >> fractionPart [
 
 { #category : #comparing }
 SmallFloat64 >> identityHash [
-	"Answer an integer unique to the receiver."
-	<primitive: 171>
-	^self primitiveFailed
+	"We need the override since basicIdentityHash is already in SmallInteger range,
+	 the bitShift: 8 of the super implementation would lead to a LargeInteger"
+	^ self basicIdentityHash
 ]
 
 { #category : #'mathematical functions' }

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -214,7 +214,8 @@ SmallInteger >> asFloat [
 
 { #category : #'system primitives' }
 SmallInteger >> basicIdentityHash [
-
+	"The value answered is signed, within the full 
+	 SmallInteger range, on the contrary to normal objects."
 	^self
 ]
 
@@ -455,8 +456,9 @@ SmallInteger >> highBitOfPositiveReceiver [
 
 { #category : #comparing }
 SmallInteger >> identityHash [
-
-	^self hashMultiply
+	"Answer a SmallInteger whose value is related to the receiver's identity.
+	 Specific override here to decrease the number of conflicts"
+	^ self hashMultiply
 ]
 
 { #category : #testing }


### PR DESCRIPTION
https://pharo.manuscript.com/f/cases/20936/64bit-primitiveFailure-for-1-0-largeIdentityHash

Fixes on all identityHash and basicIdentityHash methods to make them work in 32 and 64 bits.
Be careful not to create large integers