### PR TITLE
20943-Use-MirrorPrimitives-instead-of-Context-mirror-based-methods

### DIFF
--- a/src/GT-Inspector/GTInspectorProtoObjectNode.class.st
+++ b/src/GT-Inspector/GTInspectorProtoObjectNode.class.st
@@ -31,7 +31,7 @@ GTInspectorProtoObjectNode >> key [
 
 { #category : #accessing }
 GTInspectorProtoObjectNode >> rawValue [ 
-	^ thisContext object: self hostObject instVarAt: index 
+	^ MirrorPrimitives fixedFieldOf: self hostObject at: index 
 ]
 
 { #category : #accessing }

--- a/src/GT-Inspector/ProtoObject.extension.st
+++ b/src/GT-Inspector/ProtoObject.extension.st
@@ -23,11 +23,11 @@ ProtoObject >> gtInspectorActions [
 		from: self class
 		to: ProtoObject)
 		collect: [ :eachPragma | 
-			thisContext
-				object: self
+			MirrorPrimitives
+				withReceiver: self
 				perform: eachPragma methodSelector
 				withArguments: #()
-				inClass: self class ].
+				inSuperclass: self class ].
 	^ all
 		asSortedCollection: [ :a :b | 
 			| first second |
@@ -65,19 +65,19 @@ ProtoObject >> gtInspectorPresentationsFromPragmas: aCollection In: composite in
 						cull: aGTInspector
 						cull: self ].
 			eachPragma methodSelector numArgs = 1
-				ifTrue: [ thisContext
-						object: self
+				ifTrue: [ MirrorPrimitives
+						withReceiver: self
 						perform: eachPragma methodSelector
 						withArguments: {composite}
-						inClass: self class ].
+						inSuperclass: self class ].
 			eachPragma methodSelector numArgs = 2
-				ifTrue: [ thisContext
-						object: self
+				ifTrue: [ MirrorPrimitives
+						withReceiver: self
 						perform: eachPragma methodSelector
 						withArguments:
 							{composite.
 							aGTInspector}
-						inClass: self class ] ]
+						inSuperclass: self class ] ]
 ]
 
 { #category : #'*GT-Inspector' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1314,7 +1314,7 @@ Context >> object: anObject perform: selector withArguments: argArray inClass: l
 	self primitiveFailed
 ]
 
-{ #category : #accessing }
+{ #category : #'mirror primitives' }
 Context >> objectClass: aReceiver [
 	<primitive: 111>
 	self primitiveFailed

--- a/src/Kernel/ModificationForbidden.class.st
+++ b/src/Kernel/ModificationForbidden.class.st
@@ -10,7 +10,7 @@ selector <Symbol> selector that can be used to reproduce the mutation (typically
 "
 Class {
 	#name : #ModificationForbidden,
-	#superclass : #Exception,
+	#superclass : #Error,
 	#instVars : [
 		'object',
 		'fieldIndex',
@@ -21,18 +21,13 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-ModificationForbidden class >> for: anObject atInstVar: fieldIndex with: newValue retrySelector: selector [
+ModificationForbidden class >> for: anObject at: fieldIndex with: newValue retrySelector: selector [
 
 	^self new 
 		object: anObject;
 		fieldIndex: fieldIndex;
 		newValue: newValue;
 		retrySelector: selector
-]
-
-{ #category : #accessing }
-ModificationForbidden >> defaultAction [
-	UnhandledError signalForException: self
 ]
 
 { #category : #accessing }
@@ -104,7 +99,7 @@ ModificationForbidden >> retryModification [
 	fieldIndex notNil
 		ifTrue: [ object perform: retrySelector with: fieldIndex with: newValue ]
 		ifFalse: [object perform: retrySelector with: newValue ].
-	self resume: newValue
+	self resumeUnchecked: newValue
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -182,7 +182,7 @@ ProtoObject >> isNil [
 ProtoObject >> modificationForbiddenFor: selector index: index value: value [
 	^ (ModificationForbidden 
 		for: self
-		atInstVar: index
+		at: index
 		with: value
 		retrySelector: selector) signal
 ]

--- a/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTests.class.st
+++ b/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTests.class.st
@@ -38,6 +38,16 @@ MirrorPrimitivesTests >> testChangingFixedFieldOfFixedObject [
 	self should: [MirrorPrimitives fixedFieldOf: object at: 3 put: 500] raise: PrimitiveFailed
 ]
 
+{ #category : #'tests-write barrier' }
+MirrorPrimitivesTests >> testChangingFixedFieldOfReadOnlyObject [
+
+	| object |
+	object := 10@20.
+	object beReadOnlyObject.
+	
+	self should: [MirrorPrimitives fixedFieldOf: object at: 1 put: 500] raise: ModificationForbidden
+]
+
 { #category : #'tests-fields accessing' }
 MirrorPrimitivesTests >> testChangingFixedFieldOfWeakMessageSend [
 
@@ -126,6 +136,16 @@ MirrorPrimitivesTests >> testChangingIndexableFieldOfArray [
 MirrorPrimitivesTests >> testChangingIndexableFieldOfFixedObject [
 	
 	self should: [MirrorPrimitives indexableFieldOf: 10@20 at: 1 put: 10] raise: Error
+]
+
+{ #category : #'tests-write barrier' }
+MirrorPrimitivesTests >> testChangingIndexableFieldOfReadOnlyArray [
+	
+	| array |
+	array := {10. 20}.
+	array beReadOnlyObject.
+	
+	self should: [MirrorPrimitives indexableFieldOf: array at: 1 put: 5] raise: ModificationForbidden
 ]
 
 { #category : #'tests-fields accessing' }
@@ -387,6 +407,16 @@ MirrorPrimitivesTests >> testGettingIndexibleSizeOfWeakMessageSend [
 	actual := MirrorPrimitives indexableSizeOf: arrayWithInstVars.
 	
 	self assert: actual equals: 1 "receiver of weak message send is stored as first array item"
+]
+
+{ #category : #'tests-comparison' }
+MirrorPrimitivesTests >> testIdenticalEquality [
+
+	| object |
+	object := 0@0.
+	
+	self assert: (MirrorPrimitives check: object identicalTo: object).
+	self deny: (MirrorPrimitives check: object identicalTo: 0@0).
 ]
 
 { #category : #'tests-write barrier' }

--- a/src/ReflectionMirrors-Primitives/MirrorPrimitives.class.st
+++ b/src/ReflectionMirrors-Primitives/MirrorPrimitives.class.st
@@ -12,6 +12,18 @@ Class {
 	#category : #'ReflectionMirrors-Primitives'
 }
 
+{ #category : #comparison }
+MirrorPrimitives class >> check: anObject identicalTo: anotherObject [
+	"Answer whether the first and second arguments are the same object (have the
+	 same object pointer) without sending a message to the first argument.  This
+	 mimics the action of the VM when it compares two object pointers.  Used to
+	 simulate the execution machinery by, for example, the debugger.
+	 Primitive.  See Object documentation whatIsAPrimitive."
+
+	<primitive: 110>
+	self primitiveFailed
+]
+
 { #category : #'class relationship' }
 MirrorPrimitives class >> classOf: anObject [
 	"Primitive. Answer the object which is the receiver's class"
@@ -75,15 +87,24 @@ MirrorPrimitives class >> fixedFieldOf: anObject at: anIndex [
 ]
 
 { #category : #'fields accessing' }
-MirrorPrimitives class >> fixedFieldOf: anObject at: anIndex put: aValue [ 
+MirrorPrimitives class >> fixedFieldOf: anObject at: anIndex put: newValue [ 
 	"Primitive. Store a value into a fixed variable in the argument anObject.
 	 The numbering of the variables corresponds to the named instance
 	 variables.  Fail if the index is not an Integer or is not the index of a
 	 fixed variable.  Answer the value stored as the result"
 
 	<primitive: 74>
-	"Access beyond fixed fields"
-	^self primitiveFail 
+	anIndex isInteger ifTrue: [
+		(anIndex between: 1 and: (self fixedSizeOf: anObject)) 
+			ifTrue: [
+				anObject isReadOnlyObject ifTrue: [ 
+					^self 
+						modificationForbiddenFor: anObject 
+						at: anIndex 
+						with: newValue
+						selector: #instVarAt:put:]].
+		^self primitiveFail].		
+	self errorNonIntegerIndex
 ]
 
 { #category : #'fields accessing' }
@@ -121,7 +142,7 @@ MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex [
 ]
 
 { #category : #'fields accessing' }
-MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex put: newObject [
+MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex put: newValue [
 	"Primitive. Assumes receiver is indexable. Store the argument value in 
 	the indexable element of the receiver indicated by index. Fail if the 
 	index is not an Integer or is out of bounds. Or fail if the value is not of 
@@ -132,7 +153,14 @@ MirrorPrimitives class >> indexableFieldOf: anObject at: anIndex put: newObject 
 	anIndex isInteger ifTrue:
 		[(self classOf: anObject) isVariable
 			ifTrue: [(anIndex between: 1 and: (self indexableSizeOf: anObject))
-					ifTrue: [self errorImproperStore]
+					ifTrue: [
+						anObject isReadOnlyObject ifTrue: [
+							^self 
+								modificationForbiddenFor: anObject 
+								at: anIndex 
+								with: newValue
+								selector: #basicAt:put:].		
+						^self errorImproperStore]
 					ifFalse: [self errorSubscriptBounds: anIndex]]
 			ifFalse: [self errorNotIndexableFor: anObject]].
 	
@@ -159,6 +187,16 @@ MirrorPrimitives class >> isObjectReadOnly: anObject [
 MirrorPrimitives class >> makeObject: anObject readOnly: aBoolean [
 	<primitive: 164 error: ec>
 	^ self primitiveFail
+]
+
+{ #category : #errors }
+MirrorPrimitives class >> modificationForbiddenFor: anObject at: fieldIndex with: newObject selector: selector [
+	
+	^(ModificationForbidden 
+		for: anObject 
+		at: fieldIndex 
+		with: newObject 
+		retrySelector: selector) signal
 ]
 
 { #category : #printing }
@@ -220,6 +258,8 @@ MirrorPrimitives class >> withReceiver: receiver perform: selector withArguments
 	<primitive: 100 error: error>
 	(selector isSymbol)
 		ifFalse: [^ self error: 'selector argument must be a Symbol'].
+	((self classOf: argArray) == Array) ifFalse:
+		[^self error: 'argArray must be an Array'].
 	(selector numArgs = self indexableSizeOf: argArray)
 		ifFalse: [^ self error: 'incorrect number of arguments'].
 	((self classOf: receiver) == lookupClass or: [(self classOf: receiver) inheritsFrom: lookupClass])

--- a/src/Slot/IndexedSlot.class.st
+++ b/src/Slot/IndexedSlot.class.st
@@ -44,10 +44,10 @@ IndexedSlot >> isVirtual [
 
 { #category : #'meta-object-protocol' }
 IndexedSlot >> read: anObject [
-	^ thisContext object: anObject instVarAt: index
+	^ MirrorPrimitives fixedFieldOf: anObject at: index
 ]
 
 { #category : #'meta-object-protocol' }
 IndexedSlot >> write: aValue to: anObject [
-	^ thisContext object: anObject instVarAt: index put: aValue.
+	^ MirrorPrimitives fixedFieldOf: anObject at: index put: aValue
 ]


### PR DESCRIPTION
All users of Context based mirror primitives are now using MirrorPrimitives.
MirrorPrimitives includes ModificationForbidden logic with tests

ModificationForbidden subclassed from Error again. 
Because instead running all tests with some readonly problems will spawn debugger. Because generally exceptions do not catched by SUnit.
But I think this ModificationForbidden must be a error. The fact that it can be fixed and resumed do not made it notification or warning. It is similar to MessageNotUnderstood which is resumable too