### PR TITLE
20952 Super setUp need to be called in ExampleSetTest, SessionManagerRegistrationOrderTest, GTS and GLM prefixed tests

### DIFF
--- a/src/GT-SUnitDebugger/GTSUnitExampleWithProblematicSetUpTest.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitExampleWithProblematicSetUpTest.class.st
@@ -19,6 +19,7 @@ GTSUnitExampleWithProblematicSetUpTest class >> isUnitTest [
 
 { #category : #running }
 GTSUnitExampleWithProblematicSetUpTest >> setUp [
+	super setUp.
 	42 messageThatIsNotUnderstood
 ]
 

--- a/src/GT-SUnitDebugger/GTSUnitExampleWithProblematicSetUpTest.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitExampleWithProblematicSetUpTest.class.st
@@ -19,7 +19,7 @@ GTSUnitExampleWithProblematicSetUpTest class >> isUnitTest [
 
 { #category : #running }
 GTSUnitExampleWithProblematicSetUpTest >> setUp [
-	super setUp.
+	super setUp. 
 	42 messageThatIsNotUnderstood
 ]
 

--- a/src/GT-SUnitDebugger/GTSUnitExampleWithSetUpAndNoTearDownTest.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitExampleWithSetUpAndNoTearDownTest.class.st
@@ -22,6 +22,7 @@ GTSUnitExampleWithSetUpAndNoTearDownTest class >> isUnitTest [
 
 { #category : #running }
 GTSUnitExampleWithSetUpAndNoTearDownTest >> setUp [
+	super setUp.
 	a := 42.
 ]
 

--- a/src/GT-SUnitDebugger/GTSUnitExampleWithSetUpAndTearDownTest.class.st
+++ b/src/GT-SUnitDebugger/GTSUnitExampleWithSetUpAndTearDownTest.class.st
@@ -22,6 +22,7 @@ GTSUnitExampleWithSetUpAndTearDownTest class >> isUnitTest [
 
 { #category : #running }
 GTSUnitExampleWithSetUpAndTearDownTest >> setUp [
+	super setUp.
 	a := 42.
 ]
 

--- a/src/Glamour-Tests-Core/GLMTransmissionScriptingTest.class.st
+++ b/src/Glamour-Tests-Core/GLMTransmissionScriptingTest.class.st
@@ -9,6 +9,7 @@ Class {
 
 { #category : #running }
 GLMTransmissionScriptingTest >> setUp [
+	super setUp.
 	browser := GLMExplicitBrowser new.
 	browser addPane: (GLMPane new name: #one).
 	browser addPane: (GLMPane new name: #two).

--- a/src/Glamour-Tests-Core/GLMTreePresentationTest.class.st
+++ b/src/Glamour-Tests-Core/GLMTreePresentationTest.class.st
@@ -10,6 +10,7 @@ Class {
 
 { #category : #running }
 GLMTreePresentationTest >> setUp [
+	super setUp.
 	pane := GLMPane named: 'test'.
 	presentation := GLMTreePresentation new.
 	pane addPresentation: presentation.

--- a/src/SUnit-Tests/ExampleSetTest.class.st
+++ b/src/SUnit-Tests/ExampleSetTest.class.st
@@ -13,6 +13,7 @@ Class {
 
 { #category : #running }
 ExampleSetTest >> setUp [
+	super setUp.
 	empty := Set new.
 	full := Set with: 5 with: #abc
 ]

--- a/src/System-SessionManager-Tests/SessionManagerRegistrationOrderTest.class.st
+++ b/src/System-SessionManager-Tests/SessionManagerRegistrationOrderTest.class.st
@@ -24,6 +24,7 @@ SessionManagerRegistrationOrderTest >> register: aString atSystemPriority: anInt
 
 { #category : #running }
 SessionManagerRegistrationOrderTest >> setUp [
+	super setUp.
 	manager := SessionManager new
 ]
 


### PR DESCRIPTION
add missing super setUp calls.

https://pharo.fogbugz.com/f/cases/20952/Super-setUp-need-to-be-called-in-ExampleSetTest-SessionManagerRegistrationOrderTest-GTS-and-GLM-prefixed-tests