### PR TITLE
20960-Move-ExecutionDisplayPlugin-from-Reflectivity-Examples-directly-to-Nautilus-

### DIFF
--- a/src/Nautilus/ExecutionDisplayMorph.class.st
+++ b/src/Nautilus/ExecutionDisplayMorph.class.st
@@ -7,7 +7,7 @@ My color (the execution indicator) fades away over time.
 Class {
 	#name : #ExecutionDisplayMorph,
 	#superclass : #BorderedMorph,
-	#category : #'Reflectivity-Examples'
+	#category : #'Nautilus-Plugins-Examples'
 }
 
 { #category : #private }

--- a/src/Nautilus/ExecutionDisplayPlugin.class.st
+++ b/src/Nautilus/ExecutionDisplayPlugin.class.st
@@ -8,7 +8,7 @@ Class {
 		'morph',
 		'link'
 	],
-	#category : #'Reflectivity-Examples'
+	#category : #'Nautilus-Plugins-Examples'
 }
 
 { #category : #position }

--- a/src/Nautilus/NautilusUI.class.st
+++ b/src/Nautilus/NautilusUI.class.st
@@ -1843,6 +1843,11 @@ NautilusUI >> signatureFor: aSelector [
 		ifFalse: [ aSelector ]
 ]
 
+{ #category : #'smart suggestions support' }
+NautilusUI >> sugsContext [
+	^ SugsNautilusContext model: self.
+]
+
 { #category : #'menus behavior' }
 NautilusUI >> toggleBreakConditionOnEntryIn: aMethod [
 	"Install or uninstall a halt-on-entry breakpoint"

--- a/src/Nautilus/SugsNautilusContext.class.st
+++ b/src/Nautilus/SugsNautilusContext.class.st
@@ -1,0 +1,77 @@
+"
+The implementation who asumes that my model it's a nautilus object.
+"
+Class {
+	#name : #SugsNautilusContext,
+	#superclass : #SugsAbstractContext,
+	#category : #Nautilus
+}
+
+{ #category : #refactoring }
+SugsNautilusContext >> browsedEnvironment [
+	^ model browsedEnvironment
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> code [
+
+	^ self sourceTextArea getString
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> contentSelection [
+	^ model contentSelection
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> flashSourceCodeArea [
+	^ model flashSourceCodeArea
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> formatSourceCode [
+	| formatted |
+	formatted := selectedNode formattedCode.
+	formatted = self code
+		ifTrue: [ ^ self ].
+	self sourceTextArea
+		formatSourceCodeInView;
+		hasUnacceptedEdits: true
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> selectTheTextForTheNode [
+	selectionPreviousHighligth := self selectedInterval.
+	selectedNode ifNotNil: [ self contentSelection ]
+]
+
+{ #category : #accessing }
+SugsNautilusContext >> selectedClass [
+	^ model selectedClass
+]
+
+{ #category : #accessing }
+SugsNautilusContext >> selectedInterval [
+
+	^ model selectionInterval
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> selectedMethod [
+	^ model selectedMethod
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> selectionInterval [
+	^ model selectionInterval
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> sourceTextArea [
+	^ model sourceTextModel
+]
+
+{ #category : #refactoring }
+SugsNautilusContext >> window [
+	^ model window 
+]


### PR DESCRIPTION
ExecutionDisplayPlugin and ExecutionDisplayMorph are moved to the Nautilus under 'Plugins-Examples' tag.https://pharo.fogbugz.com/f/cases/20960/Move-ExecutionDisplayPlugin-from-Reflectivity-Examples-directly-to-Nautilus