### PR TITLE
20964 Unused temp variables in ConfigurationCommandLineHandler

### DIFF
--- a/src/ConfigurationCommandLineHandler-Core/ConfigurationCommandLineHandler.class.st
+++ b/src/ConfigurationCommandLineHandler-Core/ConfigurationCommandLineHandler.class.st
@@ -198,7 +198,7 @@ ConfigurationCommandLineHandler >> listConfigurations [
 
 { #category : #actions }
 ConfigurationCommandLineHandler >> loadConfigurationNames [
-	| references configurations |
+	| references |
 	
 	references := self gofer allResolved.
 		


### PR DESCRIPTION
remove unused temp var

https://pharo.fogbugz.com/f/cases/20964/Unused-temp-variables-in-ConfigurationCommandLineHandler