### PR TITLE
20921 PackageChecker>>check not needed anymore

### DIFF
--- a/src/Deprecated70/PackageChecker.class.st
+++ b/src/Deprecated70/PackageChecker.class.st
@@ -4,7 +4,7 @@ Utility class to check packages
 Class {
 	#name : #PackageChecker,
 	#superclass : #Object,
-	#category : #'RPackage-Tests'
+	#category : #Deprecated70
 }
 
 { #category : #check }


### PR DESCRIPTION
It is the only method in this class. We move this class to Deprecated70 to remove it in Pharo 8

https://pharo.fogbugz.com/f/cases/20921/PackageChecker-check-not-needed-anymore