### PR TITLE
20968 Unused temps in various GML methods

### DIFF
--- a/src/Glamour-Browsers/GLMWizard.class.st
+++ b/src/Glamour-Browsers/GLMWizard.class.st
@@ -619,7 +619,6 @@ GLMWizard >> updateBrowserTitle [
 { #category : #events }
 GLMWizard >> updatePane [
 
-	|tmpPane|
 	self notifyAndSetAsCurrentPane: self computePane.
 ]
 
@@ -643,7 +642,6 @@ GLMWizard >> updateWhenNext [
 { #category : #events }
 GLMWizard >> updateWhenPrevious [
 
-	|tmpPane|
 	self notifyAndRemoveCurrentPane.
 	self stepToUse decrementNumberOfDisplay.
 	self stepToUse overBeginning 

--- a/src/Glamour-Morphic-Widgets/GLMExpanderLabelNodeModel.class.st
+++ b/src/Glamour-Morphic-Widgets/GLMExpanderLabelNodeModel.class.st
@@ -42,7 +42,7 @@ GLMExpanderLabelNodeModel >> displayText [
 
 { #category : #callbacks }
 GLMExpanderLabelNodeModel >> elementColumn [
-	| row tags tagsFilter |
+	| row |
 	row := OrderedCollection with: (self displayText).
 	
 "	tags:= self containerTree glamourPresentation tagsFor: self item to: #show.

--- a/src/Glamour-Tests-Core/GLMPortTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPortTest.class.st
@@ -123,7 +123,7 @@ GLMPortTest >> testSimplePort [
 
 { #category : #tests }
 GLMPortTest >> testTransientValue [
-	| port pane browser |
+	| browser |
 	browser := GLMTabulator new.
 	browser
 		column: #one;

--- a/src/Glamour-Tests-Core/GLMPresentationTest.class.st
+++ b/src/Glamour-Tests-Core/GLMPresentationTest.class.st
@@ -113,7 +113,7 @@ GLMPresentationTest >> testCopyRootPrototype [
 
 { #category : #tests }
 GLMPresentationTest >> testCopyTheTransformation [
-	| presentation newPresentation transformation |
+	| presentation newPresentation |
 	presentation := GLMPresentation new.
 	presentation selectionTransformation: [:each | each + 1].
 	newPresentation := presentation copy.

--- a/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMListMorphicTest.class.st
@@ -106,7 +106,7 @@ GLMListMorphicTest >> testOnlyOneMorphPerRowInList [
 
 { #category : #tests }
 GLMListMorphicTest >> testTextBackgroundColor [
-	| browser firstTreeMorph secondTreeMorph treeNodeMorph txtMorph |
+	| browser firstTreeMorph treeNodeMorph txtMorph |
 	browser := GLMTabulator new.
 	browser column: #one.
 	browser transmit

--- a/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTabulatorMorphicTest.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #tests }
 GLMTabulatorMorphicTest >> testMultipleInitialSelection [
-	| browser firstTreeMorph secondTreeMorph |
+	| browser firstTreeMorph |
 	browser := GLMTabulator new.
 	browser column: #one.
 	browser

--- a/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
+++ b/src/Glamour-Tests-Morphic/GLMTextMorphicTest.class.st
@@ -61,7 +61,7 @@ GLMTextMorphicTest >> testPastingUpdatesTextPort [
 
 { #category : #tests }
 GLMTextMorphicTest >> testResettingTheSelection [
-	| composite textMorph textPresentation |
+	| composite textPresentation |
 	composite := GLMCompositePresentation new with: [ :a | a text display: '123456789' ].
 	window := composite openOn: 4.
 	textPresentation := composite presentations first.


### PR DESCRIPTION
 
Fix unused temps in 

GLMWizard>>#updateWhenPrevious
GLMExpanderLabelNodeModel>>#elementColumn
GLMListMorphicTest>>#testTextBackgroundColor
GLMPortTest>>#testTransientValue"
GLMPresentationTest>>#testCopyTheTransformation
GLMTabulatorMorphicTest>>#testMultipleInitialSelection
GLMTextMorphicTest>>#testResettingTheSelection
GLMWizard>>#updatePane

https://pharo.fogbugz.com/f/cases/20968/Unused-temps-in-various-GML-methods