### PR TITLE
20972-ShiftClassInstaller-do-not-announce-ClassModificationApplied-event

### DIFF
--- a/src/Shift-Changes/ShAbstractChange.class.st
+++ b/src/Shift-Changes/ShAbstractChange.class.st
@@ -17,7 +17,7 @@ Class {
 		'builder',
 		'oldClass'
 	],
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #comparing }

--- a/src/Shift-Changes/ShAbstractChangeDetector.class.st
+++ b/src/Shift-Changes/ShAbstractChangeDetector.class.st
@@ -14,7 +14,7 @@ Class {
 	#instVars : [
 		'builder'
 	],
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #comparing }

--- a/src/Shift-Changes/ShAbstractInstanceSideClassChangeDetector.class.st
+++ b/src/Shift-Changes/ShAbstractInstanceSideClassChangeDetector.class.st
@@ -4,7 +4,7 @@ I am an special Class change detector, used when we have to include the change i
 Class {
 	#name : #ShAbstractInstanceSideClassChangeDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #changes }

--- a/src/Shift-Changes/ShBitLayoutChangeDetector.class.st
+++ b/src/Shift-Changes/ShBitLayoutChangeDetector.class.st
@@ -4,7 +4,7 @@ I can compare an old class and a builder to detect if the layout kind changed an
 Class {
 	#name : #ShBitLayoutChangeDetector,
 	#superclass : #ShAbstractChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #comparing }

--- a/src/Shift-Changes/ShBitLayoutChanged.class.st
+++ b/src/Shift-Changes/ShBitLayoutChanged.class.st
@@ -5,7 +5,7 @@ Specially if there is a change from PointerLayout to BitLayout and if there is n
 Class {
 	#name : #ShBitLayoutChanged,
 	#superclass : #ShAbstractChange,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #propagating }

--- a/src/Shift-Changes/ShClassChanged.class.st
+++ b/src/Shift-Changes/ShClassChanged.class.st
@@ -5,12 +5,13 @@ I announce with a copy of the old class and the new class.
 Class {
 	#name : #ShClassChanged,
 	#superclass : #ShAbstractChange,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #announcing }
 ShClassChanged >> announceChanges [
 	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass to: builder newClass.
+	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newClass
 ]
 
 { #category : #announcing }

--- a/src/Shift-Changes/ShClassSlotChangeDetector.class.st
+++ b/src/Shift-Changes/ShClassSlotChangeDetector.class.st
@@ -4,7 +4,7 @@ I know how to detect a change in the collection of slots of the metaclass.
 Class {
 	#name : #ShClassSlotChangeDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShClassTraitCompositionChangedDetector.class.st
+++ b/src/Shift-Changes/ShClassTraitCompositionChangedDetector.class.st
@@ -5,7 +5,7 @@ I will not rest longer!!! I should go to the modular trait library.
 Class {
 	#name : #ShClassTraitCompositionChangedDetector,
 	#superclass : #ShTraitCompositionChangedDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShInstanceShapeChanged.class.st
+++ b/src/Shift-Changes/ShInstanceShapeChanged.class.st
@@ -6,7 +6,7 @@ I propagate the changes adding a change like me in the subclasses.
 Class {
 	#name : #ShInstanceShapeChanged,
 	#superclass : #ShAbstractChange,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #testing }

--- a/src/Shift-Changes/ShLayoutChangeDetector.class.st
+++ b/src/Shift-Changes/ShLayoutChangeDetector.class.st
@@ -4,7 +4,7 @@ I know how to detect a change in the layout of a class.
 Class {
 	#name : #ShLayoutChangeDetector,
 	#superclass : #ShAbstractInstanceSideClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -5,12 +5,13 @@ I announce with a copy of the old class and the new class.
 Class {
 	#name : #ShMetaclassChanged,
 	#superclass : #ShAbstractChange,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #announcing }
 ShMetaclassChanged >> announceChanges [
 	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass class to: builder newMetaclass.
+	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newMetaclass
 ]
 
 { #category : #accessing }

--- a/src/Shift-Changes/ShNoChangesInClass.class.st
+++ b/src/Shift-Changes/ShNoChangesInClass.class.st
@@ -4,5 +4,5 @@ This notification is raised if there is no changes in a class when invoked the c
 Class {
 	#name : #ShNoChangesInClass,
 	#superclass : #Notification,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }

--- a/src/Shift-Changes/ShSharedPoolChangeDetector.class.st
+++ b/src/Shift-Changes/ShSharedPoolChangeDetector.class.st
@@ -4,7 +4,7 @@ I know how to detect a change in the shared pools.
 Class {
 	#name : #ShSharedPoolChangeDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-Changes/ShSharedVariablesChangeDetector.class.st
@@ -4,7 +4,7 @@ I know how to detect a change in the collection of the shared variables (class v
 Class {
 	#name : #ShSharedVariablesChangeDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShSlotChangeDetector.class.st
+++ b/src/Shift-Changes/ShSlotChangeDetector.class.st
@@ -4,7 +4,7 @@ I know how to detect a change in the collection of slots.
 Class {
 	#name : #ShSlotChangeDetector,
 	#superclass : #ShAbstractInstanceSideClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShSuperclassChangedDetector.class.st
+++ b/src/Shift-Changes/ShSuperclassChangedDetector.class.st
@@ -4,7 +4,7 @@ I detect if there is a change in the superclass
 Class {
 	#name : #ShSuperclassChangedDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #initialization }

--- a/src/Shift-Changes/ShTraitCompositionChangedDetector.class.st
+++ b/src/Shift-Changes/ShTraitCompositionChangedDetector.class.st
@@ -5,7 +5,7 @@ I will not rest longer!!! I should go to the modular trait library.
 Class {
 	#name : #ShTraitCompositionChangedDetector,
 	#superclass : #ShAbstractClassChangeDetector,
-	#category : 'Shift-Changes'
+	#category : #'Shift-Changes'
 }
 
 { #category : #accessing }


### PR DESCRIPTION
Class changes should notify ClassModificationApplied for Pharo6 compatibility

https://pharo.fogbugz.com/f/cases/20972/ShiftClassInstaller-do-not-announce-ClassModificationApplied-event