### PR TITLE
20962-Rubric-should-not-depends-on-NautilusCommons2

### DIFF
--- a/src/Nautilus/RubCommentAnnotationDisplayer.class.st
+++ b/src/Nautilus/RubCommentAnnotationDisplayer.class.st
@@ -11,7 +11,7 @@ Class {
 		'lineNumbersDisplayMorph',
 		'extendCommentPolicyMorph'
 	],
-	#category : #'Rubric-Editing-Widgets'
+	#category : #'Nautilus-Rubric'
 }
 
 { #category : #querying }


### PR DESCRIPTION
RubCommentAnnotationDisplayer is moved to Nautilus under tag Rubric

https://pharo.fogbugz.com/f/cases/20962/Rubric-should-not-depends-on-NautilusCommons