### PR TITLE
20942-Integrate-Epicea-826-in-Ph7

### DIFF
--- a/src/Epicea/EpLog.class.st
+++ b/src/Epicea/EpLog.class.st
@@ -1,7 +1,13 @@
 "
 I am a log of system events.
 
-Normally I enable a monitor (an EpMonitor), who adds instances of EpEvent into me.
+A user of my instances is EpMonitor, who adds instances of EpEvent into me when certain system announcements happen.
+
+My #entries contain the events ordered as ""the oldest first"".
+
+Examples:
+
+EpLog freshFromFile: 'path/to/ombu/file.ombu' asFileReference.
 "
 Class {
 	#name : #EpLog,
@@ -37,6 +43,13 @@ EpLog class >> new [
 EpLog class >> newNull [
 
 	^ self newWithStore: OmNullStore new.
+]
+
+{ #category : #'instance creation' }
+EpLog class >> newWithEvents: eventsTheOldestFirst [
+
+	^ self newWithStore: (OmMemoryStore withAll: eventsTheOldestFirst)
+
 ]
 
 { #category : #'instance creation' }

--- a/src/Epicea/EpRenameClassRefactoring.class.st
+++ b/src/Epicea/EpRenameClassRefactoring.class.st
@@ -21,9 +21,10 @@ EpRenameClassRefactoring class >> rename: oldName to: newName [
 
 { #category : #converting }
 EpRenameClassRefactoring >> asRBRefactoring [
-	^ RBRenameClassRefactoring
-		rename: oldName
-		to: newName
+
+	^ RBRenameClassRefactoring new 
+		className: oldName 
+		newName: newName
 ]
 
 { #category : #'initialize-release' }

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -65,13 +65,15 @@ EpApplyPreviewer >> visitBehaviorCommentChange: aChange [
 	self
 		behaviorNamed: aChange behaviorAffectedName
 		ifPresent: [ :aBehavior | 
-			^ { EpBehaviorCommentChange 
-					newWithBehavior: aBehavior
-					oldComment: aBehavior organization classComment
-					newComment: aChange newComment 
-					oldStamp: aBehavior organization commentStamp
-					newStamp: aChange newStamp 
-				} ].
+			(aBehavior organization classComment = aChange newComment) ifFalse: [ 
+				^ { 
+					EpBehaviorCommentChange 
+						newWithBehavior: aBehavior
+						oldComment: aBehavior organization classComment
+						newComment: aChange newComment 
+						oldStamp: aBehavior organization commentStamp
+						newStamp: aChange newStamp 
+				} ] ].
 
 	^ #()
 ]

--- a/src/EpiceaBrowsers/EpLatestCodeChangeFilter.class.st
+++ b/src/EpiceaBrowsers/EpLatestCodeChangeFilter.class.st
@@ -30,20 +30,13 @@ EpLatestCodeChangeFilter >> accepts: anOmEntry [
 	finalReference := log referenceTo: anOmEntry.
 	anOmEntry content isCodeChange ifFalse: [ ^ false ].
 
-	self entriesFromHead do: [:each |
+	logBrowserModel cachedLogEntries reverseDo: [:each |
 		(log referenceTo: each) = finalReference ifTrue: [ ^ true ].
 		(each content isCodeChange and: [
 			each content doesOverride: anOmEntry content ]) ifTrue: [ ^ false ].
 	].
 
 	^ false "shouldn't happen"
-]
-
-{ #category : #private }
-EpLatestCodeChangeFilter >> entriesFromHead [
-	"Answer a cached collection of entries where first is the most recent one."
-	
-	^ logBrowserModel cachedLogEntries
 ]
 
 { #category : #comparing }

--- a/src/EpiceaBrowsers/EpLogBrowserModel.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserModel.class.st
@@ -130,12 +130,13 @@ EpLogBrowserModel >> applyChangesIn: entries [
 EpLogBrowserModel >> applyCompleteRefactoringInSelection [
 
 	| entries |
-	entries := self selectedEntryItems.
-	entries ifEmpty: [ ^ self inform: 'No code changes to apply' ].
+	entries := self selectedEntries.
+	entries size = 1 ifFalse: [ 
+		^ self inform: 'Please select one refactoring' ]. "Only implemented for one"
 	
 	EpLogBrowserOperationFactory new
 		logBrowserModel: self;
-		entries: { entries first };  "TODO: only first?"
+		entries: entries;
 		errorHandlerBlock: self operationsErrorHandlerBlock;	
 		applyCompleteRefactoring.
 
@@ -145,12 +146,13 @@ EpLogBrowserModel >> applyCompleteRefactoringInSelection [
 EpLogBrowserModel >> applyPropagateRefactoringInSelection [
 
 	| entries |
-	entries := self selectedEntryItems.
-	entries ifEmpty: [ ^ self inform: 'No code changes to apply' ].
+	entries := self selectedEntries.
+	entries size = 1 ifFalse: [ 
+		^ self inform: 'Please select one refactoring' ]. "Only implemented for one"
 	
 	EpLogBrowserOperationFactory new
 		logBrowserModel: self;
-		entries: { entries first };  "TODO: only first?"
+		entries: entries;
 		errorHandlerBlock: self operationsErrorHandlerBlock;
 		applyPropagateRefactoring.
 
@@ -220,7 +222,7 @@ EpLogBrowserModel >> cachedLogEntries [
 		ifFalse: [
 			'Reading log'
 				displayProgressFrom: 0 to: 1 
-				during: [ cachedLogEntries := log entries reversed ]
+				during: [ cachedLogEntries := log entries ]
 			]
 
 ]
@@ -331,7 +333,7 @@ EpLogBrowserModel >> eventsMenuActions [
 EpLogBrowserModel >> fileOutSelection [
 
 	| entries outputDirectory |
-	entries := (self selectedEntryItems collect: [ :each | each entry ]) reversed.
+	entries := self selectedEntryItems collect: [ :each | each entry ].
 	outputDirectory := log store directory.
 	
 	EpOmbuExporter askFileNameAndFileOut: entries in: outputDirectory.
@@ -342,7 +344,7 @@ EpLogBrowserModel >> filterAfter [
 
 	self selectedEntryItems ifNotEmpty: [ :items |
 		| time |
-		time := items last entry tags at: EpLog timeKey.
+		time := items first entry tags at: EpLog timeKey.
 		self addFilter: (EpPluggableFilter after: time) ]
 ]
 
@@ -386,7 +388,7 @@ EpLogBrowserModel >> filterBefore [
 
 	self selectedEntryItems ifNotEmpty: [ :items |
 		| time |
-		time := items first entry tags at: EpLog timeKey.
+		time := items last entry tags at: EpLog timeKey.
 		self addFilter: (EpPluggableFilter before: time) ]
 ]
 
@@ -729,7 +731,6 @@ EpLogBrowserModel >> openPreviewToApplySelectedChanges [
 
 	| entries previewLog |
 	entries := self selectedCodeChanges.
-	entries ifEmpty: [ entries := self filteredEntries ].
 	entries ifEmpty: [ ^ self inform: 'No changes to preview apply' ].
 
 	previewLog := EpLogBrowserOperationFactory new
@@ -748,7 +749,6 @@ EpLogBrowserModel >> openPreviewToRevertSelectedChanges [
 
 	| entries previewLog |
 	entries := self selectedCodeChanges.
-	entries ifEmpty: [ entries := self filteredEntries ].
 	entries ifEmpty: [ ^ self inform: 'No changes to preview revert' ].
 
 	previewLog := EpLogBrowserOperationFactory new
@@ -793,7 +793,7 @@ EpLogBrowserModel >> refresh [
 
 	"Refresh log"
 	itemsModel resetSelection. "Needed, else #items: can silently fail"
-	itemsModel items: self filteredEntryReferences.
+	itemsModel items: self filteredEntryReferences reversed.
 
 	"Refresh toolbar"	
 	toolbarModel refresh.
@@ -889,6 +889,12 @@ EpLogBrowserModel >> selectedCodeChanges [
 ]
 
 { #category : #'menu - accessing' }
+EpLogBrowserModel >> selectedEntries [
+
+	^ self selectedEntryItems collect: #entry
+]
+
+{ #category : #'menu - accessing' }
 EpLogBrowserModel >> selectedEntryItems [
 
 	^ self selectedEntryReferences collect: [:each |
@@ -897,9 +903,9 @@ EpLogBrowserModel >> selectedEntryItems [
 
 { #category : #'menu - accessing' }
 EpLogBrowserModel >> selectedEntryReferences [
-	self flag: #todo. "Workaround: FastTableModel can return nil"
+	self flag: #todo. "Workaround: FastTableModel might return nil items"
 
-	^ itemsModel selectedItemsSorted select: [:each | each isNotNil ]
+	^ itemsModel selectedItemsSorted reversed select: [:each | each isNotNil ]
 ]
 
 { #category : #accessing }

--- a/src/EpiceaBrowsers/EpLogBrowserOperationFactory.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserOperationFactory.class.st
@@ -1,5 +1,7 @@
 "
-I implement behavior to apply and revert code changes.
+I implement behavior to apply and revert code changes. 
+
+Important Note: My #entries are expected to be ordered as ""the oldest first"" (as in EpLog>>entries).
 "
 Class {
 	#name : #EpLogBrowserOperationFactory,
@@ -14,10 +16,11 @@ Class {
 
 { #category : #public }
 EpLogBrowserOperationFactory >> applyCodeChanges [
+	"Note: This method is intended to be used from EpLogBrowser's preview mode, where the code changes were previously transformed at #newApplyPreviewLog."
 
 	self
 		trigger: [ 
-			self entries reverseDo: [:each |
+			self entries do: [:each |
 				self handleErrorDuring: [ 
 					each content applyCodeChange ]]] 
 		with: self newApplyEvent
@@ -27,7 +30,7 @@ EpLogBrowserOperationFactory >> applyCodeChanges [
 EpLogBrowserOperationFactory >> applyCompleteRefactoring [
 
 	| refactoringEntry refactoring |
-	refactoringEntry := self entries first entries first. "TODO: only first?"
+	refactoringEntry := self entries first. "Refactorings are applied one at time"
 	refactoring := refactoringEntry content asRBRefactoring.
 	
 	self applyRBRefactoring: refactoring
@@ -38,7 +41,7 @@ EpLogBrowserOperationFactory >> applyCompleteRefactoring [
 EpLogBrowserOperationFactory >> applyPropagateRefactoring [
 
 	| refactoringEntry refactoring |
-	refactoringEntry := self entries first entries first. "TODO: only first?"
+	refactoringEntry := self entries first. "Refactorings are applied one at time"
 	refactoring := EpRBPropagateRefactoring target: refactoringEntry content asRBRefactoring.
 
 	self applyRBRefactoring: refactoring
@@ -64,6 +67,8 @@ EpLogBrowserOperationFactory >> entries [
 
 { #category : #accessing }
 EpLogBrowserOperationFactory >> entries: aCollection [
+	"Important Note: My #entries must be sorted the oldest first."
+
 	entries := aCollection
 ]
 
@@ -77,6 +82,12 @@ EpLogBrowserOperationFactory >> errorHandlerBlock: aBlock [
 	errorHandlerBlock := aBlock
 ]
 
+{ #category : #accessing }
+EpLogBrowserOperationFactory >> events [
+
+	^ self entries collect: [:each | each content ]
+]
+
 { #category : #private }
 EpLogBrowserOperationFactory >> handleErrorDuring: aBlock [
 	"TODO: do not catch *all* Errors.
@@ -87,6 +98,21 @@ EpLogBrowserOperationFactory >> handleErrorDuring: aBlock [
 		on: Error
 		do: self errorHandlerBlock
 
+]
+
+{ #category : #private }
+EpLogBrowserOperationFactory >> latestEventsFrom: previewEventsTheOldestFirst [
+	"TODO: move method"
+	
+	| aLog filter |
+	aLog := EpLog newWithStore: (OmMemoryStore withAll: previewEventsTheOldestFirst).
+	logBrowserModel := EpLogBrowserModel newWithLog: aLog.
+	filter := EpLatestCodeChangeFilter new
+		logBrowserModel: logBrowserModel;
+		yourself.
+	^ aLog entries 
+		select: [ :each | filter accepts: each ] 
+		thenCollect: [ :each | each content ]
 ]
 
 { #category : #accessing }
@@ -110,26 +136,12 @@ EpLogBrowserOperationFactory >> newApplyEvent [
 EpLogBrowserOperationFactory >> newApplyPreviewLog [
 
 	| events |
-	events := self entries flatCollect: [:each | 
-		each content previewedApplyEvents ].
+	events := self latestEventsFrom: self events.
+
+	events := events flatCollect: [:each | 
+		each previewedApplyEvents ].
 	
-	^ self newPreviewLogFor: events
-
-]
-
-{ #category : #private }
-EpLogBrowserOperationFactory >> newPreviewLogFor: rawEvents [
-
-	| aLog filter latestEvents |
-	self flag: #fix.
-	aLog := EpLog newWithStore: (OmMemoryStore withAll: rawEvents).
-	logBrowserModel := EpLogBrowserModel newWithLog: aLog.
-	filter := EpLatestCodeChangeFilter new logBrowserModel: logBrowserModel; yourself.
-	latestEvents := aLog entries 
-		select: [:each | filter accepts: each ]
-		thenCollect: [:each | each content ].
-
-	^ EpLog newWithStore: (OmMemoryStore withAll: latestEvents)
+	^ EpLog newWithEvents: events
 
 ]
 
@@ -144,10 +156,12 @@ EpLogBrowserOperationFactory >> newRevertEvent [
 EpLogBrowserOperationFactory >> newRevertPreviewLog [
 
 	| events |
-	events := self entries reversed flatCollect: [:each | 
-		each content asRevertedCodeChange previewedApplyEvents ].
+	events := self latestEventsFrom: self events reversed.
 
-	^ self newPreviewLogFor: events
+	events := events flatCollect: [:each | 
+		each asRevertedCodeChange previewedApplyEvents ].
+
+	^ EpLog newWithEvents: events
 
 ]
 
@@ -156,7 +170,7 @@ EpLogBrowserOperationFactory >> revertCodeChanges [
 
 	self
 		trigger: [ 
-			self entries do: [:each | 
+			self entries reverseDo: [:each | 
 				self handleErrorDuring: [ 
 					each content asRevertedCodeChange applyCodeChange ]]]
 		with: self newRevertEvent
@@ -164,10 +178,11 @@ EpLogBrowserOperationFactory >> revertCodeChanges [
 
 { #category : #public }
 EpLogBrowserOperationFactory >> revertCodeChangesInPreviewMode [
+	"Note: This method is intended to be used from EpLogBrowser's preview mode, where the code changes were previously transformed at #newRevertPreviewLog. That's why here the transformed code changes are simply applied as if was a redo (apply) operation and not as an undo (revert)."
 
 	self
 		trigger: [ 
-			self entries reverseDo: [:each |
+			self entries do: [:each |
 				self handleErrorDuring: [ 
 					each content applyCodeChange ]]] 
 		with: self newRevertEvent

--- a/src/EpiceaBrowsersTests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsersTests/EpApplyPreviewerTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #resources }
 EpApplyPreviewerTest >> assertEmptyPreviewLog [
 
-	self assert: self outputEvents isEmpty.
+	self assert: self outputEvents isEmpty description: 'Shouldn''t find anything to apply'.
 ]
 
 { #category : #resources }
@@ -48,7 +48,7 @@ EpApplyPreviewerTest >> outputEvents [
 	outputLog :=
 		EpLogBrowserOperationFactory new
 			logBrowserModel: logBrowserModel;
-			entries: { inputEntry };
+			entries: inputEntries;
 			errorHandlerBlock: [:error | error signal ];
 			newApplyPreviewLog.
 	
@@ -427,6 +427,19 @@ EpApplyPreviewerTest >> testRedundantBehaviorCategoryChangeWithAbsentBehavior [
 ]
 
 { #category : #tests }
+EpApplyPreviewerTest >> testRedundantBehaviorCommentChange [
+
+	| aClass |
+	aClass := classFactory newClass.
+	aClass classComment: 'before'.
+	aClass classComment: 'after'.
+	aClass classComment: 'before'.
+	self setHeadAsInputEntry.
+
+	self assertEmptyPreviewLog.
+]
+
+{ #category : #tests }
 EpApplyPreviewerTest >> testRedundantBehaviorCommentChangeWithAbsentBehavior [
 
 	| aClass |
@@ -566,6 +579,19 @@ EpApplyPreviewerTest >> testRedundantProtocolRemoval [
 ]
 
 { #category : #'tests - multiple changes' }
+EpApplyPreviewerTest >> testRedundantSequenceOfMethodModifications [
+
+	| aClass |
+	aClass := classFactory newClass.
+	aClass compile: 'fortyTwo ^42' classified: 'number'.
+	aClass compile: 'fortyTwo ^43' classified: 'number'.
+	aClass compile: 'fortyTwo ^44' classified: 'number'.
+	self setMonitorLogAsInputEntries.
+
+	self assertEmptyPreviewLog
+]
+
+{ #category : #'tests - multiple changes' }
 EpApplyPreviewerTest >> testSequenceOfClassAndMethodAddition [
 
 	| aClass |
@@ -580,6 +606,28 @@ EpApplyPreviewerTest >> testSequenceOfClassAndMethodAddition [
 		| outputClasses |
 		outputClasses := output collect: #class as: Array.
 		self assert: outputClasses equals: { EpClassAddition. EpMethodAddition }.
+		]
+
+]
+
+{ #category : #'tests - multiple changes' }
+EpApplyPreviewerTest >> testSequenceOfMethodModifications [
+
+	| aClass |
+	aClass := classFactory newClass.
+	aClass compile: 'fortyTwo ^42' classified: 'number'.
+	aClass compile: 'fortyTwo ^43' classified: 'number'.
+	aClass compile: 'fortyTwo ^44' classified: 'number'.
+	self setMonitorLogAsInputEntries.
+
+	aClass removeSelector: #fortyTwo.
+	aClass removeFromSystem.
+
+	self assertOutputsEventsWith: [:output | 
+		| outputClasses |
+		outputClasses := output collect: #class as: Array.
+		self assert: outputClasses equals: { EpClassAddition. EpMethodModification }.
+		self assert: output last methodAffectedSourceCode equals: 'fortyTwo ^44'.
 		]
 
 ]

--- a/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
+++ b/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
@@ -249,11 +249,11 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 	aClass := classFactory newClass.
 	aClass compile: 'fortyTwo ^42'.
 
-	headBeforeRecompiling := monitor head.
+	headBeforeRecompiling := monitor log head.
 
 	aClass compile: 'fortyTwo ^42'.
 	
-	self assert: monitor head == headBeforeRecompiling
+	self assert: monitor log head == headBeforeRecompiling
 ]
 
 { #category : #tests }

--- a/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
+++ b/src/EpiceaTests/EpCodeChangeIntegrationTest.class.st
@@ -249,11 +249,11 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 	aClass := classFactory newClass.
 	aClass compile: 'fortyTwo ^42'.
 
-	headBeforeRecompiling := monitor log head.
+	headBeforeRecompiling := monitor head.
 
 	aClass compile: 'fortyTwo ^42'.
 	
-	self assert: monitor log head == headBeforeRecompiling
+	self assert: monitor head == headBeforeRecompiling
 ]
 
 { #category : #tests }

--- a/src/EpiceaTests/EpLogTest.class.st
+++ b/src/EpiceaTests/EpLogTest.class.st
@@ -36,13 +36,14 @@ EpLogTest >> testEntriesCount [
 { #category : #tests }
 EpLogTest >> testEntryReferences [
 
-	| entryReferences |
+	| entryReferences entries |
 	entryReferences := log entryReferences.
+	entries := log entries.
 	
-	entryReferences do: [:each |
+	entryReferences withIndexDo: [:each :index |
 		log
 			entryFor: each
-			ifPresent: [:entry | "ok" ]
+			ifPresent: [:entry | self assert: entry equals: (entries at: index) ]
 			ifAbsent: [ self fail ] ].
 
 	self assert: entryReferences size equals: 5.

--- a/src/HiedraTests/HiNodesAndLinksIteratorWithOneLinkModelTest.class.st
+++ b/src/HiedraTests/HiNodesAndLinksIteratorWithOneLinkModelTest.class.st
@@ -37,7 +37,6 @@ HiNodesAndLinksIteratorWithOneLinkModelTest >> iteratedAsArray [
 
 { #category : #running }
 HiNodesAndLinksIteratorWithOneLinkModelTest >> setUp [
-	super setUp.
 	linkBuilder := HiLinkBuilder new
 		targetsBlock: [ :node | node parents ];
 		yourself.

--- a/src/Ombu/OmFileStore.class.st
+++ b/src/Ombu/OmFileStore.class.st
@@ -198,8 +198,9 @@ OmFileStore >> entryPositionsByLocalName [
 
 { #category : #accessing }
 OmFileStore >> entryReferences [
+	"Optimized implementation for potentially large files"
 	
-	^ (self entriesCount to: 1 by: -1) collect: [:index |
+	^ (1 to: self entriesCount) collect: [:index |
 			self referenceToLocalName: index asString ]
 ]
 

--- a/src/OmbuTests/OmSessionStoreNameStrategyTest.class.st
+++ b/src/OmbuTests/OmSessionStoreNameStrategyTest.class.st
@@ -41,7 +41,7 @@ OmSessionStoreNameStrategyTest >> fileReferenceWith: aName [
 
 { #category : #running }
 OmSessionStoreNameStrategyTest >> setUp [
-	super setUp.
+
 	strategy := self strategyClass new
 ]
 

--- a/src/OmbuTests/OmStoreTest.class.st
+++ b/src/OmbuTests/OmStoreTest.class.st
@@ -140,16 +140,19 @@ OmStoreTest >> testEntryForPresentEntry [
 
 { #category : #tests }
 OmStoreTest >> testEntryReferences [
-	| entryReferences |
+	| entryReferences entries |
 
 	1 to: 7 do: [ :each | store newEntry: (OmEntry content: each) ].
 
 	entryReferences := store entryReferences.
+	entries := store entries.
 	
-	entryReferences do: [:each |
+	entryReferences withIndexDo: [:each :index |	
 		store
 			entryFor: each
-			ifPresent: [:entry | "ok" ]
+			ifPresent: [:entry | 
+				self assert: entry equals: (entries at: index) 
+				"They must have the same order" ]
 			ifAbsent: [ self fail ] ].
 
 	self assert: entryReferences size equals: 7. "To be sure it tests something"

--- a/src/Slot/DoubleByteLayout.class.st
+++ b/src/Slot/DoubleByteLayout.class.st
@@ -7,16 +7,16 @@ Class {
 	#category : #'Slot-Layout'
 }
 
-{ #category : #'instance creation' }
-DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
-	^ superLayout extendDoubleByte
-		host: aClass;
-		yourself
-]
-
 { #category : #extending }
 DoubleByteLayout >> extendDoubleByte [
 	^ DoubleByteLayout new
+]
+
+{ #category : #'methodsFor:' }
+DoubleByteLayout >> extending: superLayout scope: aScope host: aClass [
+	^ superLayout extendDoubleByte
+		host: aClass;
+		yourself
 ]
 
 { #category : #format }

--- a/src/Slot/DoubleWordLayout.class.st
+++ b/src/Slot/DoubleWordLayout.class.st
@@ -7,16 +7,16 @@ Class {
 	#category : #'Slot-Layout'
 }
 
-{ #category : #'instance creation' }
-DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
-	^ superLayout extendDoubleWord
-		host: aClass;
-		yourself
-]
-
 { #category : #extending }
 DoubleWordLayout >> extendDoubleWord [
 	^ DoubleWordLayout new
+]
+
+{ #category : #'methodsFor:' }
+DoubleWordLayout >> extending: superLayout scope: aScope host: aClass [
+	^ superLayout extendDoubleWord
+		host: aClass;
+		yourself
 ]
 
 { #category : #format }


### PR DESCRIPTION
Upgrade Epicea to 8.2.7 (but keep Cyril's contribution in this repository which is not copied upstream yet).

Changes:

- Fix case 20223.
- Fix EpLog and OmFileStore #entryReferences, the result must have the same order as #entries.
- Improve apply preview of class comments.
- Sync with changes in Pharo 7: remove override of ZnBufferedWriteStream>>#cr since it''s already present in latest version of Zinc.
- Improve some code comments.
- Fix refactoring apply (general case)
- Fix class rename refactoring