### PR TITLE
21020 Add lint rules to ensure super setUp as first and super tearDown as last message in unit tests

### DIFF
--- a/src/SUnit-Rules/ShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ShouldSendSuperSetUpAsFirstMessage.class.st
@@ -1,0 +1,48 @@
+"
+In a test case the setUp method should call super setUp as first message
+"
+Class {
+	#name : #ShouldSendSuperSetUpAsFirstMessage,
+	#superclass : #ReAbstractRule,
+	#category : #'SUnit-Rules'
+}
+
+{ #category : #'testing-interest' }
+ShouldSendSuperSetUpAsFirstMessage class >> checksMethod [
+
+	^ true
+]
+
+{ #category : #utility }
+ShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompiledMethod [
+	"Return true if the method is a setUp method and a call to super setUp is not the first message send."
+	
+	| searcher |
+	searcher := RBParseTreeSearcher new 
+						matchesAnyMethodOf: #(
+							'setUp             super setUp. `.@any' 
+							'setUp | `@temps | super setUp. `.@any') 
+						do: [ :node :answer | true ];
+						yourself.
+	^(searcher executeTree: aCompiledMethod parseTree initialAnswer: false) not
+]
+
+{ #category : #running }
+ShouldSendSuperSetUpAsFirstMessage >> check: aMethod forCritiquesDo: aCritiqueBlock [
+
+	((aMethod methodClass inheritsFrom: TestCase)
+		and: [ aMethod selector = #setUp and: [ self class superSetUpNotCalledFirstIn: aMethod ]])
+			ifTrue: [ aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+]
+
+{ #category : #accessing }
+ShouldSendSuperSetUpAsFirstMessage >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : #accessing }
+ShouldSendSuperSetUpAsFirstMessage >> name [
+
+	^ 'Provide a call to super setUp as the first message in the setUp method'
+]

--- a/src/SUnit-Rules/ShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ShouldSendSuperTearDownAsLastMessage.class.st
@@ -1,0 +1,48 @@
+"
+In a test case the tearDown method should call super tearDown as last message
+"
+Class {
+	#name : #ShouldSendSuperTearDownAsLastMessage,
+	#superclass : #ReAbstractRule,
+	#category : #'SUnit-Rules'
+}
+
+{ #category : #'testing-interest' }
+ShouldSendSuperTearDownAsLastMessage class >> checksMethod [
+
+	^ true
+]
+
+{ #category : #utility }
+ShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCompiledMethod [
+	"Return true if the method is a tearDown method and a call to super tearDown is not the last message send."
+	
+	| searcher |
+	searcher := RBParseTreeSearcher new 
+						matchesAnyMethodOf: #(
+							'tearDown             `.@any. super tearDown' 
+							'tearDown | `@temps | `.@any. super tearDown') 
+						do: [ :node :answer | true ];
+						yourself.
+	^(searcher executeTree: aCompiledMethod parseTree initialAnswer: false) not
+]
+
+{ #category : #running }
+ShouldSendSuperTearDownAsLastMessage >> check: aMethod forCritiquesDo: aCritiqueBlock [
+
+	((aMethod methodClass inheritsFrom: TestCase)
+		and: [ aMethod selector = #tearDown and: [ self class superTearDownNotCalledLastIn: aMethod ]])
+			ifTrue: [ aCritiqueBlock cull: (self critiqueFor: aMethod) ]
+]
+
+{ #category : #accessing }
+ShouldSendSuperTearDownAsLastMessage >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : #accessing }
+ShouldSendSuperTearDownAsLastMessage >> name [
+
+	^ 'Provide a call to super tearDown as the last message in the tearDown method'
+]


### PR DESCRIPTION
Add two lint rules to ensure initial setUp and final tearDown

For details see https://pharo.fogbugz.com/f/cases/21020/