### PR TITLE
21043-ContextlookupSymbol-implements-a-wrong-lookup-and-should-reuse-the-lookup-of-the-rest-of-the-image

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -140,10 +140,20 @@ ContextTest >> testLookupSymbol [
 	localVar := 2.
 	instVarForTestLookupSymbol := 3.
 	classVarForTestLookupSymbol := 4.
+	ContextTestAssistantA classVarForTestLookupSymbol: 5.
+	"Check lookup of local variable"
 	self assert: (thisContext lookupSymbol: #localVar) equals: 2.
+	"Check lookup of instance variable"
 	self assert: (thisContext lookupSymbol: #instVarForTestLookupSymbol) equals: 3.
+	"Check lookup of class variable"
 	self assert: (thisContext lookupSymbol: #classVarForTestLookupSymbol) equals: 4.
+	"Check lookup of global variable"
 	self assert: (thisContext lookupSymbol: #Smalltalk) equals: Smalltalk.
+	"Check lookup of class variable declared by a superclass"
+	self assert: (ContextTestAssistantB lookupSymbolInThisContext: #classVarForTestLookupSymbol) equals: 5.
+	"Check lookup of non-existant variable"
+	self assert: (thisContext lookupSymbol: #gibberishgibberish) equals: nil.
+	
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTestAssistantA.class.st
+++ b/src/Kernel-Tests/ContextTestAssistantA.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #ContextTestAssistantA,
+	#superclass : #Object,
+	#classVars : [
+		'classVarForTestLookupSymbol'
+	],
+	#category : #'Kernel-Tests-Methods'
+}
+
+{ #category : #'as yet unclassified' }
+ContextTestAssistantA class >> classVarForTestLookupSymbol [
+	^ classVarForTestLookupSymbol
+]
+
+{ #category : #'as yet unclassified' }
+ContextTestAssistantA class >> classVarForTestLookupSymbol: aValue [
+	classVarForTestLookupSymbol := aValue.
+]

--- a/src/Kernel-Tests/ContextTestAssistantB.class.st
+++ b/src/Kernel-Tests/ContextTestAssistantB.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #ContextTestAssistantB,
+	#superclass : #ContextTestAssistantA,
+	#category : #'Kernel-Tests-Methods'
+}
+
+{ #category : #'as yet unclassified' }
+ContextTestAssistantB class >> lookupSymbolInThisContext: aSymbol [
+	^ (thisContext lookupSymbol: aSymbol)
+]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1122,25 +1122,17 @@ Context >> longStack [
 
 { #category : #accessing }
 Context >> lookupSymbol: aSymbol [
-	"Pool variables not supported yet.
-	In order, looks up among:
-		1) Local variables and arguments
-		2) Instance variables of the receiver
-		3) Class variables of the class of the receiver
-		4) Pool variables (NOT IMPLEMENTED)
-		5) Global variables
-	If nothing is found, returns nil.
-	"
-	| classVariablesHolder |
-	(self tempNames includes: aSymbol) ifTrue: [^ self tempNamed: aSymbol].
-	(self receiver class allInstVarNames includes: aSymbol) ifTrue: [ ^ self receiver instVarNamed: aSymbol ].
-	classVariablesHolder := self receiver.
-	(self receiver isClass) ifFalse: [
-		"If the receiver is not a class, its class hold its class variables" classVariablesHolder := 		classVariablesHolder class].
-	(classVariablesHolder allClassVarNames includes: aSymbol) ifTrue: [ ^ classVariablesHolder classVarNamed: aSymbol].
-	"(self receiver instanceSide allClassVarNames includes: aSymbol) ifTrue: [ ^ self receiver instanceSide classVarNamed: aSymbol]."
-	Smalltalk globals at: aSymbol ifPresent: [ :value | ^ value ].
+	| scope var |
+	scope := self sourceNodeExecuted scope.
+	var := scope lookupVar: aSymbol asString.
+	"Local variables"
+	(var isKindOf: OCTempVariable) ifTrue: [^ var searchFromContext: self scope: scope].
+	"Instance variables"
+	(var isKindOf: OCSlotVariable) ifTrue: [^ self receiver instVarNamed: aSymbol].
+	"Class variables and globals"
+	(var isKindOf: OCLiteralVariable) ifTrue: [ ^ var assoc value ].
 	^ nil.
+	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix issue 21043