### PR TITLE
21063 Super setUp need to be called in OmSessionStoreNameStrategyTest

### DIFF
--- a/src/OmbuTests/OmSessionStoreNameStrategyTest.class.st
+++ b/src/OmbuTests/OmSessionStoreNameStrategyTest.class.st
@@ -41,7 +41,7 @@ OmSessionStoreNameStrategyTest >> fileReferenceWith: aName [
 
 { #category : #running }
 OmSessionStoreNameStrategyTest >> setUp [
-
+	super setUp.
 	strategy := self strategyClass new
 ]
 


### PR DESCRIPTION
Add missing call to super setUp

https://pharo.fogbugz.com/f/cases/21063/Super-setUp-need-to-be-called-in-OmSessionStoreNameStrategyTest