### PR TITLE
21065 Super setUp need to be called in HiNodesAndLinksIteratorWithOneLinkModelTest

### DIFF
--- a/src/HiedraTests/HiNodesAndLinksIteratorWithOneLinkModelTest.class.st
+++ b/src/HiedraTests/HiNodesAndLinksIteratorWithOneLinkModelTest.class.st
@@ -37,6 +37,7 @@ HiNodesAndLinksIteratorWithOneLinkModelTest >> iteratedAsArray [
 
 { #category : #running }
 HiNodesAndLinksIteratorWithOneLinkModelTest >> setUp [
+	super setUp.
 	linkBuilder := HiLinkBuilder new
 		targetsBlock: [ :node | node parents ];
 		yourself.


### PR DESCRIPTION
call super setUp in setUp method

https://pharo.fogbugz.com/f/cases/21065/Super-setUp-need-to-be-called-in-HiNodesAndLinksIteratorWithOneLinkModelTest