### PR TITLE
21120 Super tearDown need to be called as last message in tearDown of ZnStaticFileServerDelegateTests

### DIFF
--- a/src/Zinc-Tests/ZnStaticFileServerDelegateTests.class.st
+++ b/src/Zinc-Tests/ZnStaticFileServerDelegateTests.class.st
@@ -44,7 +44,8 @@ ZnStaticFileServerDelegateTests >> tearDown [
 	ZnFileSystemUtils 
 		deleteIfExists: 'small.html'; 
 		deleteIfExists: 'large.html'; 
-		deleteIfExists: 'wide.html'
+		deleteIfExists: 'wide.html'.
+	super tearDown	
 	
 ]
 


### PR DESCRIPTION
add super call at the end of tearDown

https://pharo.fogbugz.com/f/cases/21120/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-ZnStaticFileServerDelegateTests