### PR TITLE
21119 Super tearDown need to be called as last message in tearDown of ZipArchiveTest

### DIFF
--- a/src/Compression-Tests/ZipArchiveTest.class.st
+++ b/src/Compression-Tests/ZipArchiveTest.class.st
@@ -36,6 +36,7 @@ ZipArchiveTest >> tearDown [
 	zip close.	
 	subdir ensureDeleteAll.
 	zipFile ensureDelete.
+	super tearDown 
 ]
 
 { #category : #tests }


### PR DESCRIPTION
easily fixed by adding super tearDown

https://pharo.fogbugz.com/f/cases/21119/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-ZipArchiveTest