### PR TITLE
21118 Super tearDown need to be called as last message in tearDown of ZdcPluginSSLSessionTests

### DIFF
--- a/src/Zodiac-Tests/ZdcPluginSSLSessionTests.class.st
+++ b/src/Zodiac-Tests/ZdcPluginSSLSessionTests.class.st
@@ -22,6 +22,7 @@ ZdcPluginSSLSessionTests >> tearDown [
 
 	session destroy.
 	session := nil.
+	super tearDown 
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21118/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-ZdcPluginSSLSessionTests