### PR TITLE
21116 Super tearDown need to be called as last message in tearDown of VSReleaseDevelopmentVersionCommandTest

### DIFF
--- a/src/Versionner-Tests-Core-Commands/VSReleaseDevelopmentVersionCommandTest.class.st
+++ b/src/Versionner-Tests-Core-Commands/VSReleaseDevelopmentVersionCommandTest.class.st
@@ -54,9 +54,10 @@ VSReleaseDevelopmentVersionCommandTest >> setUp [
 
 { #category : #running }
 VSReleaseDevelopmentVersionCommandTest >> tearDown [
-	super tearDown.
+
 	ASTCache reset.
-	classFactory cleanUp
+	classFactory cleanUp.
+	super tearDown	
 ]
 
 { #category : #tests }


### PR DESCRIPTION
 

https://pharo.fogbugz.com/f/cases/21116/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-VSReleaseDevelopmentVersionCommandTest