### PR TITLE
21113 Super tearDown need to be called as last message in tearDown of classes with S

### DIFF
--- a/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/SendsDeprecatedMethodToGlobalRuleTest.class.st
@@ -49,8 +49,8 @@ SendsDeprecatedMethodToGlobalRuleTest >> tearDown [
 
 	Smalltalk globals removeKey: self globalName ifAbsent: [ ].
 	globalName := nil.
-	
 	testClass := nil.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ScheduleTest.class.st
+++ b/src/Kernel-Tests/ScheduleTest.class.st
@@ -61,6 +61,7 @@ ScheduleTest >> setUp [
 ScheduleTest >> tearDown [
 
 	DateAndTime localTimeZone: restoredTimeZone.
+	super tearDown 
 
 ]
 

--- a/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
+++ b/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
@@ -48,7 +48,8 @@ SmalllintManifestCheckerTest >> setUp [
 SmalllintManifestCheckerTest >> tearDown [
 	
 	self cleaningResources.
-	ASTCache reset
+	ASTCache reset.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Network-Tests/SocketStreamTest.class.st
+++ b/src/Network-Tests/SocketStreamTest.class.st
@@ -36,6 +36,7 @@ SocketStreamTest >> setUp [
 SocketStreamTest >> tearDown [
 	clientStream ifNotNil:[clientStream destroy].
 	serverStream ifNotNil:[serverStream destroy].
+	super tearDown 
 ]
 
 { #category : #'stream protocol' }

--- a/src/Network-Tests/SocketTest.class.st
+++ b/src/Network-Tests/SocketTest.class.st
@@ -53,6 +53,7 @@ SocketTest >> tearDown [
 	listenerSocket ifNotNil:[listenerSocket destroy].
 	clientSocket ifNotNil:[clientSocket destroy].
 	serverSocket ifNotNil:[serverSocket destroy].
+	super tearDown 
 
 ]
 

--- a/src/SUnit-UITesting/SimulateMouseSpecification.class.st
+++ b/src/SUnit-UITesting/SimulateMouseSpecification.class.st
@@ -20,6 +20,7 @@ SimulateMouseSpecification >> menuOpenedDuring: aBlock [
 SimulateMouseSpecification >> tearDown [
 
 	morph delete.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -36,9 +36,9 @@ SlotAnnouncementsTest >> subscribeOn: anAnnouncement [
 
 { #category : #running }
 SlotAnnouncementsTest >> tearDown [ 
-	super tearDown.
-	
+
 	SystemAnnouncer uniqueInstance unsubscribe: collectedAnnouncements.
+	super tearDown.
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -93,7 +93,6 @@ SlotClassBuilderTest >> makeWithLayout: aClassLayout andSlots: someSlots [
 { #category : #running }
 SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
-	super tearDown.
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		{ self aClassName. self anotherClassName. self yetAnotherClassName. self yetYetAnotherClassName } do: [ :each | 
@@ -112,6 +111,8 @@ SlotClassBuilderTest >> tearDown [
 		packageNamed: self aCategory
 		ifAbsent: [ ^ self ]) 
 		unregister.
+		
+	super tearDown.	
 ]
 
 { #category : #'helpers-names' }

--- a/src/SmartSuggestions-Tests/SugsSuggestionTest.class.st
+++ b/src/SmartSuggestions-Tests/SugsSuggestionTest.class.st
@@ -106,6 +106,7 @@ SugsSuggestionTest >> setUp [
 
 { #category : #running }
 SugsSuggestionTest >> tearDown [
-	super tearDown.
-	self removeClass: emptyClass .
+	
+	self removeClass: emptyClass.
+	super tearDown
 ]

--- a/src/Spec-Tests/SpecInterpreterTest.class.st
+++ b/src/Spec-Tests/SpecInterpreterTest.class.st
@@ -27,6 +27,7 @@ SpecInterpreterTest >> tearDown [
 
 	specInterpreterClass := nil.
 	specInterpreter := nil.
+	super tearDown 
 ]
 
 { #category : #tests }

--- a/src/Spec-Tests/SpecTestCase.class.st
+++ b/src/Spec-Tests/SpecTestCase.class.st
@@ -56,8 +56,9 @@ SpecTestCase >> setUp [
 
 { #category : #running }
 SpecTestCase >> tearDown [
+	
+	window ifNotNil: [ window delete ].
 	super tearDown.
-	window ifNotNil: [ window delete ]
 ]
 
 { #category : #tests }

--- a/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
+++ b/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
@@ -42,8 +42,9 @@ SystemSettingsPersistenceTest >> systemSettingNodeList [
 
 { #category : #running }
 SystemSettingsPersistenceTest >> tearDown [
-	super tearDown.
+	
 	MockSettings cleanUp.
+	super tearDown.
 
 ]
 

--- a/src/Tests/SystemAnnouncerTest.class.st
+++ b/src/Tests/SystemAnnouncerTest.class.st
@@ -20,11 +20,10 @@ SystemAnnouncerTest >> setUp [
 
 { #category : #running }
 SystemAnnouncerTest >> tearDown [
-	super tearDown.
 
-	SystemAnnouncer announcer: oldSystemAnnouncer.
-	
+	SystemAnnouncer announcer: oldSystemAnnouncer.	
 	factory cleanUp.
+	super tearDown.
 ]
 
 { #category : #tests }

--- a/src/Tests/SystemNavigationTest.class.st
+++ b/src/Tests/SystemNavigationTest.class.st
@@ -71,9 +71,10 @@ SystemNavigationTest >> systemNavigationToTest [
 
 { #category : #running }
 SystemNavigationTest >> tearDown [
-	super tearDown.
+	
 	self classFactory cleanUp. 
 	SystemAnnouncer announcer: oldSystemAnnouncer.
+	super tearDown.
 	
 ]
 


### PR DESCRIPTION
Fixed ScheduleTest>>#tearDown
SendsDeprecatedMethodToGlobalRuleTest>>#tearDown
SimulateMouseSpecification>>#tearDown
SlotAnnouncementsTest>>#tearDown
SlotClassBuilderTest>>#tearDown
SmalllintManifestCheckerTest>>#tearDown
SocketStreamTest>>#tearDown
SocketTest>>#tearDown
SpecInterpreterTest>>#tearDown
SpecTestCase>>#tearDown
SugsSuggestionTest>>#tearDown
SystemAnnouncerTest>>#tearDown
SystemNavigationTest>>#tearDown
SystemSettingsPersistenceTest>>#tearDown

see https://pharo.fogbugz.com/f/cases/21113