### PR TITLE
21111 Super tearDown need to be called as last message in tearDown of RecursionStopperTest and ResumableTestFailureTestCase

### DIFF
--- a/src/Kernel-Tests/RecursionStopperTest.class.st
+++ b/src/Kernel-Tests/RecursionStopperTest.class.st
@@ -50,6 +50,7 @@ RecursionStopperTest >> setUp [
 RecursionStopperTest >> tearDown [
 
 	fork ifNotNil: [ fork terminate. fork := nil ].
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/SUnit-Tests/ResumableTestFailureTestCase.class.st
+++ b/src/SUnit-Tests/ResumableTestFailureTestCase.class.st
@@ -66,6 +66,7 @@ ResumableTestFailureTestCase >> tearDown [
 			description: 'We saw the ''You should not see me'' failure'.
 	self deny: 'You should see more than me' = duplicateFailureLog last
 			description: 'We did not see more than a ''You should see more than me'' failure'.
+	super tearDown 
 ]
 
 { #category : #running }


### PR DESCRIPTION
Fix tearDown of RecursionStopperTest and ResumableTestFailureTestCase

https://pharo.fogbugz.com/f/cases/21111