### PR TITLE
21108 Super tearDown need to be called as last message in tearDown of RGMethodDefinitionTest

### DIFF
--- a/src/Ring-Tests-Kernel/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Tests-Kernel/RGMethodDefinitionTest.class.st
@@ -18,8 +18,10 @@ RGMethodDefinitionTest >> runCase [
 
 { #category : #running }
 RGMethodDefinitionTest >> tearDown [
+
 	self class removeSelectorSilently: #foo.
 	self class removeProtocol: 'test'.
+	super tearDown 
 ]
 
 { #category : #'test - accessing source' }


### PR DESCRIPTION
Fix RGMethodDefinitionTest>>#tearDown


see https://pharo.fogbugz.com/f/cases/21108