### PR TITLE
21106 Super tearDown need to be called as last message in tearDown of PharoTutorial tests

### DIFF
--- a/src/ProfStef-Tests/PharoTutorialTestGo.class.st
+++ b/src/ProfStef-Tests/PharoTutorialTestGo.class.st
@@ -9,7 +9,8 @@ Class {
 
 { #category : #running }
 PharoTutorialTestGo >> tearDown [
-	ProfStef default close
+	ProfStef default close.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/ProfStef-Tests/PharoTutorialTestGoOnMockTutorial.class.st
+++ b/src/ProfStef-Tests/PharoTutorialTestGoOnMockTutorial.class.st
@@ -15,7 +15,8 @@ PharoTutorialTestGoOnMockTutorial >> setUp [
 
 { #category : #running }
 PharoTutorialTestGoOnMockTutorial >> tearDown [
-	ProfStef default close
+	ProfStef default close.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION

Fixed tearDown in 
PharoTutorialTestGo>>#tearDown
PharoTutorialTestGoOnMockTutorial>>#tearDown

see https://pharo.fogbugz.com/f/cases/21106