### PR TITLE
21105 Super tearDown need to be called as last message in tearDown of PharoBootstrapRuleTest

### DIFF
--- a/src/Kernel-Tests-Rules/PharoBootstrapRuleTest.class.st
+++ b/src/Kernel-Tests-Rules/PharoBootstrapRuleTest.class.st
@@ -19,6 +19,7 @@ PharoBootstrapRuleTest >> tearDown [
 	PharoBootstrapRule
 		classVarNamed: 'DependencyChecker' 
 		put: checkerBackup.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
 https://pharo.fogbugz.com/f/cases/21105/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-PharoBootstrapRuleTest