### PR TITLE
21128-FastTable-search-should-not-setup-first-selected-item-if-nothing-is-found

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -80,7 +80,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 									(contents
 										addAttribute: (TextColor new color: Color red);
 										yourself) ] ] ];
-		whenEditorEscapedDo: [ self table selectRowIndex: currentSelIndex.
+		whenEditorEscapedDo: [ founds ifTrue: [self table selectRowIndex: currentSelIndex].
 			self table highlightRowIndexes: currentHighlightedIndexes ].
 	ed autoAccept: true.
 	founds

--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -37,9 +37,10 @@ FTSearchFunction >> keyStroke: anEvent [
 FTSearchFunction >> realSearch [
 	| founds |
 	founds := self table dataSource searchText: pattern.
-	self table
-		selectRowIndex: (founds ifEmpty: [ 1 ] ifNotEmpty: [ founds first ]);
-		highlightRowIndexes: founds.
+
+	founds ifNotEmpty: [ self table selectRowIndex: founds first ].
+	self table highlightRowIndexes: founds.
+	
 	^ founds notEmpty
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -65,7 +65,7 @@ FTSearchFunction >> showSearchFieldFromKeystrokeEvent: anEvent [
 		withEditedContentsDo:
 				[ :contents :editor | 
 			contents
-				ifEmpty: [ self table selectRowIndex: currentSelIndex. 
+				ifEmpty: [ founds ifTrue: [self table selectRowIndex: currentSelIndex]. 
 					self table highlightRowIndexes: currentHighlightedIndexes ]
 				ifNotEmpty:
 					[ founds := self searchFor: contents.


### PR DESCRIPTION
Now search function select only found first row. If nothig was found selection is not changed.https://pharo.fogbugz.com/f/cases/21128/FastTable-search-should-not-setup-first-selected-item-if-nothing-is-found