### PR TITLE
21072 Super tearDown need to be called as last message in tearDown of ASTCacheResetTest

### DIFF
--- a/src/Reflectivity-Tests/ASTCacheResetTest.class.st
+++ b/src/Reflectivity-Tests/ASTCacheResetTest.class.st
@@ -35,7 +35,8 @@ ASTCacheResetTest >> setUp [
 { #category : #running }
 ASTCacheResetTest >> tearDown [
 	ASTCache default: cache.
-	node removeLink: link
+	node removeLink: link.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21072/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-ASTCacheResetTest


add super tearDown