### PR TITLE
21073 Super tearDown need to be called as last message in tearDown of BinaryFileStreamTest, BreakpointTest, BuilderManifestTest

### DIFF
--- a/src/Files-Tests/BinaryFileStreamTest.class.st
+++ b/src/Files-Tests/BinaryFileStreamTest.class.st
@@ -26,11 +26,11 @@ BinaryFileStreamTest >> setUp [
 { #category : #running }
 BinaryFileStreamTest >> tearDown [
 
-	super tearDown.
 	self killTestFile.
 	"We must ensure that files are collected before running other tests.
 	In windows, we cannot open the same file twice."
-	3 timesRepeat: [ Smalltalk garbageCollect. ]
+	3 timesRepeat: [ Smalltalk garbageCollect ].
+	super tearDown.
 ]
 
 { #category : #testing }

--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -31,6 +31,7 @@ BuilderManifestTest >> tearDown [
 			cl
 				removeFromChanges;
 				removeFromSystemUnlogged ].
+	super tearDown		
 
 ]
 

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -30,12 +30,12 @@ BreakpointTest >> setUp [
 
 { #category : #running }
 BreakpointTest >> tearDown [
-	| pkg |
-	super tearDown.
+	| pkg |	
 	Breakpoint all addAll: previousBreakpoints.
 	cls ifNotNil: [ cls isObsolete ifFalse: [ cls removeFromSystem ] ].
 	pkg := 'DummyPackage' asPackageIfAbsent: [ ]. 
-	pkg ifNotNil: [ pkg removeFromSystem ]
+	pkg ifNotNil: [ pkg removeFromSystem ].
+	super tearDown.
 ]
 
 { #category : #tests }


### PR DESCRIPTION

https://pharo.fogbugz.com/f/cases/21073/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-BinaryFileStreamTest-BreakpointTest-BuilderManifestTest