### PR TITLE
21077 Super tearDown need to be called as last message in tearDown of DateAndTimeDosEpochTest, DateAndTimeEpochTest, DateAndTimeUnixE

### DIFF
--- a/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
@@ -28,6 +28,7 @@ DateAndTimeDosEpochTest >> tearDown [
      "wish I could remove the time zones I added earlier, but there is no method for that"
 
      DateAndTime localTimeZone: localTimeZoneToRestore.
+	  super tearDown
 
 ]
 

--- a/src/Kernel-Tests/DateAndTimeEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeEpochTest.class.st
@@ -39,7 +39,7 @@ DateAndTimeEpochTest >> setUp [
 { #category : #running }
 DateAndTimeEpochTest >> tearDown [
      DateAndTime localTimeZone: localTimeZoneToRestore.
-     "wish I could remove the time zones I added earlier, but there is no method for that"
+     super tearDown
 
 ]
 

--- a/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
@@ -25,7 +25,7 @@ DateAndTimeUnixEpochTest >> setUp [
 { #category : #running }
 DateAndTimeUnixEpochTest >> tearDown [
      DateAndTime localTimeZone: localTimeZoneToRestore.
-     "wish I could remove the time zones I added earlier, but there is no method for that"
+     super tearDown
 
 ]
 

--- a/src/Kernel-Tests/DelayMicrosecondSchedulerTest.class.st
+++ b/src/Kernel-Tests/DelayMicrosecondSchedulerTest.class.st
@@ -25,7 +25,8 @@ DelayMicrosecondSchedulerTest >> delaySchedulerClass [
 { #category : #running }
 DelayMicrosecondSchedulerTest >> tearDown [ 	
 	"Trigger system timingSempaphore, in case it was replaced"
-	Delay testCaseSupportTimingSemaphore signal
+	Delay testCaseSupportTimingSemaphore signal.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/DelayMillisecondSchedulerTest.class.st
+++ b/src/Kernel-Tests/DelayMillisecondSchedulerTest.class.st
@@ -18,7 +18,8 @@ DelayMillisecondSchedulerTest >> busyWaitMilliseconds: milliseconds [
 { #category : #running }
 DelayMillisecondSchedulerTest >> tearDown [ 	
 	"Trigger system timingSempaphore, in case it was replaced"
-	Delay testCaseSupportTimingSemaphore signal
+	Delay testCaseSupportTimingSemaphore signal.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION


https://pharo.fogbugz.com/f/cases/21077/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-DateAndTimeDosEpochTest-DateAndTimeEpochTest-DateAndTimeUnixE