### PR TITLE
20757-Playground-should-be-extensible-as-GT-Inspector

### DIFF
--- a/src/GT-Playground/GTPlayground.class.st
+++ b/src/GT-Playground/GTPlayground.class.st
@@ -344,6 +344,7 @@ GTPlayground >> codeIn: a [
 				iconName: #glamorousMore;
 				title: 'Play pages';
 				yourself);
+		with: [ :presentation | self pageActionsIn: presentation ];
 		dynamicActionsOnSelection: [ self contextMenuActions ];
 		onChangeOfPort: #text
 			act: [ :text :page | 
@@ -397,8 +398,9 @@ GTPlayground >> compose [
 	GTInspector isStepRefreshEnabled ifTrue: [
 		self wantsAutomaticRefresh: true.
 		self wantsSteps: true.
-		self stepTime: GTInspector stepRefreshRate ]
+		self stepTime: GTInspector stepRefreshRate ].
 	
+	self playgroundActionsIn: self.
 ]
 
 { #category : #'building actions' }
@@ -458,6 +460,52 @@ GTPlayground >> openOn: aPage [
 			not to minization or maximization"
 			self class setPreferredExtentIfWanted: window extent ] ].
 	^ window
+]
+
+{ #category : #accessing }
+GTPlayground >> pageActionPragma [
+	^ #pageActionOrder:
+]
+
+{ #category : #'building actions' }
+GTPlayground >> pageActions [
+	^ (Pragma
+		allNamed: self pageActionPragma
+		from: self class
+		to: Object
+		sortedByArgument: 1)
+		collect:
+			[ :eachPragma | self perform: eachPragma methodSelector ]
+]
+
+{ #category : #'building actions' }
+GTPlayground >> pageActionsIn: aGLMPharoScriptPresentation [ 
+	"Build Page actions that appears next to the page title."
+	self pageActions do: [ :eachAction | 
+		aGLMPharoScriptPresentation addAction: eachAction ]
+]
+
+{ #category : #accessing }
+GTPlayground >> playgroundActionPragma [
+	^ #playgroundActionOrder:
+]
+
+{ #category : #'building actions' }
+GTPlayground >> playgroundActions [
+	^ (Pragma
+		allNamed: self playgroundActionPragma
+		from: self class
+		to: Object
+		sortedByArgument: 1)
+		collect:
+			[ :eachPragma | self perform: eachPragma methodSelector ]
+]
+
+{ #category : #'building actions' }
+GTPlayground >> playgroundActionsIn: aGTPlayground [ 
+	"Build Playground actions that appears on the title bar."
+	self playgroundActions do: [ :eachAction | 
+		aGTPlayground addAction: eachAction ]
 ]
 
 { #category : #'accessing-dynamic' }

--- a/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
+++ b/src/GT-Tests-Playground/GTPlaygroundBasicTest.class.st
@@ -41,6 +41,52 @@ GTPlaygroundBasicTest >> testAccessBindings [
 ]
 
 { #category : #running }
+GTPlaygroundBasicTest >> testPageActionsIn [
+
+	| actions selector action |
+	selector := playground class 
+		compile: 'mockMethodPageAction
+	<pageActionOrder: 10>
+	^ GLMGenericAction new
+		action: [ :presentation | self inform: ''page action works'' ];
+		iconNamed: #abstract;
+		title: ''A mock page action''' 
+		classified: '*GTMockTests'.
+		
+	self assert: selector notNil.
+	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
+	actions := playground pageActions.
+	self deny: actions size isZero.
+	action := actions detect: [ :eachAction | eachAction title = 'A mock page action' ].
+	self deny: action isNil.
+	playground class removeSelector: selector.
+	'GTMockTests' asPackage removeFromSystem.
+]
+
+{ #category : #running }
+GTPlaygroundBasicTest >> testPlaygroundActionsIn [
+
+	| actions selector action |
+	selector := playground class 
+		compile: 'mockMethodPlaygrounAction
+	<playgroundActionOrder: 100>
+	^ GLMGenericAction new
+		action: [ :presentation | self inform: ''playground action works'' ];
+		iconNamed: #abstract;
+		title: ''A mock playground action''' 
+		classified: '*GTMockTests'.
+		
+	self assert: selector notNil.
+	window := playground openOn: (GTPlayPage new saveContent: 'a:=1. b:=a+1').
+	actions := playground playgroundActions.
+	self deny: actions size isZero.
+	action := actions detect: [ :eachAction | eachAction title = 'A mock playground action' ].
+	self deny: action isNil.
+	playground class removeSelector: selector.
+	'GTMockTests' asPackage removeFromSystem.
+]
+
+{ #category : #running }
 GTPlaygroundBasicTest >> testResetBindings [
 	|obtainedBindings|
 


### PR DESCRIPTION
fixes case 20757add possibility to extend page actions (buttons next to the Page tab) and playground actions (buttons on the top right corner) as the following example:

```
GTPlayground >> examplePageAction
	<pageActionOrder: 50>
	^ GLMGenericAction new
		action: [ :presentation | self inform: 'action triggered' ];
		icon: (self iconNamed: #glamorousOpen);
		title: 'Say Hello' translated;
		condition: [ true ].
```

Similarly for `<playgroundActionOrder: 20>` pragma.