### PR TITLE
21088 Super tearDown need to be called as last message in tearDown of LazyTabGroupTest and LinkedListTest

### DIFF
--- a/src/Collections-Tests/LinkedListTest.class.st
+++ b/src/Collections-Tests/LinkedListTest.class.st
@@ -322,7 +322,7 @@ LinkedListTest >> tearDown [
 	nonEmpty := nil.
 	otherList := nil.
 	
-	^ super tearDown
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
+++ b/src/Glamour-Tests-Morphic/LazyTabGroupTest.class.st
@@ -20,7 +20,8 @@ LazyTabGroupTest >> setUp [
 
 { #category : #running }
 LazyTabGroupTest >> tearDown [
-	window ifNotNil: [window delete]
+	window ifNotNil: [ window delete ].
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
 https://pharo.fogbugz.com/f/cases/21088/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-LazyTabGroupTest-and-LinkedListTest