### PR TITLE
21098 Super tearDown need to be called as last message in tearDown of NECControllerTest, NECUntypedModelTest

### DIFF
--- a/src/NECompletion-Tests/NECControllerTest.class.st
+++ b/src/NECompletion-Tests/NECControllerTest.class.st
@@ -22,8 +22,8 @@ NECControllerTest >> setUp [
 NECControllerTest >> tearDown [
 	"Tearing down code for NECControllerTest"
 
-
 	controller := nil.
+	super tearDown
 ]
 
 { #category : #'tests-keyboard' }

--- a/src/NECompletion-Tests/NECUntypedModelTest.class.st
+++ b/src/NECompletion-Tests/NECUntypedModelTest.class.st
@@ -16,7 +16,9 @@ NECUntypedModelTest >> setUp [
 
 { #category : #running }
 NECUntypedModelTest >> tearDown [
-	NECPreferences caseSensitive: prefValueCase
+
+	NECPreferences caseSensitive: prefValueCase.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION

https://pharo.fogbugz.com/f/cases/21098/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-NECControllerTest-NECUntypedModelTest