### PR TITLE
21081 Super tearDown need to be called as last message in tearDown of FileSystemHandleTest, FileSystemTest, FileTest

### DIFF
--- a/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemHandleTest.class.st
@@ -39,6 +39,7 @@ FileSystemHandleTest >> setUp [
 FileSystemHandleTest >> tearDown [
 	handle ensureClosed.
 	reference ensureDelete.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -56,7 +56,8 @@ FileSystemTest >> setUp [
 FileSystemTest >> tearDown [
 	toDelete
 		select: [ :path | filesystem exists: path ]
-		thenDo: [ :path | filesystem delete: path ]
+		thenDo: [ :path | filesystem delete: path ].
+	super tearDown	
 ]
 
 { #category : #'tests-streams-compatibility' }

--- a/src/Files-Tests/FileTest.class.st
+++ b/src/Files-Tests/FileTest.class.st
@@ -8,6 +8,7 @@ Class {
 FileTest >> tearDown [
 
 	'asd.txt' asFileReference ensureDelete.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION

https://pharo.fogbugz.com/f/cases/21081/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-FileSystemHandleTest-FileSystemTest-FileTest