### PR TITLE
21096 Super tearDown need to be called as last message in tearDown of MonthTest and MultiByteFileStreamTest

### DIFF
--- a/src/Deprecated70/MultiByteFileStreamTest.class.st
+++ b/src/Deprecated70/MultiByteFileStreamTest.class.st
@@ -34,6 +34,7 @@ MultiByteFileStreamTest >> lineEndTestFile [
 MultiByteFileStreamTest >> tearDown [
 	'foobug6933' asFileReference ensureDelete.
 	self lineEndTestFile asFileReference ensureDelete.
+	super tearDown 
 ]
 
 { #category : #testing }

--- a/src/Kernel-Tests/MonthTest.class.st
+++ b/src/Kernel-Tests/MonthTest.class.st
@@ -38,8 +38,8 @@ MonthTest >> setUp [
 { #category : #running }
 MonthTest >> tearDown [
 
-	super tearDown.
 	month := nil.
+	super tearDown.	
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21096/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-MonthTest-and-MultiByteFileStreamTest