### PR TITLE
21086 Super tearDown need to be called as last message in tearDown of IVsAndClassVarNamesConflictTest

### DIFF
--- a/src/Kernel-Tests/IVsAndClassVarNamesConflictTest.class.st
+++ b/src/Kernel-Tests/IVsAndClassVarNamesConflictTest.class.st
@@ -18,8 +18,9 @@ IVsAndClassVarNamesConflictTest >> setUp [
 
 { #category : #running }
 IVsAndClassVarNamesConflictTest >> tearDown [
-	super tearDown.
-	classFactory cleanUp
+
+	classFactory cleanUp.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
https://pharo.fogbugz.com/f/cases/21086/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-IVsAndClassVarNamesConflictTest