### PR TITLE
21089 Super tearDown need to be called as last message in tearDown of Versionner tests

### DIFF
--- a/src/Versionner-Tests-Core-Commands/MBCommandTests.class.st
+++ b/src/Versionner-Tests-Core-Commands/MBCommandTests.class.st
@@ -71,6 +71,7 @@ MBCommandTests >> tearDown [
 	Smalltalk at: self configurationName ifPresent: [:cls | cls removeFromSystem ].
 
 	MetacelloPlatform current authorName: authorName.
+	super tearDown
 ]
 
 { #category : #accessing }

--- a/src/Versionner-Tests-Core-Model/MBAbstractTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBAbstractTest.class.st
@@ -60,8 +60,9 @@ MBAbstractTest >> setUp [
 
 { #category : #running }
 MBAbstractTest >> tearDown [
-	super tearDown.
+	
 	configuration := nil.
-	self removeClassIfExist: self configurationName asSymbol
+	self removeClassIfExist: self configurationName asSymbol.
+	super tearDown
 
 ]

--- a/src/Versionner-Tests-Core-Model/MBConfigurationBranchTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBConfigurationBranchTest.class.st
@@ -42,7 +42,7 @@ MBConfigurationBranchTest >> tearDown [
 	gofer := Gofer new.
 	self tearDownPackages do: [:pkgName | (self hasPackage: pkgName) ifTrue: [ gofer package: pkgName ]].
 	gofer references notEmpty ifTrue: [ gofer unload ].
-
+	super tearDown
 ]
 
 { #category : #running }

--- a/src/Versionner-Tests-Core-Model/MBConfigurationRootTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBConfigurationRootTest.class.st
@@ -76,6 +76,7 @@ MBConfigurationRootTest >> tearDown [
 	gofer := Gofer new.
 	self tearDownPackages do: [:pkgName | (self hasPackage: pkgName) ifTrue: [ gofer package: pkgName ]].
 	gofer references notEmpty ifTrue: [ gofer unload ].
+	super tearDown
 
 ]
 

--- a/src/Versionner-Tests-Core-Model/MBPackageInfoTest.class.st
+++ b/src/Versionner-Tests-Core-Model/MBPackageInfoTest.class.st
@@ -24,13 +24,6 @@ MBPackageInfoTest >> setUp [
 	package := MBPackageInfo named: 'FooBarZork'.
 ]
 
-{ #category : #running }
-MBPackageInfoTest >> tearDown [
-"	(Smalltalk includesKey: #TMPClass)
-		ifTrue: [ (Smalltalk at: #TMPClass) removeFromSystem ].
-"
-]
-
 { #category : #tests }
 MBPackageInfoTest >> testInstantiation [
 	self should: [ MBPackageInfo new ] raise: Error.


### PR DESCRIPTION
 

https://pharo.fogbugz.com/f/cases/21089/Super-tearDown-need-to-be-called-as-last-message-in-tearDown-of-Versionner-tests