### PR TITLE
21175-ReleaseTest-testUndeclared-should-allow-stubs-for-test-purpose

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -216,18 +216,18 @@ ReleaseTest >> testThatAllMethodsArePackaged [
 
 { #category : #testing }
 ReleaseTest >> testUndeclared [
-	| undeclaredReferences |
+	| undeclaredBindings |
 	
 	Smalltalk cleanOutUndeclared. 
-	undeclaredReferences := Undeclared keys reject: [:each |
+	undeclaredBindings := Undeclared keys reject: [:each |
 			each includesSubstring: 'undeclaredStub' caseSensitive: false].
 	
 	self 
-		assert: undeclaredReferences isEmpty 
+		assert: undeclaredBindings isEmpty 
 		description: (String streamContents: [ :s|
 			s 
 				nextPutAll: 'Found undeclared references: ';
-				print: undeclaredReferences ])
+				print: undeclaredBindings ])
 ]
 
 { #category : #testing }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -219,7 +219,8 @@ ReleaseTest >> testUndeclared [
 	| undeclaredReferences |
 	
 	Smalltalk cleanOutUndeclared. 
-	undeclaredReferences := Undeclared.
+	undeclaredReferences := Undeclared keys reject: [:each |
+			each includesSubstring: 'undeclaredStub' caseSensitive: false].
 	
 	self 
 		assert: undeclaredReferences isEmpty 
@@ -227,7 +228,6 @@ ReleaseTest >> testUndeclared [
 			s 
 				nextPutAll: 'Found undeclared references: ';
 				print: undeclaredReferences ])
-	
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Not testUndeclared allows variables with substribg undeclaredStub (case insensitive)
Substring check is better than just prefix. Because for some reason other application prefix can be needed.https://pharo.fogbugz.com/f/cases/21175/ReleaseTest-testUndeclared-should-allow-stubs-for-test-purpose