### PR TITLE
21091 MTDevelopmentWorkfowTestWithXMLParser should be renamed to MTDevelopmentWorkflowTestWithXMLParser

### DIFF
--- a/src/Versionner-Tests-Core-DependenciesModel/MTDevelopmentWorkflowTest.class.st
+++ b/src/Versionner-Tests-Core-DependenciesModel/MTDevelopmentWorkflowTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MTDevelopmentWorkfowTest,
+	#name : #MTDevelopmentWorkflowTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'project',
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : #tests }
-MTDevelopmentWorkfowTest >> testCreateInitialDevelopment [
+MTDevelopmentWorkflowTest >> testCreateInitialDevelopment [
 	|  version configuration |
 
 	project := MTProject newNamed: 'Z' withInitialVersion: '0.1'  inRepository: 'http://smalltalkhub.com/mc/demarey/Versionner/main'.
@@ -29,7 +29,7 @@ MTDevelopmentWorkfowTest >> testCreateInitialDevelopment [
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTest >> testNewProjectWithInitialVersionInRepository [
+MTDevelopmentWorkflowTest >> testNewProjectWithInitialVersionInRepository [
 	|  projectName configClass |
 
 	projectName := 'VersionnerTest'.
@@ -46,7 +46,7 @@ MTDevelopmentWorkfowTest >> testNewProjectWithInitialVersionInRepository [
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTest >> testNextDevelopmentVersionString [
+MTDevelopmentWorkflowTest >> testNextDevelopmentVersionString [
 	| workflow |
 	
 	workflow := MTDevelopmentWorkfow new.
@@ -56,7 +56,7 @@ MTDevelopmentWorkfowTest >> testNextDevelopmentVersionString [
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTest >> testStandardizeDevVersionString [
+MTDevelopmentWorkflowTest >> testStandardizeDevVersionString [
 	| workflow |
 	
 	workflow := MTDevelopmentWorkfow new.

--- a/src/Versionner-Tests-Core-DependenciesModel/MTDevelopmentWorkflowTestWithXMLParser.class.st
+++ b/src/Versionner-Tests-Core-DependenciesModel/MTDevelopmentWorkflowTestWithXMLParser.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #MTDevelopmentWorkfowTestWithXMLParser,
-	#superclass : #MTDevelopmentWorkfowTest,
+	#name : #MTDevelopmentWorkflowTestWithXMLParser,
+	#superclass : #MTDevelopmentWorkflowTest,
 	#category : #'Versionner-Tests-Core-DependenciesModel'
 }
 
 { #category : #utility }
-MTDevelopmentWorkfowTestWithXMLParser >> setDevelopment: aVersionString [
+MTDevelopmentWorkflowTestWithXMLParser >> setDevelopment: aVersionString [
 	project configurationClass compile: 'development: spec
 	<symbolicVersion: #''development''>
 
@@ -13,7 +13,7 @@ MTDevelopmentWorkfowTestWithXMLParser >> setDevelopment: aVersionString [
 ]
 
 { #category : #running }
-MTDevelopmentWorkfowTestWithXMLParser >> setUp [
+MTDevelopmentWorkflowTestWithXMLParser >> setUp [
 	"Create a model of the project version we want to work on."
 	| version |
 	super setUp.
@@ -28,13 +28,13 @@ MTDevelopmentWorkfowTestWithXMLParser >> setUp [
 ]
 
 { #category : #running }
-MTDevelopmentWorkfowTestWithXMLParser >> tearDown [ 
+MTDevelopmentWorkflowTestWithXMLParser >> tearDown [ 
 	classFactory cleanUp.
 	super tearDown
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTestWithXMLParser >> testCreateBaseline [
+MTDevelopmentWorkflowTestWithXMLParser >> testCreateBaseline [
 	| baselineName baseline |
 	
 	baselineName := '84.1'.
@@ -50,13 +50,13 @@ MTDevelopmentWorkfowTestWithXMLParser >> testCreateBaseline [
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTestWithXMLParser >> testCreateNextDevelopment [
+MTDevelopmentWorkflowTestWithXMLParser >> testCreateNextDevelopment [
 	project devWorkflow createNextDevelopment: '999'.
 	self assert: (project configurationClass selectors includes: #'baseline999:').
 ]
 
 { #category : #tests }
-MTDevelopmentWorkfowTestWithXMLParser >> testIsDevelopmentUsedInRelease [
+MTDevelopmentWorkflowTestWithXMLParser >> testIsDevelopmentUsedInRelease [
 	| workflow |
 	workflow := project devWorkflow.
 	self assert: workflow isDevelopmentUsedInRelease equals: false.


### PR DESCRIPTION
renamed two classes to fix typo

https://pharo.fogbugz.com/f/cases/21091/MTDevelopmentWorkfowTestWithXMLParser-should-be-renamed-to-MTDevelopmentWorkflowTestWithXMLParser