### PR TITLE
21217-ShortcutReminder-should-work-with-any-kind-of-menus

### DIFF
--- a/src/Morphic-Base/MenuItemMorph.class.st
+++ b/src/Morphic-Base/MenuItemMorph.class.st
@@ -411,8 +411,8 @@ MenuItemMorph >> invokeWithEvent: evt [
 			ifFalse:
 				[selArgCount = arguments size
 					ifTrue: [target perform: selector withArguments: arguments]
-					ifFalse: [target perform: selector withArguments: (arguments copyWith: evt)].
-		self showShortcut ].
+					ifFalse: [target perform: selector withArguments: (arguments copyWith: evt)]].
+		self showShortcut.
 		self changed].
 ]
 


### PR DESCRIPTION
showShortcut reminder was in wrong place in menu item invoke  method.

https://pharo.fogbugz.com/f/cases/21217/ShortcutReminder-should-work-with-any-kind-of-menus