### PR TITLE
Only pass background exceptions when we #shouldPassBackgroundFailures (fixes #17813)

### DIFF
--- a/src/SUnit-Core/ProcessMonitorTestService.class.st
+++ b/src/SUnit-Core/ProcessMonitorTestService.class.st
@@ -288,7 +288,7 @@ ProcessMonitorTestService >> handleBackgroundException: anUnhandledException [
 
 	self handleException: anUnhandledException.
 
-	anUnhandledException pass
+	self shouldPassBackgroundFailures ifTrue: [ anUnhandledException pass ]
 ]
 
 { #category : 'controlling' }


### PR DESCRIPTION
Normally during test cleanup we will terminate any suspended background processes, so they will not actually get to resume and hit the #pass. However if the error was raised in an #ensure: block, the background process will finish executing the handler even when sent #terminate, so we need to avoid passing the exception and opening a debugger.

I _think_ this is correct—certainly the behavior of `passBackgroundFailures`, e.g. when a halt is encountered, should be unaffected as that explicitly causes `shouldPassBackgroundFailures` to return `true` before resuming anything. But I'd appreciate another set of eyes on it, and if I should be checking a different condition, or a new condition variable needs to be added, that's possible too.

Fixes #17813