### PR TITLE
Deprecate TSortable

### DIFF
--- a/src/Deprecated13/TSortable.trait.st
+++ b/src/Deprecated13/TSortable.trait.st
@@ -9,10 +9,16 @@ To get the behavior I define, my users should implement:
 "
 Trait {
 	#name : 'TSortable',
-	#category : 'Kernel-Traits-Base',
-	#package : 'Kernel-Traits',
-	#tag : 'Base'
+	#category : 'Deprecated13',
+	#package : 'Deprecated13'
 }
+
+{ #category : 'testing' }
+TSortable classSide >> isDeprecated [
+	"This trait has no user and will be removed from Pharo."
+
+	^ true
+]
 
 { #category : 'sorting' }
 TSortable >> isSorted [

--- a/src/Deprecated14/TSortable.trait.st
+++ b/src/Deprecated14/TSortable.trait.st
@@ -9,8 +9,8 @@ To get the behavior I define, my users should implement:
 "
 Trait {
 	#name : 'TSortable',
-	#category : 'Deprecated13',
-	#package : 'Deprecated13'
+	#category : 'Deprecated14',
+	#package : 'Deprecated14'
 }
 
 { #category : 'testing' }

--- a/src/Kernel-Extended-Tests/AdditionalMethodStateTest.class.st
+++ b/src/Kernel-Extended-Tests/AdditionalMethodStateTest.class.st
@@ -29,7 +29,7 @@ AdditionalMethodStateTest >> testAnalogousCodeTo [
 	state := AdditionalMethodState new: 1.
 	state
 		basicAt: 1
-		put: #traitSource -> TSortable.
+		put: #traitSource -> TEmpty.
 
 	self
 		shouldnt: [ state analogousCodeTo: state ]

--- a/src/Refactoring-Environment-Tests/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Environment-Tests/RBBrowserEnvironmentTest.class.st
@@ -245,14 +245,13 @@ RBBrowserEnvironmentTest >> testBrowserEnvironment [
 
 { #category : 'tests - environments' }
 RBBrowserEnvironmentTest >> testClassEnvironment [
+
 	| aClassEnvironment |
-	aClassEnvironment := RBClassEnvironment
-		onEnvironment: universalEnvironment
-		classes: (Array with: Object with: Object class).
+	aClassEnvironment := RBClassEnvironment onEnvironment: universalEnvironment classes: (Array with: Object with: Object class).
 	self universalTestFor: aClassEnvironment.
-	self deny: (universalEnvironment isClassEnvironment).
-	self assert: (aClassEnvironment isClassEnvironment).
-	self assert: (aClassEnvironment packages size) equals: 1.
+	self deny: universalEnvironment isClassEnvironment.
+	self assert: aClassEnvironment isClassEnvironment.
+	self assert: aClassEnvironment packages size equals: 1.
 	self assert: (aClassEnvironment implementorsOf: #printString) numberSelectors equals: 1.
 
 	self assert: (RBClassEnvironment class: Class) selectors size

--- a/src/Ring-Definitions-Core-Tests/RGMetatraitDefinitionTest.class.st
+++ b/src/Ring-Definitions-Core-Tests/RGMetatraitDefinitionTest.class.st
@@ -13,11 +13,11 @@ Class {
 RGMetatraitDefinitionTest >> testAsClassTraitfinition [
 
 	| rgCTrait cTrait |
-	cTrait := TSortable classTrait.
+	cTrait := TEmpty classTrait.
 	rgCTrait := cTrait asRingDefinition.
 	self assert: rgCTrait isRingObject.
 	self assert: rgCTrait isTrait.
-	self assert: rgCTrait name identicalTo: #'TSortable classTrait'.
+	self assert: rgCTrait name identicalTo: #'TEmpty classTrait'.
 	self assert: rgCTrait package name identicalTo: cTrait package name.
 	self assert: rgCTrait packageTag identicalTo: cTrait packageTag name.
 	self assert: rgCTrait classSide identicalTo: rgCTrait

--- a/src/Ring-Definitions-Core-Tests/RGTraitDefinitionTest.class.st
+++ b/src/Ring-Definitions-Core-Tests/RGTraitDefinitionTest.class.st
@@ -12,13 +12,16 @@ Class {
 { #category : 'testing' }
 RGTraitDefinitionTest >> testAddingMethods [
 	| newMethod newClass |
-	newClass := RGTraitDefinition named: #TSortable.
-	newMethod := (RGMethodDefinition named: #sort)
+	newClass := RGTraitDefinition named: #TIsEmpty.
+	newMethod := (RGMethodDefinition named: #isNotEmpty)
 		parent: newClass;
-		protocol: 'sorting';
+		protocol: 'testing';
 		sourceCode:
-			'sort
-									self sort: [:a :b | a <= b]'.
+			'isNotEmpty
+	"Evaluate the given block with the receiver as argument, answering its value
+	unless the receiver is empty, in which case answer the receiver."
+
+	^ self isEmpty not'.
 
 	self assert: newMethod isMeta not.
 	self assert: newClass hasMethods not.
@@ -32,9 +35,9 @@ RGTraitDefinitionTest >> testAddingMethods [
 							^lastIndex - firstIndex + 1'.
 
 	self assert: newClass hasMethods.
-	self assert: newClass selectors asSet equals: #(sort size) asSet.
-	self assert: (newClass includesSelector: #sort).
-	self assert: (newClass methodNamed: #sort) equals: newMethod.
+	self assert: newClass selectors asSet equals: #(isNotEmpty size) asSet.
+	self assert: (newClass includesSelector: #isNotEmpty).
+	self assert: (newClass methodNamed: #isNotEmpty) equals: newMethod.
 	self assert: newClass methods size equals: 2.
 	self assert: newClass selectors size equals: 2.
 	self assert: newClass allSelectors size equals: 2.	"no hierarchy"
@@ -42,7 +45,7 @@ RGTraitDefinitionTest >> testAddingMethods [
 	newMethod := newClass methodNamed: #size.
 	self assert: newMethod parent equals: newClass.
 
-	self assert: (newClass compiledMethodNamed: #sort) isNotNil.
+	self assert: (newClass compiledMethodNamed: #isNotEmpty) isNotNil.
 	self assert: (newClass compiledMethodNamed: #foo) isNil
 ]
 
@@ -50,10 +53,10 @@ RGTraitDefinitionTest >> testAddingMethods [
 RGTraitDefinitionTest >> testAsTraitDefinition [
 
 	| newTrait |
-	newTrait := TSortable asRingDefinition.
+	newTrait := TEmpty asRingDefinition.
 	self assert: newTrait isRingObject.
 	self assert: newTrait isTrait.
-	self assert: newTrait name identicalTo: #TSortable.
+	self assert: newTrait name identicalTo: #TEmpty.
 	self assert: newTrait package isNotNil.
 	self assert: newTrait packageTag isNotNil.
 	self assert: newTrait superclassName isNotNil.
@@ -67,19 +70,19 @@ RGTraitDefinitionTest >> testAsTraitDefinition [
 { #category : 'testing' }
 RGTraitDefinitionTest >> testExistingTrait [
 	| newClass metaClass |
-	newClass := RGTraitDefinition named: #TSortable.
+	newClass := RGTraitDefinition named: #TEmpty.
 	self assert: newClass isTrait.
 	self assert: newClass isDefined.
-	self assert: newClass realClass equals: TSortable.
+	self assert: newClass realClass equals: TEmpty.
 	self assert: newClass isMeta not.
 
 	newClass withMetaclass.
 	self assert: newClass hasMetaclass.
 	metaClass := newClass classSide.
 	self assert: metaClass isMeta.
-	self assert: metaClass name equals: 'TSortable classTrait'.
+	self assert: metaClass name equals: 'TEmpty classTrait'.
 	self assert: metaClass instanceSide equals: newClass.
-	self assert: metaClass realClass equals: TSortable classSide
+	self assert: metaClass realClass equals: TEmpty classSide
 ]
 
 { #category : 'testing' }
@@ -105,8 +108,8 @@ RGTraitDefinitionTest >> testNonExistingClass [
 RGTraitDefinitionTest >> testTraitEquality [
 
 	| newClass |
-	self assert: TSortable asRingDefinition equals: TSortable asRingDefinition.
+	self assert: TEmpty asRingDefinition equals: TEmpty asRingDefinition.
 
-	newClass := TSortable asRingDefinition package: (RGPackageDefinition named: #Kernel).
-	self assert: TSortable asRingDefinition equals: newClass
+	newClass := TEmpty asRingDefinition package: (RGPackageDefinition named: #Kernel).
+	self assert: TEmpty asRingDefinition equals: newClass
 ]

--- a/src/Ring-Definitions-Monticello-Tests/RGMonticelloTest.class.st
+++ b/src/Ring-Definitions-Monticello-Tests/RGMonticelloTest.class.st
@@ -51,11 +51,11 @@ RGMonticelloTest >> testConvertingMCMethodDefinition [
 { #category : 'testing' }
 RGMonticelloTest >> testConvertingMCTraitDefinition [
 	| mcClass ringClass |
-	mcClass := TSortable asClassDefinition.
+	mcClass := TEmpty asClassDefinition.
 	ringClass := mcClass asRingDefinition.
 
 	self assert: ringClass isTrait.
-	self assert: ringClass classSide realClass equals: TSortable classSide.
-	self assert: (ringClass isSameRevisionAs: TSortable asRingDefinition).
+	self assert: ringClass classSide realClass equals: TEmpty classSide.
+	self assert: (ringClass isSameRevisionAs: TEmpty asRingDefinition).
 	self deny: (ringClass isSameRevisionAs: TAssertable asRingDefinition)
 ]

--- a/src/Ring-Definitions-Monticello-Tests/RGTraitDefinitionTest.extension.st
+++ b/src/Ring-Definitions-Monticello-Tests/RGTraitDefinitionTest.extension.st
@@ -4,15 +4,15 @@ Extension { #name : 'RGTraitDefinitionTest' }
 RGTraitDefinitionTest >> testAsFullTraitDefinition [
 
 	| rgClass |
-	rgClass := TSortable asRingDefinition.
+	rgClass := TIsEmpty asRingDefinition.
 	self assertEmpty: rgClass methods.
 	self assert: rgClass superclass isNil.
 	self assertEmpty: rgClass subclasses.
 	self assert: rgClass package name equals: #'Kernel-Traits'.
 
-	rgClass := TSortable asFullRingDefinition.
+	rgClass := TIsEmpty asFullRingDefinition.
 	self denyEmpty: rgClass methods.
-	self assert: (rgClass methodNamed: #isSorted) package isNotNil.
+	self assert: (rgClass methodNamed: #isNotEmpty) package isNotNil.
 	self assert: rgClass superclass isNotNil.
 	self assert: rgClass superclass name equals: #Trait.
 	self assertEmpty: rgClass subclasses.

--- a/src/Tools-Tests/OpenToolTest.class.st
+++ b/src/Tools-Tests/OpenToolTest.class.st
@@ -58,7 +58,7 @@ OpenToolTest >> testInspectInteger [
 { #category : 'tests - inspect' }
 OpenToolTest >> testInspectTraitClass [
 	| inspector |
-	inspector := self openInspectorOn: TSortable.
+	inspector := self openInspectorOn: TEmpty.
 	inspector changed.
 	inspector close
 ]
@@ -89,8 +89,9 @@ OpenToolTest >> testOpenBrowseOnMethod [
 
 { #category : 'tests - browse' }
 OpenToolTest >> testOpenBrowseOnTraitMethod [
+
 	| browser |
-	browser := (TSortable>>#isSorted) browse.
+	browser := (TIsEmpty >> #isEmpty) browse.
 	browser changed.
 	browser close
 ]

--- a/src/Traits-Tests/ClassTraitTest.class.st
+++ b/src/Traits-Tests/ClassTraitTest.class.st
@@ -73,11 +73,11 @@ ClassTraitTest >> testInitialization [
 ClassTraitTest >> testIsClassOrTrait [
 
 	self
-		assert: TSortable isClassOrTrait;
+		assert: TEmpty isClassOrTrait;
 		assert: Class isClassOrTrait;
 		assert: Class class isClassOrTrait;
 		deny: Object new isClassOrTrait;
-		assert: TSortable classTrait isClassOrTrait
+		assert: TEmpty classTrait isClassOrTrait
 ]
 
 { #category : 'tests' }

--- a/src/Traits-Tests/TraitLegacyPharoClassDefinitionPrinterTest.class.st
+++ b/src/Traits-Tests/TraitLegacyPharoClassDefinitionPrinterTest.class.st
@@ -57,6 +57,13 @@ TraitLegacyPharoClassDefinitionPrinterTest >> testTComparableClassTrait [
 ]
 
 { #category : 'tests - traits' }
+TraitLegacyPharoClassDefinitionPrinterTest >> testTEmpty [
+
+	self assert: (self forClass: TEmpty classTrait) equals: 'TEmpty classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : 'tests - traits' }
 TraitLegacyPharoClassDefinitionPrinterTest >> testTEventVisitorClassTrait [
 
 	self assert: (self forClass: EpTEventVisitor classTrait) equals: 'EpTEventVisitor classTrait
@@ -70,13 +77,6 @@ TraitLegacyPharoClassDefinitionPrinterTest >> testTIsEmpty [
 	self assert: (self forClass: TIsEmpty) equals: 'Trait named: #TIsEmpty
 	 uses: {}
 	 package: ''Kernel-Traits-Base'''
-]
-
-{ #category : 'tests - traits' }
-TraitLegacyPharoClassDefinitionPrinterTest >> testTSortable [
-
-	self assert: (self forClass: TSortable classTrait) equals: 'TSortable classTrait
-	instanceVariableNames: '''''
 ]
 
 { #category : 'tests - traits' }

--- a/src/Traits-Tests/TraitOldPharoClassDefinitionPrinterTest.class.st
+++ b/src/Traits-Tests/TraitOldPharoClassDefinitionPrinterTest.class.st
@@ -47,6 +47,13 @@ TraitOldPharoClassDefinitionPrinterTest >> testTComparableClassTrait [
 ]
 
 { #category : 'tests - traits' }
+TraitOldPharoClassDefinitionPrinterTest >> testTEmpty [
+
+	self assert: (self forClass: TEmpty classTrait) equals: 'TEmpty classTrait
+	instanceVariableNames: '''''
+]
+
+{ #category : 'tests - traits' }
 TraitOldPharoClassDefinitionPrinterTest >> testTEventVisitorClassTrait [
 
 	self assert: (self forClass: EpTEventVisitor classTrait) equals: 'EpTEventVisitor classTrait
@@ -61,13 +68,6 @@ TraitOldPharoClassDefinitionPrinterTest >> testTIsEmpty [
 	self assert: (self forClass: TIsEmpty) equals: 'Trait named: #TIsEmpty
 	instanceVariableNames: ''''
 	package: ''Kernel-Traits-Base'''
-]
-
-{ #category : 'tests - traits' }
-TraitOldPharoClassDefinitionPrinterTest >> testTSortable [
-
-	self assert: (self forClass: TSortable classTrait) equals: 'TSortable classTrait
-	instanceVariableNames: '''''
 ]
 
 { #category : 'tests - traits' }


### PR DESCRIPTION
Multiple people already agreed to remove the trait with no user in Pharo issues. Pavel did a first PR that has failures. In this change I am updating the tests using this trait, I deprecate it and I remove the package that contained it before.

Fixes #16357