### PR TITLE
Speedup Traits recompilation 

### DIFF
--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -256,6 +256,12 @@ TaAbstractComposition >> hasMethod: aSelector [
 		do: [ ^ false ]
 ]
 
+{ #category : 'testing' }
+TaAbstractComposition >> hasSlots [
+
+	^ self slots isNotEmpty
+]
+
 { #category : 'comparing' }
 TaAbstractComposition >> hash [
 	^ self subclassResponsibility
@@ -365,7 +371,7 @@ TaAbstractComposition >> name [
 TaAbstractComposition >> needsRecompilation: aSelector [
 	"Checks if a selector should be compiled because it uses new slots or if its code has been rewritten."
 
-	^ self slots isNotEmpty or: [ self changesSourceCode: aSelector ]
+	^ self hasSlots or: [ self changesSourceCode: aSelector ]
 ]
 
 { #category : 'querying' }

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -410,13 +410,9 @@ TaAbstractComposition >> saveSourceCode: sourceCode ofMethod: newMethod [
 
 { #category : 'accessing' }
 TaAbstractComposition >> selectors [
-
-	| set |
-	set := OrderedCollection new: 60.
-	self selectorsDo: [ :selector | set add: selector ].
-	
 	"We return an array because this was the behavior before. Maybe we could directly return the set but that might break some code"
-	^ set removeDuplicates asArray
+
+	^ (OrderedCollection streamContents: [ :stream | self selectorsDo: [ :selector | stream nextPut: selector ] ]) removeDuplicates asArray
 ]
 
 { #category : 'enumerating' }

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -262,6 +262,14 @@ TaAbstractComposition >> hash [
 ]
 
 { #category : 'testing' }
+TaAbstractComposition >> includesSelector: aSelector [
+
+	self selectorsDo: [ :selector | selector = aSelector ifTrue: [ ^ true ] ].
+
+	^ false
+]
+
+{ #category : 'testing' }
 TaAbstractComposition >> includesTrait: aTrait [
 	"Checks if the trait is used in the trait composition"
 

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -402,6 +402,20 @@ TaAbstractComposition >> saveSourceCode: sourceCode ofMethod: newMethod [
 
 { #category : 'accessing' }
 TaAbstractComposition >> selectors [
+
+	| set |
+	set := OrderedCollection new: 60.
+	self selectorsDo: [ :selector | set add: selector ].
+	
+	"We return an array because this was the behavior before. Maybe we could directly return the set but that might break some code"
+	^ set removeDuplicates asArray
+]
+
+{ #category : 'enumerating' }
+TaAbstractComposition >> selectorsDo: aBlock [
+	"Iterate over the selectors of the trait composition. Be careful, we might iterate multiple time on the same selectors if multiple members have the same selector. 
+	If you want to avoid this, use #selectors that filters duplicated selectors."
+
 	self subclassResponsibility
 ]
 

--- a/src/Traits/TaAliasMethod.class.st
+++ b/src/Traits/TaAliasMethod.class.st
@@ -142,8 +142,10 @@ TaAliasMethod >> reverseAlias: aSelector [
 ]
 
 { #category : 'accessing' }
-TaAliasMethod >> selectors [
-	^ inner selectors , self existingAliasedSelectors.
+TaAliasMethod >> selectorsDo: aBlock [
+
+	inner selectorsDo: aBlock.
+	self existingAliasedSelectors do: aBlock
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaAliasMethod.class.st
+++ b/src/Traits/TaAliasMethod.class.st
@@ -141,7 +141,7 @@ TaAliasMethod >> reverseAlias: aSelector [
 	^ (inner reverseAlias: aSelector) , (aliases associations select: [ :a | a value = aSelector ] thenCollect: #key)
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaAliasMethod >> selectorsDo: aBlock [
 
 	inner selectorsDo: aBlock.

--- a/src/Traits/TaClassCompositionElement.class.st
+++ b/src/Traits/TaClassCompositionElement.class.st
@@ -23,7 +23,7 @@ TaClassCompositionElement >> methods [
 		  (innerClassLocalMethods includes: methodSelector) not and: [ traitedClassSelectors anySatisfy: [ :x | x = methodSelector ] ] ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaClassCompositionElement >> selectorsDo: aBlock [
 	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 

--- a/src/Traits/TaClassCompositionElement.class.st
+++ b/src/Traits/TaClassCompositionElement.class.st
@@ -24,16 +24,21 @@ TaClassCompositionElement >> methods [
 ]
 
 { #category : 'accessing' }
-TaClassCompositionElement >> selectors [
+TaClassCompositionElement >> selectorsDo: aBlock [
 	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 
-	| innerClassLocalMethods traitedClassSelectors |
-	innerClassLocalMethods := innerClass localMethods collect: [ :each | each selector ].
-	traitedClassSelectors := TraitedClass selectors.
-	^ super selectors reject: [ :selector |
-		  | methodSelector |
-		  methodSelector := selector.
-		  (innerClassLocalMethods includes: methodSelector) not and: [ traitedClassSelectors anySatisfy: [ :x | x = methodSelector ] ] ]
+	| selectorsToExclude block |
+	selectorsToExclude := TraitedClass selectors \ innerClass localSelectors.
+
+	block := [ :selector |
+		         | actualSelector |
+		         actualSelector := self actualSelector: selector.
+
+		         (selectorsToExclude includes: selector) ifFalse: [ aBlock value: actualSelector ] ].
+	
+	"We do not rely on the methods of the innerclass because while removing a trait we might return the removed methods during the removal and I need to work properly during the method dictionary rebuild"
+	innerClass localSelectors do: block.
+	innerClass traitComposition selectorsDo: block
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaCompositionElement.class.st
+++ b/src/Traits/TaCompositionElement.class.st
@@ -27,6 +27,14 @@ TaCompositionElement >> = aTrait [
 		ifFalse: [ ^ false ]
 ]
 
+{ #category : 'accessing' }
+TaCompositionElement >> actualSelector: selector [
+
+	^ selector = #initializeTalent
+		  ifTrue: [ self initializeSelectorForMe ]
+		  ifFalse: [ selector ]
+]
+
 { #category : 'users' }
 TaCompositionElement >> addUser: aClass [
 	"When a user is added to me I propagate to the real Trait, as I am the root of the TraitComposition"
@@ -156,15 +164,17 @@ TaCompositionElement >> reverseAlias: aSelector [
 ]
 
 { #category : 'accessing' }
-TaCompositionElement >> selectors [
-	" I get all the selectors of the methods in this talent, if there is a #initializeTalent selector I rename it to #initializeTalent_NameOfTalent"
+TaCompositionElement >> selectorsDo: aBlock [
+	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 
-	| originals |
+	| selectorsToExclude block |
+	selectorsToExclude := TraitedClass selectors \ innerClass localSelectors.
+
+	block := [ :selector | aBlock value: (self actualSelector: selector) ].
+	
 	"We do not rely on the methods of the innerclass because while removing a trait we might return the removed methods during the removal and I need to work properly during the method dictionary rebuild"
-	originals := innerClass localSelectors , innerClass traitComposition selectors.
-	^ (originals includes: #initializeTalent)
-		  ifTrue: [ (originals reject: [ :e | e = #initializeTalent ]) copyWith: self initializeSelectorForMe ]
-		  ifFalse: [ originals ]
+	innerClass localSelectors do: block.
+	innerClass traitComposition selectorsDo: block
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaCompositionElement.class.st
+++ b/src/Traits/TaCompositionElement.class.st
@@ -163,18 +163,13 @@ TaCompositionElement >> reverseAlias: aSelector [
 	^ #()
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaCompositionElement >> selectorsDo: aBlock [
 	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 
-	| selectorsToExclude block |
-	selectorsToExclude := TraitedClass selectors \ innerClass localSelectors.
-
-	block := [ :selector | aBlock value: (self actualSelector: selector) ].
-	
 	"We do not rely on the methods of the innerclass because while removing a trait we might return the removed methods during the removal and I need to work properly during the method dictionary rebuild"
-	innerClass localSelectors do: block.
-	innerClass traitComposition selectorsDo: block
+	innerClass localSelectors do: [ :selector | aBlock value: (self actualSelector: selector) ].
+	innerClass traitComposition selectorsDo: [ :selector | aBlock value: (self actualSelector: selector) ]
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaEmptyComposition.class.st
+++ b/src/Traits/TaEmptyComposition.class.st
@@ -122,7 +122,7 @@ TaEmptyComposition >> reverseAlias: aSelector [
 	^ #()
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaEmptyComposition >> selectorsDo: aBlock [
 	"Noop"
 

--- a/src/Traits/TaEmptyComposition.class.st
+++ b/src/Traits/TaEmptyComposition.class.st
@@ -123,8 +123,10 @@ TaEmptyComposition >> reverseAlias: aSelector [
 ]
 
 { #category : 'accessing' }
-TaEmptyComposition >> selectors [
-	^#()
+TaEmptyComposition >> selectorsDo: aBlock [
+	"Noop"
+
+	
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaPrecedenceComposition.class.st
+++ b/src/Traits/TaPrecedenceComposition.class.st
@@ -50,9 +50,9 @@ TaPrecedenceComposition >> isConflictingSelector: aSelector [
 
 { #category : 'accessing' }
 TaPrecedenceComposition >> memberForSelector: aSelector [
-
 	"I look first in the prefered trait if not in the other member"
-	((preferedTrait selectors includes: aSelector) and: [ (preferedTrait compiledMethodAt: aSelector) isRequired not ]) ifTrue: [ ^ preferedTrait ].
+
+	((preferedTrait includesSelector: aSelector) and: [ (preferedTrait compiledMethodAt: aSelector) isRequired not ]) ifTrue: [ ^ preferedTrait ].
 
 	^ super memberForSelector: aSelector
 ]

--- a/src/Traits/TaRemoveMethod.class.st
+++ b/src/Traits/TaRemoveMethod.class.st
@@ -53,8 +53,9 @@ TaRemoveMethod >> removedSelectors: anObject [
 ]
 
 { #category : 'accessing' }
-TaRemoveMethod >> selectors [
-	^ inner selectors reject: [ :selector | removedSelectors includes: selector ]
+TaRemoveMethod >> selectorsDo: aBlock [
+
+	inner selectorsDo: [ :selector | (removedSelectors includes: selector) ifFalse: [ aBlock value: selector ] ]
 ]
 
 { #category : 'printing' }

--- a/src/Traits/TaRemoveMethod.class.st
+++ b/src/Traits/TaRemoveMethod.class.st
@@ -52,7 +52,7 @@ TaRemoveMethod >> removedSelectors: anObject [
 	removedSelectors := anObject
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaRemoveMethod >> selectorsDo: aBlock [
 
 	inner selectorsDo: [ :selector | (removedSelectors includes: selector) ifFalse: [ aBlock value: selector ] ]

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -117,6 +117,13 @@ TaSequence >> copyWithoutTrait: aTrait [
 	^ self class withAll: newMembers
 ]
 
+{ #category : 'accessing' }
+TaSequence >> hasSlots [
+	"Overriding to implement a faster check to speed up trait recompilation."
+
+	^ members anySatisfy: #hasSlots
+]
+
 { #category : 'comparing' }
 TaSequence >> hash [
 	^ self class hash

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -249,7 +249,7 @@ TaSequence >> selectorForConflict: selector [
 							space ] ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaSequence >> selectorsDo: aBlock [
 
 	members do: [ :member | member selectorsDo: aBlock ]

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -250,9 +250,9 @@ TaSequence >> selectorForConflict: selector [
 ]
 
 { #category : 'accessing' }
-TaSequence >> selectors [
-	"We should really introduce a #removeDuplicates or #withoutDuplicates on Array..."
-	^ (members flatCollect: [ :member | member selectors ] as: Set) asArray
+TaSequence >> selectorsDo: aBlock [
+
+	members do: [ :member | member selectorsDo: aBlock ]
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -170,8 +170,8 @@ TaSequence >> memberForSelector: aSelector [
 	I first look for a valid member, if not, I will return the first"
 
 	^ members
-		  detect: [ :member | (member selectors includes: aSelector) and: [ (member compiledMethodAt: aSelector) isRequired not ] ]
-		  ifNone: [ members detect: [ :member | member selectors includes: aSelector ] ]
+		  detect: [ :member | (member includesSelector: aSelector) and: [ (member compiledMethodAt: aSelector) isRequired not ] ]
+		  ifNone: [ members detect: [ :member | member includesSelector: aSelector ] ]
 ]
 
 { #category : 'operations' }

--- a/src/Traits/TaSingleComposition.class.st
+++ b/src/Traits/TaSingleComposition.class.st
@@ -122,8 +122,9 @@ TaSingleComposition >> reverseAlias: aSelector [
 ]
 
 { #category : 'accessing' }
-TaSingleComposition >> selectors [
-	^ inner selectors
+TaSingleComposition >> selectorsDo: aBlock [
+
+	inner selectorsDo: aBlock
 ]
 
 { #category : 'accessing' }

--- a/src/Traits/TaSingleComposition.class.st
+++ b/src/Traits/TaSingleComposition.class.st
@@ -121,7 +121,7 @@ TaSingleComposition >> reverseAlias: aSelector [
 	^ inner reverseAlias: aSelector
 ]
 
-{ #category : 'accessing' }
+{ #category : 'enumerating' }
 TaSingleComposition >> selectorsDo: aBlock [
 
 	inner selectorsDo: aBlock


### PR DESCRIPTION
Trait recompilation can become really slow if the trait is used a lot.

For example, on my machine, it takes 58seconds to add an ivar to TEntityMetalevelDependency from Moose. 

Here is a step forward into speeding up this. I introduced a method #selectorsDo: on trait compositions and I used it to implement a faster #includesSelector:. 

The idea of #selectorsDo: is to not create intermediate collections and to stop faster if we have a non local return. 

With this change, the recompilation of TEntityMetalevelDependency dropped to around 45sec. The change is not huge, but it is better than nothing. 