### PR TITLE
Fix transformations order : `Move Method to Class`

### DIFF
--- a/src/Refactoring-Transformations/RBMoveMethodToClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodToClassTransformation.class.st
@@ -54,18 +54,16 @@ RBMoveMethodToClassTransformation >> method: aMethod class: aClass [
 
 { #category : 'transforming' }
 RBMoveMethodToClassTransformation >> privateTransform [
+
 	| oldClass newClass rbMethod originalProtocol |
 	oldClass := self classModelOf: method methodClass.
 	newClass := self classModelOf: class.
 	rbMethod := RBMethod for: newClass source: method sourceCode selector: method selector.
 	originalProtocol := method protocolName.
-
-	self generateChangesFor: (RBRemoveMethodTransformation 
-		selector: method selector
-		from: oldClass).
 	self generateChangesFor: (RBAddMethodTransformation
-		model: self model
-		sourceCode: rbMethod
-		in: newClass
-		withProtocol: originalProtocol)
+			 model: self model
+			 sourceCode: rbMethod
+			 in: newClass 
+			 withProtocol: originalProtocol).
+	self generateChangesFor: (RBRemoveMethodTransformation selector: method selector from: oldClass)
 ]


### PR DESCRIPTION
- Since it was removing the method from the source before copying it to the target, system could have raise error since the method may be used while the refactoring is performing
- Anyway this transformation is not used at the moment
- Fixes #18601