### PR TITLE
[Backport] Do not announce protocol changes while rebuilding method dictionaries

### DIFF
--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -148,7 +148,8 @@ TaAbstractComposition >> compile: selector into: aClass [
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod sourcePointer: method sourcePointer ].
 
-	aClass classify: selector under: (self protocolForMethod: method).
+	"This step should not announce anything in the system since I am used to build method dictionaries of my users."
+	self class codeChangeAnnouncer suspendAllWhile: [ aClass classify: selector under: (self protocolForMethod: method) ].
 
 	aClass addSelectorSilently: selector withMethod: newMethod.
 


### PR DESCRIPTION
Currently if you rebuild the method dictionary of a class using traits, if the trait has slots or if a method source code need to be adapted (in case of alias, or renamed slot), we announce the protocol changes of those methods.

This should not happen since we are just rebuilding a dictionary. This has really bad effects because in Moose, updating some traits makes Epicea unusable really fast. On top of that, the recompilation of traits is already slow and this makes it even slower.


I propose to backport this to P13 in order to have a Moose release with this fixed. The epicea bug happens a lot in Moose