### PR TITLE
preparation of new extension system

### DIFF
--- a/src/AST-Core/OCBlockNode.class.st
+++ b/src/AST-Core/OCBlockNode.class.st
@@ -128,6 +128,18 @@ OCBlockNode >> bar: anInteger [
 ]
 
 { #category : 'accessing' }
+OCBlockNode >> basicBcToASTCache [
+
+	^ bcToASTCache
+]
+
+{ #category : 'accessing' }
+OCBlockNode >> basicBcToASTCache: anObject [
+
+	bcToASTCache := anObject
+]
+
+{ #category : 'accessing' }
 OCBlockNode >> blockVariables [
 	| vars |
 	vars := super blockVariables asOrderedCollection.

--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -77,6 +77,18 @@ AthensCairoCanvas >> copyPage [
 	self ffiCall: #( void cairo_copy_page (self) )
 ]
 
+{ #category : 'accessing' }
+AthensCairoCanvas >> currentClipRect [
+
+	^ currentClipRect
+]
+
+{ #category : 'accessing' }
+AthensCairoCanvas >> currentClipRect: anObject [
+
+	currentClipRect := anObject
+]
+
 { #category : 'drawing' }
 AthensCairoCanvas >> draw [
 	"Fill the shape (anObject) using currently selected paint
@@ -147,6 +159,12 @@ AthensCairoCanvas >> handle [
 	^ handle value
 ]
 
+{ #category : 'accessing' }
+AthensCairoCanvas >> handle: anObject [
+
+	handle := anObject
+]
+
 { #category : 'initialization' }
 AthensCairoCanvas >> initializeWithSurface: anAthensSurface [
 	super initializeWithSurface: anAthensSurface.
@@ -175,8 +193,20 @@ AthensCairoCanvas >> paintTransform [
 ]
 
 { #category : 'accessing' }
+AthensCairoCanvas >> paintTransform: anObject [
+
+	paintTransform := anObject
+]
+
+{ #category : 'accessing' }
 AthensCairoCanvas >> pathTransform [
 	^ pathTransform
+]
+
+{ #category : 'accessing' }
+AthensCairoCanvas >> pathTransform: anObject [
+
+	pathTransform := anObject
 ]
 
 { #category : 'private' }

--- a/src/Athens-Cairo/AthensCairoPathBuilder.class.st
+++ b/src/Athens-Cairo/AthensCairoPathBuilder.class.st
@@ -213,6 +213,18 @@ AthensCairoPathBuilder >> cwArcTo: newEndPoint angle: angle [
 	^ self arcTo: newEndPoint angle: angle cw: true
 ]
 
+{ #category : 'accessing' }
+AthensCairoPathBuilder >> endPoint [
+
+	^ endPoint
+]
+
+{ #category : 'accessing' }
+AthensCairoPathBuilder >> endPoint: anObject [
+
+	endPoint := anObject
+]
+
 { #category : 'private' }
 AthensCairoPathBuilder >> getCurrentPoint [
 	^ context getCurrentPoint
@@ -233,6 +245,12 @@ AthensCairoPathBuilder >> glyphPath: glyphs size: numGlyphs [
 { #category : 'path commands' }
 AthensCairoPathBuilder >> hLineTo: x [
 	^ self lineTo: (absolute ifTrue: [ x @ endPoint y] ifFalse: [ x @ 0 ])
+]
+
+{ #category : 'accessing' }
+AthensCairoPathBuilder >> lastControlPoint [
+
+	^ lastControlPoint
 ]
 
 { #category : 'path commands' }

--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -361,6 +361,12 @@ AthensCairoSurface >> attemptToRecurseDrawing [
 	^ self
 ]
 
+{ #category : 'accessing' }
+AthensCairoSurface >> basicHandle [
+
+	^ handle
+]
+
 { #category : 'caching' }
 AthensCairoSurface >> cacheAt: anObject ifAbsentPut: aBlock [
 	"Answer an object from surface's cache identified by anObject,

--- a/src/Athens-Cairo/CoonsPaintPatch.extension.st
+++ b/src/Athens-Cairo/CoonsPaintPatch.extension.st
@@ -2,16 +2,17 @@ Extension { #name : 'CoonsPaintPatch' }
 
 { #category : '*Athens-Cairo' }
 CoonsPaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+
 	meshGradientPaint
 		beginPatch;
-		moveTo: (controlPoints at: 1);
-		curveVia: (controlPoints at: 2) and: (controlPoints at: 3) to: (controlPoints at: 4);
-		curveVia: (controlPoints at: 5) and: (controlPoints at: 6) to: (controlPoints at: 7);
-		curveVia: (controlPoints at: 8) and: (controlPoints at: 9) to: (controlPoints at: 10);
-		curveVia: (controlPoints at: 11) and: (controlPoints at: 12) to: (controlPoints at: 1);
-		setCorner: 0 color: colors first;
-		setCorner: 1 color: colors second;
-		setCorner: 2 color: colors third;
-		setCorner: 3 color: colors fourth;
+		moveTo: (self controlPoints at: 1);
+		curveVia: (self controlPoints at: 2) and: (self controlPoints at: 3) to: (self controlPoints at: 4);
+		curveVia: (self controlPoints at: 5) and: (self controlPoints at: 6) to: (self controlPoints at: 7);
+		curveVia: (self controlPoints at: 8) and: (self controlPoints at: 9) to: (self controlPoints at: 10);
+		curveVia: (self controlPoints at: 11) and: (self controlPoints at: 12) to: (self controlPoints at: 1);
+		setCorner: 0 color: self colors first;
+		setCorner: 1 color: self colors second;
+		setCorner: 2 color: self colors third;
+		setCorner: 3 color: self colors fourth;
 		endPatch
 ]

--- a/src/Athens-Cairo/GenericPaintPatch.extension.st
+++ b/src/Athens-Cairo/GenericPaintPatch.extension.st
@@ -2,8 +2,7 @@ Extension { #name : 'GenericPaintPatch' }
 
 { #category : '*Athens-Cairo' }
 GenericPaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+
 	meshGradientPaint beginPatch.
-	[
-		buildBlock value: meshGradientPaint
-	] ensure: [ meshGradientPaint endPatch ]
+	[ self buildBlock value: meshGradientPaint ] ensure: [ meshGradientPaint endPatch ]
 ]

--- a/src/Athens-Cairo/TrianglePaintPatch.extension.st
+++ b/src/Athens-Cairo/TrianglePaintPatch.extension.st
@@ -2,13 +2,14 @@ Extension { #name : 'TrianglePaintPatch' }
 
 { #category : '*Athens-Cairo' }
 TrianglePaintPatch >> addToCairoMeshGradientPaint: meshGradientPaint [
+
 	meshGradientPaint
 		beginPatch;
-		moveTo: controlPoints first;
-		lineTo: controlPoints second;
-		lineTo: controlPoints third;
-		setCorner: 0 color: colors first;
-		setCorner: 1 color: colors second;
-		setCorner: 2 color: colors third;
+		moveTo: self controlPoints first;
+		lineTo: self controlPoints second;
+		lineTo: self controlPoints third;
+		setCorner: 0 color: self colors first;
+		setCorner: 1 color: self colors second;
+		setCorner: 2 color: self colors third;
 		endPatch
 ]

--- a/src/Athens-Core/AthensCanvas.class.st
+++ b/src/Athens-Core/AthensCanvas.class.st
@@ -169,6 +169,11 @@ AthensCanvas >> pathTransform [
 	^ surface pathTransform
 ]
 
+{ #category : 'accessing' }
+AthensCanvas >> privatePaint: anObject [
+	paint := anObject
+]
+
 { #category : 'drawing text' }
 AthensCanvas >> setFont: aFont [
 	"Set the current font of receiver. Font object should answer a glyph renderer instance,

--- a/src/Athens-Morphic/AthensCairoCanvas.extension.st
+++ b/src/Athens-Morphic/AthensCairoCanvas.extension.st
@@ -2,18 +2,16 @@ Extension { #name : 'AthensCairoCanvas' }
 
 { #category : '*Athens-Morphic' }
 AthensCairoCanvas >> transformBy: aDisplayTransform withClip: aClipRectangle in: aSubRectangle during: aDrawBlock [
-	self
-		clipBy: currentClipRect
-		during: [
+
+	self clipBy: self currentClipRect during: [
 			| subClip oldClip |
 			subClip := aDisplayTransform globalBoundsToLocal: aClipRectangle.
-			oldClip := currentClipRect.
-			currentClipRect := aDisplayTransform globalBoundsToLocal: self clipRect.
-			pathTransform
-				restoreAfter: [
-					pathTransform translateBy: aDisplayTransform offset negated.
-					pathTransform rotateByRadians: aDisplayTransform angle negated.
-					pathTransform scaleBy: aDisplayTransform scale.
+			oldClip := self currentClipRect.
+			self currentClipRect: (aDisplayTransform globalBoundsToLocal: self clipRect).
+			self pathTransform restoreAfter: [
+					self pathTransform translateBy: aDisplayTransform offset negated.
+					self pathTransform rotateByRadians: aDisplayTransform angle negated.
+					self pathTransform scaleBy: aDisplayTransform scale.
 					self clipBy: subClip during: [ aDrawBlock value: self ] ].
-			currentClipRect := oldClip ]
+			self currentClipRect: oldClip ]
 ]

--- a/src/Athens-Morphic/LazyListMorph.extension.st
+++ b/src/Athens-Morphic/LazyListMorph.extension.st
@@ -34,23 +34,23 @@ LazyListMorph >> athensDrawBackgroundForRow: row on: aCanvas color: aColor [
 { #category : '*Athens-Morphic' }
 LazyListMorph >> athensDrawBackgroundForSearchedRow: row on: aCanvas [
 
-	aCanvas setPaint: listSource secondarySelectionColor.
+	aCanvas setPaint: self listSource secondarySelectionColor.
 	aCanvas drawShape: (self selectionFrameForRow: row)
 ]
 
 { #category : '*Athens-Morphic' }
 LazyListMorph >> athensDrawBackgroundForSelectedRow: row on: aCanvas [
 
-	aCanvas setPaint: listSource selectionColorToUse.
+	aCanvas setPaint: self listSource selectionColorToUse.
 	aCanvas drawShape: (self selectionFrameForRow: row)
 ]
 
 { #category : '*Athens-Morphic' }
 LazyListMorph >> athensDrawSelectionOn: anAthensCanvas [
 
-	selectedRow ifNil: [ ^self ].
-	selectedRow = 0 ifTrue: [ ^self ].
-	self athensDrawBackgroundForSelectedRow: selectedRow on: anAthensCanvas
+	self selectedRow ifNil: [ ^ self ].
+	self selectedRow = 0 ifTrue: [ ^ self ].
+	self athensDrawBackgroundForSelectedRow: self selectedRow on: anAthensCanvas
 ]
 
 { #category : '*Athens-Morphic' }

--- a/src/Athens-Morphic/LazyMorphListMorph.extension.st
+++ b/src/Athens-Morphic/LazyMorphListMorph.extension.st
@@ -16,13 +16,14 @@ LazyMorphListMorph >> athensDisplay: item atRow: row on: aCanvas [
 LazyMorphListMorph >> drawSubmorphsOnAthensCanvas: anAthensCanvas [
 	"Display submorphs back to front"
 
-	| drawBlock|
-	submorphs isEmpty ifTrue: [^self].
-	drawBlock := [:canvas | | i |
-		(self topVisibleRowForCanvas: anAthensCanvas) to: (self bottomVisibleRowForCanvas: anAthensCanvas) do: [ :row |
-			i := self item: row.
-			canvas fullDrawMorph: i]].
+	| drawBlock |
+	self submorphs isEmpty ifTrue: [ ^ self ].
+	drawBlock := [ :canvas |
+		             | i |
+		             (self topVisibleRowForCanvas: anAthensCanvas) to: (self bottomVisibleRowForCanvas: anAthensCanvas) do: [ :row |
+				             i := self item: row.
+				             canvas fullDrawMorph: i ] ].
 	self clipSubmorphs
-		ifTrue: [anAthensCanvas clipBy: (anAthensCanvas clipRect intersect: self clippingBounds ifNone: [ ^ self ]) during: drawBlock]
-		ifFalse: [drawBlock value: anAthensCanvas]
+		ifTrue: [ anAthensCanvas clipBy: (anAthensCanvas clipRect intersect: self clippingBounds ifNone: [ ^ self ]) during: drawBlock ]
+		ifFalse: [ drawBlock value: anAthensCanvas ]
 ]

--- a/src/Athens-Morphic/MenuItemMorph.extension.st
+++ b/src/Athens-Morphic/MenuItemMorph.extension.st
@@ -2,8 +2,8 @@ Extension { #name : 'MenuItemMorph' }
 
 { #category : '*Athens-Morphic' }
 MenuItemMorph >> drawBackgroundOnAthensCanvas: anAthensCanvas [
-	(isSelected and: [ isEnabled ])
-		ifFalse: [ ^ self ].
+
+	(self isSelected and: [ self isEnabled ]) ifFalse: [ ^ self ].
 	anAthensCanvas setPaint: self selectionFillStyle.
 	anAthensCanvas drawShape: (0 @ 0 extent: self extent)
 ]
@@ -27,11 +27,12 @@ MenuItemMorph >> drawIconOnAthensCanvas: anAthensCanvas [
 
 { #category : '*Athens-Morphic' }
 MenuItemMorph >> drawLabelOnAthensCanvas: anAthensCanvas [
+
 	anAthensCanvas pathTransform translateX: 0 Y: self fontToUse getPreciseAscent.
-			anAthensCanvas
-				setPaint: self color;
-				setFont: self fontToUse;
-				drawString: contents
+	anAthensCanvas
+		setPaint: self color;
+		setFont: self fontToUse;
+		drawString: self contents
 ]
 
 { #category : '*Athens-Morphic' }

--- a/src/Athens-Morphic/Morph.extension.st
+++ b/src/Athens-Morphic/Morph.extension.st
@@ -48,9 +48,8 @@ Morph >> drawOnCanvasWrapperFor: anAthensCanvas [
 
 { #category : '*Athens-Morphic' }
 Morph >> drawSubmorphsOnAthensCanvas: anAthensCanvas [
-	self
-		drawClippedOnAthensCanvas: anAthensCanvas
-		during: [ submorphs reverseDo: [ :m | anAthensCanvas fullDrawMorph: m ] ]
+
+	self drawClippedOnAthensCanvas: anAthensCanvas during: [ self submorphs reverseDo: [ :m | anAthensCanvas fullDrawMorph: m ] ]
 ]
 
 { #category : '*Athens-Morphic' }

--- a/src/Athens-Morphic/MorphTreeTransformMorph.extension.st
+++ b/src/Athens-Morphic/MorphTreeTransformMorph.extension.st
@@ -2,6 +2,7 @@ Extension { #name : 'MorphTreeTransformMorph' }
 
 { #category : '*Athens-Morphic' }
 MorphTreeTransformMorph >> drawSubmorphsOnAthensCanvas: anAthensCanvas [
+
 	| clip |
 	clip := self clippingBounds intersect: anAthensCanvas clipRect.
 	anAthensCanvas
@@ -9,16 +10,15 @@ MorphTreeTransformMorph >> drawSubmorphsOnAthensCanvas: anAthensCanvas [
 		withClip: clip
 		in: self innerBounds
 		during: [ :canvas |
-			| top bottom |
-			top := self topVisibleRowForCanvas: canvas.
-			bottom := self bottomVisibleRowForCanvas: canvas startingAt: top.
-			bottom to: top by: -1 do: [ :row |
-				| m |
-				m := submorphs basicAt: row.
-				self drawRawColorOn: anAthensCanvas asCanvasWrapper forSubmorph: m.
-				canvas fullDrawMorph: m ] ].
-	owner withTreeLines
-		ifTrue: [ owner drawLinesOn: anAthensCanvas asCanvasWrapper ].
-	owner enabled
-		ifFalse: [ anAthensCanvas asCanvasWrapper fillRectangle: owner innerBounds fillStyle: (owner paneColor alpha: 0.2) ]
+				| top bottom |
+				top := self topVisibleRowForCanvas: canvas.
+				bottom := self bottomVisibleRowForCanvas: canvas startingAt: top.
+				bottom to: top by: -1 do: [ :row |
+						| m |
+						m := self submorphs basicAt: row.
+						self drawRawColorOn: anAthensCanvas asCanvasWrapper forSubmorph: m.
+						canvas fullDrawMorph: m ] ].
+	self owner withTreeLines ifTrue: [ self owner drawLinesOn: anAthensCanvas asCanvasWrapper ].
+	self owner enabled ifFalse: [
+		anAthensCanvas asCanvasWrapper fillRectangle: self owner innerBounds fillStyle: (self owner paneColor alpha: 0.2) ]
 ]

--- a/src/Athens-Morphic/Paragraph.extension.st
+++ b/src/Athens-Morphic/Paragraph.extension.st
@@ -2,84 +2,80 @@ Extension { #name : 'Paragraph' }
 
 { #category : '*Athens-Morphic' }
 Paragraph >> displayCaretAndSelectionOnAthensCanvas: anAthensCanvas [
-	selectionStart ifNil: [ ^ self ].
-	selectionStart = selectionStop
+
+	self selectionStart ifNil: [ ^ self ].
+	self selectionStart = self selectionStop
 		ifTrue: [ self drawCaretOnAthensCanvas: anAthensCanvas ]
 		ifFalse: [
-			| selection |
-			caretRect := nil.
-			selection := ParagraphSelectionBlock first: selectionStart last: selectionStop color: self selectionColor.
-			self forLinesIn: anAthensCanvas clipRect do: [ :line | selection displayInLine: line onAthensCanvas: anAthensCanvas ] ]
+				| selection |
+				self caretRect: nil.
+				selection := ParagraphSelectionBlock first: self selectionStart last: self selectionStop color: self selectionColor.
+				self forLinesIn: anAthensCanvas clipRect do: [ :line | selection displayInLine: line onAthensCanvas: anAthensCanvas ] ]
 ]
 
 { #category : '*Athens-Morphic' }
 Paragraph >> displayExtraSelectionOnAthensCanvas: anAthensCanvas [
 	| visibleRectangle |
 	visibleRectangle := anAthensCanvas clipRect.
-	refreshExtraSelection = true
+	self refreshExtraSelection = true
 		ifTrue: [ self buildSelectionBlocksFrom: visibleRectangle topLeft to: visibleRectangle bottomRight.
-			refreshExtraSelection := false ].
+			self refreshExtraSelection: false ].
 
-	extraSelectionBlocks
+	self extraSelectionBlocks
 		ifNotNil: [
 			self forLinesIn: visibleRectangle	do: [ :line |
-					extraSelectionBlocks
+					self extraSelectionBlocks
 						do: [ :selblock | self displaySelectionBlock: selblock inLine: line onAthensCanvas: anAthensCanvas ] ] ]
 ]
 
 { #category : '*Athens-Morphic' }
 Paragraph >> displaySelectionBarOnAthensCanvas: anAthensCanvas [
+
 	| visibleRectangle line |
-	selectionStart ifNil: [ ^ self ].
-	selectionStop ifNil: [ ^ self ].
+	self selectionStart ifNil: [ ^ self ].
+	self selectionStop ifNil: [ ^ self ].
 	visibleRectangle := anAthensCanvas clipRect.
-	selectionStart textLine = selectionStop textLine
-		ifFalse: [ ^ self ].
-	line := selectionStart textLine.
+	self selectionStart textLine = self selectionStop textLine ifFalse: [ ^ self ].
+	line := self selectionStart textLine.
 	anAthensCanvas setPaint: self selectionBarColor.
 	anAthensCanvas drawShape: (visibleRectangle left @ line top corner: visibleRectangle right @ line bottom)
 ]
 
 { #category : '*Athens-Morphic' }
 Paragraph >> displaySelectionBlock: aSelBlock inLine: line onAthensCanvas: anAthensCanvas [
-	(selectionStart isNotNil and: [ selectionStop isNotNil and: [ selectionStart ~= selectionStop ] ])
-		ifTrue: [
+
+	(self selectionStart isNotNil and: [ self selectionStop isNotNil and: [ self selectionStart ~= self selectionStop ] ]) ifTrue: [
 			| startIdx stopIdx selSartIdx selStopIdx selBlockRange selRange |
 			startIdx := aSelBlock first stringIndex.
 			stopIdx := aSelBlock last stringIndex.
-			selSartIdx := selectionStart stringIndex.
-			selStopIdx := selectionStop stringIndex.
+			selSartIdx := self selectionStart stringIndex.
+			selStopIdx := self selectionStop stringIndex.
 			selBlockRange := startIdx to: stopIdx.
 			selRange := selSartIdx to: selStopIdx.
-			((selBlockRange rangeIncludes: selSartIdx + 1)
-				or: [
-					(selBlockRange rangeIncludes: selStopIdx - 1)
-						or: [ (selRange rangeIncludes: startIdx + 1) or: [ selRange rangeIncludes: stopIdx - 1 ] ] ])
-				ifTrue: [ ^ self ] ].	"regular selection and this selection block overlap"
+			((selBlockRange rangeIncludes: selSartIdx + 1) or: [
+					 (selBlockRange rangeIncludes: selStopIdx - 1) or: [
+						 (selRange rangeIncludes: startIdx + 1) or: [ selRange rangeIncludes: stopIdx - 1 ] ] ]) ifTrue: [ ^ self ] ]. "regular selection and this selection block overlap"
 	aSelBlock displayInLine: line onAthensCanvas: anAthensCanvas
 ]
 
 { #category : '*Athens-Morphic' }
 Paragraph >> displayTextOnAthensCanvas: anAthensCanvas in: aRectangle [
+
 	| athensDisplayScanner offset leftInRun |
-	anAthensCanvas clipBy: aRectangle during:[
-	anAthensCanvas pathTransform
-		restoreAfter: [
-			offset := aRectangle topLeft - positionWhenComposed.
-			athensDisplayScanner := AthensDisplayScanner for: self on: anAthensCanvas.
-			leftInRun := 0.
-			self
-				forLinesIn: anAthensCanvas clipRect
-				do: [ :line |
-					line first <= line last
-						ifTrue: [ leftInRun := athensDisplayScanner displayLine: line offset: offset leftInRun: leftInRun ] ] ] ]
+	anAthensCanvas clipBy: aRectangle during: [
+			anAthensCanvas pathTransform restoreAfter: [
+					offset := aRectangle topLeft - self positionWhenComposed.
+					athensDisplayScanner := AthensDisplayScanner for: self on: anAthensCanvas.
+					leftInRun := 0.
+					self forLinesIn: anAthensCanvas clipRect do: [ :line |
+						line first <= line last ifTrue: [ leftInRun := athensDisplayScanner displayLine: line offset: offset leftInRun: leftInRun ] ] ] ]
 ]
 
 { #category : '*Athens-Morphic' }
 Paragraph >> drawCaretOnAthensCanvas: anAthensCanvas [
-	(self showCaret not or: [ selectionStart isNil ])
-		ifTrue: [ ^ self ].
-	caretRect := selectionStart topLeft asIntegerPoint extent: 1 @ selectionStart height.
+
+	(self showCaret not or: [ self selectionStart isNil ]) ifTrue: [ ^ self ].
+	self caretRect: (self selectionStart topLeft asIntegerPoint extent: 1 @ self selectionStart height).
 	anAthensCanvas setPaint: self insertionPointColor.
 	anAthensCanvas drawShape: self caretRect
 ]
@@ -99,7 +95,7 @@ Paragraph >> drawOnAthensCanvas: anAthensCanvas bounds: aRectangle color: aColor
 
 { #category : '*Athens-Morphic' }
 Paragraph >> forLinesIn: aVisibleRect do: aBlock [
-	(self lineIndexForPoint: aVisibleRect topLeft) to:
-	(self lineIndexForPoint: aVisibleRect bottomRight) do:
-		[:i | aBlock value: (lines at: i) ]
+
+	(self lineIndexForPoint: aVisibleRect topLeft) to: (self lineIndexForPoint: aVisibleRect bottomRight) do: [ :i |
+	aBlock value: (self basicLines at: i) ]
 ]

--- a/src/Athens-Morphic/ParagraphSelectionBlock.extension.st
+++ b/src/Athens-Morphic/ParagraphSelectionBlock.extension.st
@@ -5,20 +5,17 @@ ParagraphSelectionBlock >> displayInLine: line onAthensCanvas: anAthensCanvas [
 	"Display myself in the passed line."
 
 	| startIdx stopIdx leftX rightX |
-	startIdx := first stringIndex.
-	stopIdx := last stringIndex.
-	(stopIdx < line first or: [ startIdx > (line last + 1) ])
-		ifTrue: [ ^ self ].	"No selection on this line"
-	(stopIdx = line first and: [ last textLine ~= line ])
-		ifTrue: [ ^ self ].	"Selection ends on line above"
-	(startIdx = (line last + 1) and: [ last textLine ~= line ])
-		ifTrue: [ ^ self ].	"Selection begins on line below"
+	startIdx := self first stringIndex.
+	stopIdx := self last stringIndex.
+	(stopIdx < line first or: [ startIdx > (line last + 1) ]) ifTrue: [ ^ self ]. "No selection on this line"
+	(stopIdx = line first and: [ self last textLine ~= line ]) ifTrue: [ ^ self ]. "Selection ends on line above"
+	(startIdx = (line last + 1) and: [ self last textLine ~= line ]) ifTrue: [ ^ self ]. "Selection begins on line below"
 	leftX := (startIdx < line first
-		ifTrue: [ line ]
-		ifFalse: [ first ]) left.
-	rightX := (stopIdx > (line last + 1) or: [ stopIdx = (line last + 1) and: [ last textLine ~= line ] ])
-		ifTrue: [ line right ]
-		ifFalse: [ last left ].
-	anAthensCanvas setPaint: color.
+		          ifTrue: [ line ]
+		          ifFalse: [ self first ]) left.
+	rightX := (stopIdx > (line last + 1) or: [ stopIdx = (line last + 1) and: [ self last textLine ~= line ] ])
+		          ifTrue: [ line right ]
+		          ifFalse: [ self last left ].
+	anAthensCanvas setPaint: self color.
 	anAthensCanvas drawShape: (leftX @ line top corner: rightX @ line bottom)
 ]

--- a/src/Athens-Morphic/PolygonMorph.extension.st
+++ b/src/Athens-Morphic/PolygonMorph.extension.st
@@ -5,18 +5,15 @@ PolygonMorph >> adjustSegmentPointsForArrows [
 	" In the list of vertices, adjust first and last entry if this polygon uses arrows."
 
 	| verts |
-	(self isClosed or: [ self hasArrows not ])
-		ifTrue: [ ^ self vertices ].
+	(self isClosed or: [ self hasArrows not ]) ifTrue: [ ^ self vertices ].
 	verts := self vertices copy.
-	(arrows == #back or: [ arrows == #both ])
-		ifTrue: [
+	(self arrows == #back or: [ self arrows == #both ]) ifTrue: [
 			| arrow |
 			arrow := self arrowBoundsAt: verts first from: verts second.
 			arrow size = 4
 				ifTrue: [ verts at: 1 put: arrow third ]
 				ifFalse: [ verts at: 1 put: (arrow copyFrom: 2 to: 3) average ] ].
-	(arrows == #forward or: [ arrows == #both ])
-		ifTrue: [
+	(self arrows == #forward or: [ self arrows == #both ]) ifTrue: [
 			| arrow |
 			arrow := self arrowBoundsAt: verts last from: verts nextToLast.
 			arrow size = 4
@@ -141,21 +138,17 @@ PolygonMorph >> drawArrowOnAthensCanvas: anAthensCanvas at: endPoint from: prior
 	| pts spec wingBase path |
 	pts := self arrowBoundsAt: endPoint from: priorPoint.
 	wingBase := pts size = 4
-		ifTrue: [ pts third ]
-		ifFalse: [ (pts copyFrom: 2 to: 3) average ].
+		            ifTrue: [ pts third ]
+		            ifFalse: [ (pts copyFrom: 2 to: 3) average ].
 	spec := self valueOfProperty: #arrowSpec ifAbsent: [ PolygonMorph defaultArrowSpec ].
-	path := anAthensCanvas
-		createPath: [ :builder |
-			builder absolute.
-			builder moveTo: pts first.
-			pts allButFirst do: [ :p | builder lineTo: p ]. builder close. ].
+	path := anAthensCanvas createPath: [ :builder |
+			        builder absolute.
+			        builder moveTo: pts first.
+			        pts allButFirst do: [ :p | builder lineTo: p ].
+			        builder close ].
 	spec x sign = spec y sign
-		ifTrue: [
-			anAthensCanvas setPaint: self borderColor]
-		ifFalse: [
-			(anAthensCanvas
-				setStrokePaint: self borderColor)
-				width: (borderWidth + 1) // 2].
+		ifTrue: [ anAthensCanvas setPaint: self borderColor ]
+		ifFalse: [ (anAthensCanvas setStrokePaint: self borderColor) width: self borderWidth + 1 // 2 ].
 	anAthensCanvas drawShape: path.
 	^ wingBase
 ]
@@ -163,32 +156,25 @@ PolygonMorph >> drawArrowOnAthensCanvas: anAthensCanvas at: endPoint from: prior
 { #category : '*Athens-Morphic' }
 PolygonMorph >> drawArrowsOnAthensCanvas: aAthensCanvas [
 	"Answer (possibly modified) endpoints for border drawing"
-	"ArrowForms are computed only upon demand"
-	| array |
 
-	self hasArrows
-		ifFalse: [^ #() ].
+	"ArrowForms are computed only upon demand"
+
+	| array |
+	self hasArrows ifFalse: [ ^ #(  ) ].
 	"Nothing to do"
 
-	array := Array with: vertices first with: vertices last.
+	array := Array with: self vertices first with: self vertices last.
 
 	"Prevent crashes for #raised or #inset borders"
-	borderColor isColor
-		ifFalse: [ ^array ].
+	self borderColor isColor ifFalse: [ ^ array ].
 
-	(arrows == #forward or: [arrows == #both])
-		ifTrue: [ array at: 2 put: (self
-				drawArrowOnAthensCanvas: aAthensCanvas
-				at: vertices last
-				from: self nextToLastPoint) ].
+	(self arrows == #forward or: [ self arrows == #both ]) ifTrue: [
+		array at: 2 put: (self drawArrowOnAthensCanvas: aAthensCanvas at: self vertices last from: self nextToLastPoint) ].
 
-	(arrows == #back or: [arrows == #both])
-		ifTrue: [ array at: 1 put: (self
-				drawArrowOnAthensCanvas: aAthensCanvas
-				at: vertices first
-				from: self nextToFirstPoint) ].
+	(self arrows == #back or: [ self arrows == #both ]) ifTrue: [
+		array at: 1 put: (self drawArrowOnAthensCanvas: aAthensCanvas at: self vertices first from: self nextToFirstPoint) ].
 
-	^array
+	^ array
 ]
 
 { #category : '*Athens-Morphic' }

--- a/src/Athens-Morphic/RubAbstractTextArea.extension.st
+++ b/src/Athens-Morphic/RubAbstractTextArea.extension.st
@@ -7,6 +7,6 @@ RubAbstractTextArea >> drawSubmorphsOnAthensCanvas: aCanvas [
 
 	super drawSubmorphsOnAthensCanvas: aCanvas.
 	self paragraph drawOnAthensCanvas: aCanvas bounds: self drawingBounds color: self textColor.
-	(scrollPane isNil and: [ self readOnly not and: [ self hasKeyboardFocus or: [ self hasFindReplaceFocus ] ] ])
-		ifTrue: [  self drawKeyboardFocusOnAthensCanvas: aCanvas ]
+	(self scrollPane isNil and: [ self readOnly not and: [ self hasKeyboardFocus or: [ self hasFindReplaceFocus ] ] ]) ifTrue: [
+		self drawKeyboardFocusOnAthensCanvas: aCanvas ]
 ]

--- a/src/Athens-Morphic/RubParagraphDecorator.extension.st
+++ b/src/Athens-Morphic/RubParagraphDecorator.extension.st
@@ -3,8 +3,8 @@ Extension { #name : 'RubParagraphDecorator' }
 { #category : '*Athens-Morphic' }
 RubParagraphDecorator >> drawOnAthensCanvas: aCanvas bounds: aRectangle color: aColor [
 
-   (self canDrawDecoratorsOn: aCanvas) ifFalse: [ ^self ].
+	(self canDrawDecoratorsOn: aCanvas) ifFalse: [ ^ self ].
 
 	self drawOnAthensCanvas: aCanvas.
-	next drawOnAthensCanvas: aCanvas bounds: aRectangle color: aColor
+	self next drawOnAthensCanvas: aCanvas bounds: aRectangle color: aColor
 ]

--- a/src/Athens-Morphic/TransformMorph.extension.st
+++ b/src/Athens-Morphic/TransformMorph.extension.st
@@ -13,11 +13,12 @@ TransformMorph >> clipDuring: aBlock canvas: aCanvas [
 
 { #category : '*Athens-Morphic' }
 TransformMorph >> drawSubmorphsOnAthensCanvas: anAthensCanvas [
+
 	| clip |
 	clip := self clippingBounds intersect: anAthensCanvas clipRect.
 	anAthensCanvas
 		transformBy: self transform
 		withClip: clip
 		in: self innerBounds
-		during: [ :c | submorphs do: [ :m | m fullDrawOnAthensCanvas: c ] ]
+		during: [ :c | self submorphs do: [ :m | m fullDrawOnAthensCanvas: c ] ]
 ]

--- a/src/Calypso-Browser/CmdCommandActivator.extension.st
+++ b/src/Calypso-Browser/CmdCommandActivator.extension.st
@@ -3,27 +3,27 @@ Extension { #name : 'CmdCommandActivator' }
 { #category : '*Calypso-Browser' }
 CmdCommandActivator >> buildBrowserNotebookActions [
 
-	self canExecuteCommand ifFalse: [ ^ #() ].
+	self canExecuteCommand ifFalse: [ ^ #(  ) ].
 
-	^ command buildBrowserNotebookActionsUsing: self
+	^ self command buildBrowserNotebookActionsUsing: self
 ]
 
 { #category : '*Calypso-Browser' }
 CmdCommandActivator >> buildBrowserToolbar: toolbarMorph [
 
-	self canExecuteCommand ifFalse: [ ^self ].
+	self canExecuteCommand ifFalse: [ ^ self ].
 
-	command addToolbarItemInto: toolbarMorph using: self
+	self command addToolbarItemInto: toolbarMorph using: self
 ]
 
 { #category : '*Calypso-Browser' }
 CmdCommandActivator >> decorateTableCell: anItemCellMorph [
 
-	command decorateTableCell: anItemCellMorph using: self
+	self command decorateTableCell: anItemCellMorph using: self
 ]
 
 { #category : '*Calypso-Browser' }
 CmdCommandActivator >> isCommandAppliedToBrowser [
 
-	^command isAppliedToBrowser
+	^ self command isAppliedToBrowser
 ]

--- a/src/Calypso-Browser/CmdCommandMenuItem.extension.st
+++ b/src/Calypso-Browser/CmdCommandMenuItem.extension.st
@@ -3,11 +3,11 @@ Extension { #name : 'CmdCommandMenuItem' }
 { #category : '*Calypso-Browser' }
 CmdCommandMenuItem >> buildBrowserNotebookActions [
 
-	^ activator buildBrowserNotebookActions
+	^ self activator buildBrowserNotebookActions
 ]
 
 { #category : '*Calypso-Browser' }
 CmdCommandMenuItem >> buildBrowserToolbar: toolbarMorph [
 
-	activator buildBrowserToolbar: toolbarMorph
+	self activator buildBrowserToolbar: toolbarMorph
 ]

--- a/src/Calypso-Browser/CmdMenu.extension.st
+++ b/src/Calypso-Browser/CmdMenu.extension.st
@@ -3,11 +3,11 @@ Extension { #name : 'CmdMenu' }
 { #category : '*Calypso-Browser' }
 CmdMenu >> buildBrowserNotebookActions [
 
-	^ rootGroup buildBrowserNotebookActions
+	^ self rootGroup buildBrowserNotebookActions
 ]
 
 { #category : '*Calypso-Browser' }
 CmdMenu >> buildBrowserToolbar: aToolbar [
 
-	rootGroup buildBrowserToolbar: aToolbar
+	self rootGroup buildBrowserToolbar: aToolbar
 ]

--- a/src/Calypso-Browser/CmdMenuGroup.extension.st
+++ b/src/Calypso-Browser/CmdMenuGroup.extension.st
@@ -3,16 +3,15 @@ Extension { #name : 'CmdMenuGroup' }
 { #category : '*Calypso-Browser' }
 CmdMenuGroup >> buildBrowserNotebookActions [
 
-	self isActive ifFalse: [ ^#()] .
+	self isActive ifFalse: [ ^ #(  ) ].
 
-	^contents flatCollect: [ :each | each buildBrowserNotebookActions ]
+	^ self contents flatCollect: [ :each | each buildBrowserNotebookActions ]
 ]
 
 { #category : '*Calypso-Browser' }
 CmdMenuGroup >> buildBrowserToolbar: toolbarMorph [
 
-	self isActive ifFalse: [ ^self].
-	toolbarMorph submorphs ifNotEmpty: [
-		toolbarMorph addNewItem: ClyToolbarSeparatorMorph new].
-	contents do: [ :each | each buildBrowserToolbar: toolbarMorph ]
+	self isActive ifFalse: [ ^ self ].
+	toolbarMorph submorphs ifNotEmpty: [ toolbarMorph addNewItem: ClyToolbarSeparatorMorph new ].
+	self contents do: [ :each | each buildBrowserToolbar: toolbarMorph ]
 ]

--- a/src/Calypso-Browser/FTFilterFunction.extension.st
+++ b/src/Calypso-Browser/FTFilterFunction.extension.st
@@ -1,34 +1,16 @@
 Extension { #name : 'FTFilterFunction' }
 
 { #category : '*Calypso-Browser' }
-FTFilterFunction >> field [
-	^field
-]
-
-{ #category : '*Calypso-Browser' }
 FTFilterFunction >> filterNowWith: patternString [
-	pattern := patternString.
-	self field setText: pattern.
-	self filterWith: pattern.
+
+	self pattern: patternString.
+	self field setText: self pattern.
+	self filterWith: self pattern.
 	self filter
 ]
 
 { #category : '*Calypso-Browser' }
-FTFilterFunction >> initialDataSource [
-	^initialDataSource
-]
-
-{ #category : '*Calypso-Browser' }
-FTFilterFunction >> initialDataSource: aDataSource [
-	initialDataSource := aDataSource
-]
-
-{ #category : '*Calypso-Browser' }
-FTFilterFunction >> pattern [
-	^pattern
-]
-
-{ #category : '*Calypso-Browser' }
 FTFilterFunction >> terminateFilterProcess [
-	isEditingSemaphore ifNotNil: [ isEditingSemaphore terminateProcess ]
+
+	self isEditingSemaphore ifNotNil: [ self isEditingSemaphore terminateProcess ]
 ]

--- a/src/Calypso-Browser/FTTableMorph.extension.st
+++ b/src/Calypso-Browser/FTTableMorph.extension.st
@@ -10,8 +10,8 @@ FTTableMorph >> activateFilterWith: patternString [
 { #category : '*Calypso-Browser' }
 FTTableMorph >> cleanupFilter [
 	"it is ugly. but now it is easy to do like this. Normally it should be somehow supported by table package itself"
-	(function isKindOf: FTFilterFunction)
-		ifTrue: [ function terminateFilterProcess]
+
+	(self function isKindOf: FTFilterFunction) ifTrue: [ self function terminateFilterProcess ]
 ]
 
 { #category : '*Calypso-Browser' }
@@ -30,21 +30,23 @@ FTTableMorph >> filterFieldHasKeyboardFocus [
 
 { #category : '*Calypso-Browser' }
 FTTableMorph >> filterString [
-	(function isKindOf: FTFilterFunction) ifFalse: [ ^'' ].
-	^function pattern ifNil: [ '' ]
+
+	(self function isKindOf: FTFilterFunction) ifFalse: [ ^ '' ].
+	^ self function pattern ifNil: [ '' ]
 ]
 
 { #category : '*Calypso-Browser' }
 FTTableMorph >> initialDataSource [
 	"it is ugly. but now it is easy to do like this. Normally it should be somehow supported by table package itself"
-	^(function isKindOf: FTFilterFunction)
-		ifTrue: [ function initialDataSource]
-		ifFalse: [ nil ]
+
+	^ (self function isKindOf: FTFilterFunction)
+		  ifTrue: [ self function initialDataSource ]
+		  ifFalse: [ nil ]
 ]
 
 { #category : '*Calypso-Browser' }
 FTTableMorph >> initialDataSource: aDataSource [
 	"it is ugly. but now it is easy to do like this. Normally it should be somehow supported by table package itself"
-	(function isKindOf: FTFilterFunction)
-		ifTrue: [ function initialDataSource: aDataSource]
+
+	(self function isKindOf: FTFilterFunction) ifTrue: [ self function initialDataSource: aDataSource ]
 ]

--- a/src/Calypso-NavigationModel-Tests/ClyAbstractNavigationEnvironmentTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyAbstractNavigationEnvironmentTest.class.st
@@ -14,6 +14,12 @@ ClyAbstractNavigationEnvironmentTest class >> isAbstract [
 ]
 
 { #category : 'running' }
+ClyAbstractNavigationEnvironmentTest >> environment [
+
+	^ environment
+]
+
+{ #category : 'running' }
 ClyAbstractNavigationEnvironmentTest >> setUp [
 	super setUp.
 	self setUpEnvironment

--- a/src/Calypso-NavigationModel-Tests/ClyQueryTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyQueryTest.class.st
@@ -28,6 +28,42 @@ ClyQueryTest >> executeQuery [
 ]
 
 { #category : 'running' }
+ClyQueryTest >> query [
+
+	^ query
+]
+
+{ #category : 'accessing' }
+ClyQueryTest >> query: anObject [
+
+	query := anObject
+]
+
+{ #category : 'accessing' }
+ClyQueryTest >> result [
+
+	^ result
+]
+
+{ #category : 'accessing' }
+ClyQueryTest >> result: anObject [
+
+	result := anObject
+]
+
+{ #category : 'accessing' }
+ClyQueryTest >> resultItems [
+
+	^ resultItems
+]
+
+{ #category : 'accessing' }
+ClyQueryTest >> resultItems: anObject [
+
+	resultItems := anObject
+]
+
+{ #category : 'running' }
 ClyQueryTest >> setUp [
 	super setUp.
 

--- a/src/Calypso-NavigationModel-Tests/ClyScopeTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyScopeTest.class.st
@@ -19,6 +19,18 @@ ClyScopeTest >> createSampleScope [
 	self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+ClyScopeTest >> scope [
+
+	^ scope
+]
+
+{ #category : 'accessing' }
+ClyScopeTest >> scope: anObject [
+
+	scope := anObject
+]
+
 { #category : 'running' }
 ClyScopeTest >> setUp [
 	super setUp.

--- a/src/Calypso-NavigationModel/Mutex.extension.st
+++ b/src/Calypso-NavigationModel/Mutex.extension.st
@@ -5,8 +5,10 @@ Mutex >> tryEnterCritical: criticalBlock ifLocked: lockedBlock [
 
 	| activeProcess |
 	activeProcess := Processor activeProcess.
-	activeProcess == owner ifTrue:[^criticalBlock value].
-	^semaphore critical:[
-		owner := activeProcess.
-		criticalBlock ensure:[owner := nil]] ifLocked: lockedBlock
+	activeProcess == self owner ifTrue: [ ^ criticalBlock value ].
+	^ self semaphore
+		  critical: [
+				  self owner: activeProcess.
+				  criticalBlock ensure: [ self owner: nil ] ]
+		  ifLocked: lockedBlock
 ]

--- a/src/Calypso-NavigationModel/WeakValueDictionary.extension.st
+++ b/src/Calypso-NavigationModel/WeakValueDictionary.extension.st
@@ -18,5 +18,5 @@ WeakValueDictionary >> clyCleanGarbage [
 WeakValueDictionary >> clyIncludesCleanedKey: key [
 	"Answer whether the receiver has a key which value was collected as garbage"
 
-	^ (array at: (self scanFor: key)) value == nil
+	^ (self array at: (self scanFor: key)) value == nil
 ]

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyClassCreationToolMorph.extension.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyClassCreationToolMorph.extension.st
@@ -3,7 +3,7 @@ Extension { #name : 'ClyClassCreationToolMorph' }
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
 ClyClassCreationToolMorph >> criticAnalysisScope [
 
-	^ClyPackageScope of: package in: browser navigationEnvironment
+	^ ClyPackageScope of: self package in: self browser navigationEnvironment
 ]
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
@@ -13,5 +13,5 @@ ClyClassCreationToolMorph >> decorateByCritic: aCriticTool [
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
 ClyClassCreationToolMorph >> supportsCriticDecoration [
 
-	^ package isNotNil
+	^ self package isNotNil
 ]

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyClassDefinitionEditorToolMorph.extension.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyClassDefinitionEditorToolMorph.extension.st
@@ -2,7 +2,8 @@ Extension { #name : 'ClyClassDefinitionEditorToolMorph' }
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
 ClyClassDefinitionEditorToolMorph >> criticAnalysisScope [
-	^ ClyClassScope of: editingClass in: browser navigationEnvironment
+
+	^ ClyClassScope of: self editingClass in: self browser navigationEnvironment
 ]
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }

--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyMethodCodeEditorToolMorph.extension.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyMethodCodeEditorToolMorph.extension.st
@@ -2,17 +2,18 @@ Extension { #name : 'ClyMethodCodeEditorToolMorph' }
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
 ClyMethodCodeEditorToolMorph >> criticAnalysisScope [
-	^ ClyMethodScope of: editingMethod in: browser navigationEnvironment
+
+	^ ClyMethodScope of: self editingMethod in: self browser navigationEnvironment
 ]
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }
 ClyMethodCodeEditorToolMorph >> decorateByCritic: aCriticTool [
-	| segments |
-	(textMorph segments select: [ :each | each class = ClyCriticalTextSegmentMorph ])
-		do: [ :each | each delete ]. "We should not remove while iterating"
 
-	segments := aCriticTool buildCriticalTextSegmentsFor: editingMethod.
-	segments do: [ :each | textMorph addSegment: each]
+	| segments |
+	(self textMorph segments select: [ :each | each class = ClyCriticalTextSegmentMorph ]) do: [ :each | each delete ]. "We should not remove while iterating"
+
+	segments := aCriticTool buildCriticalTextSegmentsFor: self editingMethod.
+	segments do: [ :each | self textMorph addSegment: each ]
 ]
 
 { #category : '*Calypso-SystemPlugins-Critic-Browser' }

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyScope.extension.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyScope.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'ClyScope' }
 { #category : '*Calypso-SystemPlugins-InheritanceAnalysis-Queries' }
 ClyScope >> inheritanceAnalyzer [
 
-	^environment getPlugin: ClyInheritanceAnalysisEnvironmentPlugin
+	^ self environment getPlugin: ClyInheritanceAnalysisEnvironmentPlugin
 ]

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClySourceCodeContext.extension.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClySourceCodeContext.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'ClySourceCodeContext' }
 
 { #category : '*Calypso-SystemPlugins-Reflectivity-Browser' }
 ClySourceCodeContext >> isSelectedItemHasBreakpoint [
-	^selectedSourceNode hasBreakpoint
+
+	^ self selectedSourceNode hasBreakpoint
 ]

--- a/src/Calypso-SystemPlugins-Reflectivity-Browser/ClySystemBrowserContext.extension.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Browser/ClySystemBrowserContext.extension.st
@@ -2,6 +2,6 @@ Extension { #name : 'ClySystemBrowserContext' }
 
 { #category : '*Calypso-SystemPlugins-Reflectivity-Browser' }
 ClySystemBrowserContext >> isSelectedItemHasBreakpoint [
-	^selectedItems anySatisfy: [ :each |
-		each isMarkedWith: ClyMethodWithBreakpointTag ]
+
+	^ self selectedItems anySatisfy: [ :each | each isMarkedWith: ClyMethodWithBreakpointTag ]
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestedEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestedEnvironmentPlugin.class.st
@@ -97,7 +97,7 @@ ClyTestedEnvironmentPlugin >> normalizeSelectorForComparison: aString [
 	| selectorString selectorStringSize normalizedSelectorString normalizedSelectorStringSize |
 	"asString to convert Symbols"
 	selectorString := aString asString.
-	selectorStringSize := aString size.
+	selectorStringSize := selectorString size.
 	normalizedSelectorString := selectorString class new: selectorStringSize.
 	normalizedSelectorStringSize := 0.
 	"this inlined to:do: loop with direct string manipulation is faster than

--- a/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyExtendingPackagesQueryTest.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyExtendingPackagesQueryTest.extension.st
@@ -4,8 +4,8 @@ Extension { #name : 'ClyExtendingPackagesQueryTest' }
 ClyExtendingPackagesQueryTest >> testFromClassWhichTraitIsExtendedButNotItself [
 	"I'm tagging this expected failure because I'm not sure now if it is appropriate to keep
 	 or not with the removal of the 'traits-as-multiple-inheritance' stuff."
-	<expectedFailure>
 
+	<expectedFailure>
 	self queryFromScope: ClyClassScope of: ClyClassWithTraits.
-	self assert: resultItems size equals: 0
+	self assert: self resultItems size equals: 0
 ]

--- a/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyLocalClassScopeTest.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyLocalClassScopeTest.extension.st
@@ -2,20 +2,22 @@ Extension { #name : 'ClyLocalClassScopeTest' }
 
 { #category : '*Calypso-SystemPlugins-Traits-Queries-Tests' }
 ClyLocalClassScopeTest >> testConvertingToInheritedScopeShouldAddInheritedTraits [
-	| convertedScope |
-	scope := self createSampleScope.
 
-	convertedScope := scope asInheritedScope.
+	| convertedScope |
+	self scope: self createSampleScope.
+
+	convertedScope := self scope asInheritedScope.
 
 	self assert: (convertedScope representsScope: ClyInheritedTraitScope)
 ]
 
 { #category : '*Calypso-SystemPlugins-Traits-Queries-Tests' }
 ClyLocalClassScopeTest >> testConvertingToInheritingScopeShouldAddTraitUsers [
-	| convertedScope |
-	scope := self createSampleScope.
 
-	convertedScope := scope asInheritingScope.
+	| convertedScope |
+	self scope: self createSampleScope.
+
+	convertedScope := self scope asInheritingScope.
 
 	self assert: (convertedScope representsScope: ClyTraitUserScope)
 ]

--- a/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyMessageImplementorsQueryTest.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries-Tests/ClyMessageImplementorsQueryTest.extension.st
@@ -2,9 +2,9 @@ Extension { #name : 'ClyMessageImplementorsQueryTest' }
 
 { #category : '*Calypso-SystemPlugins-Traits-Queries-Tests' }
 ClyMessageImplementorsQueryTest >> testFromClassAndInheritedTrait [
-	query := ClyMessageImplementorsQuery of: #methodFromRoot1.
+	self query: (ClyMessageImplementorsQuery of: #methodFromRoot1).
 	self queryFromScope: ClyBothMetaLevelClassScope ofAll: {ClyClassWithTraits . ClyTraitRoot1}.
 
-	self assert: resultItems size equals: 1.
-	self assert: resultItems first identicalTo: ClyTraitRoot1 >> #methodFromRoot1
+	self assert: self resultItems size equals: 1.
+	self assert: self resultItems first identicalTo: ClyTraitRoot1 >> #methodFromRoot1
 ]

--- a/src/Calypso-SystemPlugins-Traits-Queries/ClySuperclassVisibilityLevel.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries/ClySuperclassVisibilityLevel.extension.st
@@ -2,9 +2,10 @@ Extension { #name : 'ClySuperclassVisibilityLevel' }
 
 { #category : '*Calypso-SystemPlugins-Traits-Queries' }
 ClySuperclassVisibilityLevel >> asTraitVisibility [
-	| traits |
-	traits := extraClassScope basisObjects select: [ :each | each isTrait ].
 
-	^(ClySingleTraitVisibilityLevel of: visibleClassScope)
-		extraClassScope: (visibleClassScope asScope: ClyClassScope ofAll: traits)
+	| traits |
+	traits := self extraClassScope basisObjects select: [ :each | each isTrait ].
+
+	^ (ClySingleTraitVisibilityLevel of: self visibleClassScope) extraClassScope:
+		  (self visibleClassScope asScope: ClyClassScope ofAll: traits)
 ]

--- a/src/Calypso-SystemQueries-Tests/ClyCompositeScopeTest.extension.st
+++ b/src/Calypso-SystemQueries-Tests/ClyCompositeScopeTest.extension.st
@@ -2,106 +2,102 @@ Extension { #name : 'ClyCompositeScopeTest' }
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToInheritedScope [
+
 	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClyInstanceSideScope of: Object in: environment.
-		ClyClassSideScope of: Array in: environment}.
+	self scope: (ClyCompositeScope on: {
+				 (ClyInstanceSideScope of: Object in: self environment).
+				 (ClyClassSideScope of: Array in: self environment) }).
 
-	convertedScope := scope asInheritedScope.
-
+	convertedScope := self scope asInheritedScope.
 	self assert: convertedScope class equals: ClyCompositeScope.
 	self assert: (convertedScope subscopes first representsScope: ClySuperclassScope).
 	self assert: (convertedScope subscopes last representsScope: ClySuperclassScope).
-	self
-		assert: (convertedScope subscopes collect: #localScopeClass as: Set)
-		equals: {ClyInstanceSideScope. ClyClassSideScope} asSet.
-	self assert: convertedScope environment equals: environment.
+	self assert: (convertedScope subscopes collect: #localScopeClass as: Set) equals: {
+			ClyInstanceSideScope.
+			ClyClassSideScope } asSet.
+	self assert: convertedScope environment equals: self environment.
 	self assert: convertedScope name equals: ClyClassScope inheritedScopeName
 ]
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToInheritingScope [
-	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClyInstanceSideScope of: Object in: environment.
-		ClyClassSideScope of: Array in: environment}.
 
-	convertedScope := scope asInheritingScope.
+	| convertedScope |
+	self scope: (ClyCompositeScope on: {
+				 (ClyInstanceSideScope of: Object in: self environment).
+				 (ClyClassSideScope of: Array in: self environment) }).
+
+	convertedScope := self scope asInheritingScope.
 
 	self assert: convertedScope class equals: ClyCompositeScope.
 	self assert: (convertedScope subscopes first representsScope: ClySubclassScope).
 	self assert: (convertedScope subscopes last representsScope: ClySubclassScope).
-	self
-		assert: (convertedScope subscopes collect: #localScopeClass as: Set)
-		equals: {ClyInstanceSideScope. ClyClassSideScope} asSet.
-	self assert: convertedScope environment equals: environment.
+	self assert: (convertedScope subscopes collect: #localScopeClass as: Set) equals: {
+			ClyInstanceSideScope.
+			ClyClassSideScope } asSet.
+	self assert: convertedScope environment equals: self environment.
 	self assert: convertedScope name equals: ClyClassScope inheritingScopeName
 ]
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToInterestingClassScope [
-	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClySuperclassScope of: String in: environment localScope: ClyInstanceSideScope.
-		ClySubclassScope of: Array in: environment localScope: ClyClassSideScope }.
 
-	convertedScope := scope asInterestingClassScope.
+	| convertedScope |
+	self scope: (ClyCompositeScope on: {
+				 (ClySuperclassScope of: String in: self environment localScope: ClyInstanceSideScope).
+				 (ClySubclassScope of: Array in: self environment localScope: ClyClassSideScope) }).
+
+	convertedScope := self scope asInterestingClassScope.
 
 	self assert: convertedScope class equals: ClyCompositeScope.
-	self
-		assert: convertedScope subscopes asSet
-		equals: {
-			ClyInterestingSuperclassScope of: String localScope: ClyInstanceSideScope.
-			ClySubclassScope of: Array localScope: ClyClassSideScope} asSet.
-	self assert: convertedScope environment equals: environment
+	self assert: convertedScope subscopes asSet equals: {
+			(ClyInterestingSuperclassScope of: String localScope: ClyInstanceSideScope).
+			(ClySubclassScope of: Array localScope: ClyClassSideScope) } asSet.
+	self assert: convertedScope environment equals: self environment
 ]
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToInterestingClassScopeShouldKeepScopeName [
-	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClySuperclassScope of: String. ClySubclassScope of: Array}.
-	scope name: 'test scope'.
 
-	convertedScope := scope asInterestingClassScope.
+	| convertedScope |
+	self scope: (ClyCompositeScope on: {
+				 (ClySuperclassScope of: String).
+				 (ClySubclassScope of: Array) }).
+	self scope name: 'test scope'.
+
+	convertedScope := self scope asInterestingClassScope.
 
 	self assert: convertedScope name equals: 'test scope'
 ]
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToNewMetaLevel [
-	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClyClassScope of: Object in: environment.
-		ClySubclassScope of: Array in: environment}.
 
-	convertedScope := scope withMetaLevel: ClyInstanceSideScope.
+	| convertedScope |
+	self scope: (ClyCompositeScope on: {
+				 (ClyClassScope of: Object in: self environment).
+				 (ClySubclassScope of: Array in: self environment) }).
+
+	convertedScope := self scope withMetaLevel: ClyInstanceSideScope.
 
 	self assert: convertedScope class equals: ClyCompositeScope.
-	self
-		assert: convertedScope subscopes first
-		equals: (ClyInstanceSideScope of: Object).
-	self
-		assert: convertedScope subscopes last class
-		equals: ClySubclassScope.
-	self
-		assert: convertedScope subscopes last localScopeClass
-		equals: ClyInstanceSideScope.
-	self assert: convertedScope environment equals: environment.
-	self
-		assert: (convertedScope subscopes collect: #environment as: Set)
-		equals: {environment} asSet
+	self assert: convertedScope subscopes first equals: (ClyInstanceSideScope of: Object).
+	self assert: convertedScope subscopes last class equals: ClySubclassScope.
+	self assert: convertedScope subscopes last localScopeClass equals: ClyInstanceSideScope.
+	self assert: convertedScope environment equals: self environment.
+	self assert: (convertedScope subscopes collect: #environment as: Set) equals: { self environment } asSet
 ]
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyCompositeScopeTest >> testConvertingToNewMetaLevelShouldKeepScopeName [
-	| convertedScope |
-	scope := ClyCompositeScope on: {
-		ClyClassScope of: Object in: environment.
-		ClySubclassScope of: Array in: environment}.
-	scope name: 'test scope'.
 
-	convertedScope := scope withMetaLevel: ClyInstanceSideScope.
+	| convertedScope |
+	self scope: (ClyCompositeScope on: {
+				 (ClyClassScope of: Object in: self environment).
+				 (ClySubclassScope of: Array in: self environment) }).
+	self scope name: 'test scope'.
+
+	convertedScope := self scope withMetaLevel: ClyInstanceSideScope.
 
 	self assert: convertedScope name equals: 'test scope'
 ]

--- a/src/Calypso-SystemQueries-Tests/ClyUnionQueryTest.extension.st
+++ b/src/Calypso-SystemQueries-Tests/ClyUnionQueryTest.extension.st
@@ -2,16 +2,20 @@ Extension { #name : 'ClyUnionQueryTest' }
 
 { #category : '*Calypso-SystemQueries-Tests' }
 ClyUnionQueryTest >> testConvertingToNewMetaLevel [
-	| newQuery scopes |
-	query
-		subqueries:
-			{(ClyAllMethodGroupsQuery from: ClyClassScope of: Object in: environment).
-			(ClyAllMethodGroupsQuery from: ClySubclassScope of: Array in: environment)}.
 
-	newQuery := query withMetaLevelScope: ClyInstanceSideScope.
+	| newQuery scopes |
+	self query subqueries: {
+			(ClyAllMethodGroupsQuery from: ClyClassScope of: Object in: self environment).
+			(ClyAllMethodGroupsQuery from: ClySubclassScope of: Array in: self environment) }.
+
+	newQuery := self query withMetaLevelScope: ClyInstanceSideScope.
 	self assert: newQuery class equals: self queryClass.
-	self assert: (newQuery subqueries collect: [:each | each class]) equals: (query subqueries collect: [:each | each class]).
-	self assert: newQuery requiredResult identicalTo: query requiredResult.
+	self
+		assert: (newQuery subqueries collect: [ :each | each class ])
+		equals: (self query subqueries collect: [ :each | each class ]).
+	self assert: newQuery requiredResult identicalTo: self query requiredResult.
 	scopes := newQuery subqueries collect: [ :each | each scope ] as: Set.
-	self assert: scopes equals: {(ClyInstanceSideScope of: Object) . (ClySubclassScope of: Array localScope: ClyInstanceSideScope)} asSet
+	self assert: scopes equals: {
+			(ClyInstanceSideScope of: Object).
+			(ClySubclassScope of: Array localScope: ClyInstanceSideScope) } asSet
 ]

--- a/src/Calypso-SystemQueries/ClassModificationApplied.extension.st
+++ b/src/Calypso-SystemQueries/ClassModificationApplied.extension.st
@@ -14,7 +14,7 @@ ClassModificationApplied >> affectsVariablesOf: aClass [
 	Therefore any class modification can affect variables from both class sides.
 	And we do not need to distinguish it"
 
-	aClass instanceSide = modifiedClass instanceSide ifTrue: [ ^true ].
+	aClass instanceSide = self modifiedClass instanceSide ifTrue: [ ^ true ].
 
-	^false
+	^ false
 ]

--- a/src/Calypso-SystemQueries/ClassRemoved.extension.st
+++ b/src/Calypso-SystemQueries/ClassRemoved.extension.st
@@ -2,7 +2,8 @@ Extension { #name : 'ClassRemoved' }
 
 { #category : '*Calypso-SystemQueries' }
 ClassRemoved >> affectsMethod: aMethod [
-	^classRemoved == aMethod origin
+
+	^ self classRemoved == aMethod origin
 ]
 
 { #category : '*Calypso-SystemQueries' }
@@ -26,7 +27,7 @@ ClassRemoved >> affectsMethodsDefinedInPackage: aPackage [
 { #category : '*Calypso-SystemQueries' }
 ClassRemoved >> affectsMethodsInProtocol: protocol [
 
-	^ classRemoved protocolNames includes: protocol
+	^ self classRemoved protocolNames includes: protocol
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/ClassRenamed.extension.st
+++ b/src/Calypso-SystemQueries/ClassRenamed.extension.st
@@ -20,13 +20,13 @@ ClassRenamed >> affectsMethodsDefinedInClass: aClass [
 { #category : '*Calypso-SystemQueries' }
 ClassRenamed >> affectsMethodsDefinedInPackage: aPackage [
 
-	^classRenamed package == aPackage
+	^ self classRenamed package == aPackage
 ]
 
 { #category : '*Calypso-SystemQueries' }
 ClassRenamed >> affectsMethodsInProtocol: protocol [
 
-	^ classRenamed protocolNames includes: protocol
+	^ self classRenamed protocolNames includes: protocol
 ]
 
 { #category : '*Calypso-SystemQueries' }
@@ -35,9 +35,9 @@ ClassRenamed >> affectsVariablesOf: aClass [
 	That's any class modification can affect variables from both class sides.
 	And we do not need to distinguish it"
 
-	aClass instanceSide = classRenamed instanceSide ifTrue: [ ^true ].
+	aClass instanceSide = self classRenamed instanceSide ifTrue: [ ^ true ].
 
-	^false
+	^ false
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/ClassRepackaged.extension.st
+++ b/src/Calypso-SystemQueries/ClassRepackaged.extension.st
@@ -21,7 +21,7 @@ ClassRepackaged >> affectsMethodsDefinedInPackage: aPackage [
 { #category : '*Calypso-SystemQueries' }
 ClassRepackaged >> affectsMethodsInProtocol: protocol [
 
-	^ classRepackaged protocolNames includes: protocol
+	^ self classRepackaged protocolNames includes: protocol
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/ClyCompositeScope.extension.st
+++ b/src/Calypso-SystemQueries/ClyCompositeScope.extension.st
@@ -23,9 +23,10 @@ ClyCompositeScope >> asInterestingClassScope [
 
 { #category : '*Calypso-SystemQueries' }
 ClyCompositeScope >> asLocalClassScope [
+
 	| newSubscopes |
-	newSubscopes := subscopes collect: [ :each | each asLocalClassScope ].
-	^ClyCompositeScope on: newSubscopes in: environment
+	newSubscopes := self subscopes collect: [ :each | each asLocalClassScope ].
+	^ ClyCompositeScope on: newSubscopes in: self environment
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/ClyMethodVisibilityLevel.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodVisibilityLevel.class.st
@@ -65,6 +65,7 @@ ClyMethodVisibilityLevel >> detectActiveState [
 
 { #category : 'accessing' }
 ClyMethodVisibilityLevel >> extraClassScope [
+
 	^ extraClassScope
 ]
 

--- a/src/Calypso-SystemQueries/ClyTypedScope.extension.st
+++ b/src/Calypso-SystemQueries/ClyTypedScope.extension.st
@@ -12,15 +12,13 @@ ClyTypedScope >> canDetectAffectOnClassesBy: aSystemAnnouncement [
 { #category : '*Calypso-SystemQueries' }
 ClyTypedScope >> includesClassesAffectedBy: aSystemAnnouncement [
 
-	^basisObjects anySatisfy: [ :each |
-		each includesClassesAffectedBy: aSystemAnnouncement ]
+	^ self basisObjects anySatisfy: [ :each | each includesClassesAffectedBy: aSystemAnnouncement ]
 ]
 
 { #category : '*Calypso-SystemQueries' }
 ClyTypedScope >> includesMethodsAffectedBy: aSystemAnnouncement [
 
-	^basisObjects anySatisfy: [ :each |
-		each includesMethodsAffectedBy: aSystemAnnouncement ]
+	^ self basisObjects anySatisfy: [ :each | each includesMethodsAffectedBy: aSystemAnnouncement ]
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/MetalinkChanged.extension.st
+++ b/src/Calypso-SystemQueries/MetalinkChanged.extension.st
@@ -3,7 +3,7 @@ Extension { #name : 'MetalinkChanged' }
 { #category : '*Calypso-SystemQueries' }
 MetalinkChanged >> affectsMethod: aMethod [
 
-	^link methods anySatisfy: [:each | each compiledMethod == aMethod compiledMethod ]
+	^ self link methods anySatisfy: [ :each | each compiledMethod == aMethod compiledMethod ]
 ]
 
 { #category : '*Calypso-SystemQueries' }
@@ -19,7 +19,6 @@ MetalinkChanged >> affectsMethodsDefinedInClass: aClass [
 
 { #category : '*Calypso-SystemQueries' }
 MetalinkChanged >> affectsMethodsDefinedInPackage: aPackage [
-	^ link methods
-		anySatisfy:
-			[ :each | each methodClass isNotNil and: [ each package == aPackage ] ]
+
+	^ self link methods anySatisfy: [ :each | each methodClass isNotNil and: [ each package == aPackage ] ]
 ]

--- a/src/Calypso-SystemQueries/MethodAnnouncement.extension.st
+++ b/src/Calypso-SystemQueries/MethodAnnouncement.extension.st
@@ -34,7 +34,7 @@ MethodAnnouncement >> affectsMethodsDefinedInPackage: aPackage [
 { #category : '*Calypso-SystemQueries' }
 MethodAnnouncement >> affectsMethodsInProtocol: protocol [
 
-	^ method protocolName == protocol
+	^ self method protocolName == protocol
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/MethodModified.extension.st
+++ b/src/Calypso-SystemQueries/MethodModified.extension.st
@@ -2,14 +2,14 @@ Extension { #name : 'MethodModified' }
 
 { #category : '*Calypso-SystemQueries' }
 MethodModified >> affectsMethod: aMethod [
-	^(super affectsMethod: aMethod) or: [oldMethod == aMethod]
+
+	^ (super affectsMethod: aMethod) or: [ self oldMethod == aMethod ]
 ]
 
 { #category : '*Calypso-SystemQueries' }
 MethodModified >> affectsMethodsDefinedInPackage: aPackage [
 
-	^(super affectsMethodsDefinedInPackage: aPackage) or: [
-		oldMethod package == aPackage ]
+	^ (super affectsMethodsDefinedInPackage: aPackage) or: [ self oldMethod package == aPackage ]
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/MethodRepackaged.extension.st
+++ b/src/Calypso-SystemQueries/MethodRepackaged.extension.st
@@ -13,11 +13,12 @@ MethodRepackaged >> affectsClassesExtendedInPackage: aPackage [
 
 { #category : '*Calypso-SystemQueries' }
 MethodRepackaged >> affectsMethodsDefinedInPackage: aPackage [
-	^(super affectsMethodsDefinedInPackage: aPackage)
-		or: [ oldPackage = aPackage ]
+
+	^ (super affectsMethodsDefinedInPackage: aPackage) or: [ self oldPackage = aPackage ]
 ]
 
 { #category : '*Calypso-SystemQueries' }
 MethodRepackaged >> affectsPackage: aPackage [
-	^newPackage == aPackage or: [ oldPackage == aPackage ]
+
+	^ self newPackage == aPackage or: [ self oldPackage == aPackage ]
 ]

--- a/src/Calypso-SystemQueries/PackageRenamed.extension.st
+++ b/src/Calypso-SystemQueries/PackageRenamed.extension.st
@@ -2,12 +2,14 @@ Extension { #name : 'PackageRenamed' }
 
 { #category : '*Calypso-SystemQueries' }
 PackageRenamed >> affectsClass: aClass [
-	^package == aClass package
+
+	^ self package == aClass package
 ]
 
 { #category : '*Calypso-SystemQueries' }
 PackageRenamed >> affectsMethod: aMethod [
-	^package == aMethod package
+
+	^ self package == aMethod package
 ]
 
 { #category : '*Calypso-SystemQueries' }
@@ -25,7 +27,7 @@ PackageRenamed >> affectsMethodsDefinedInClass: aClass [
 { #category : '*Calypso-SystemQueries' }
 PackageRenamed >> affectsMethodsDefinedInPackage: aPackage [
 
-	^package == aPackage
+	^ self package == aPackage
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemTools-Core/CDSharedVariableNode.extension.st
+++ b/src/Calypso-SystemTools-Core/CDSharedVariableNode.extension.st
@@ -4,8 +4,7 @@ Extension { #name : 'CDSharedVariableNode' }
 CDSharedVariableNode >> asCalypsoVariableOf: aClass [
 
 	| actualClass classVar |
-	actualClass := self classDefinitionNode existingClassIfAbsent: [
-		self error: 'Class is not exists yet'].
-	classVar := actualClass classVariableNamed: name asSymbol.
-	^ClyClassVariable on: classVar definedIn: actualClass
+	actualClass := self classDefinitionNode existingClassIfAbsent: [ self error: 'Class is not exists yet' ].
+	classVar := actualClass classVariableNamed: self name asSymbol.
+	^ ClyClassVariable on: classVar definedIn: actualClass
 ]

--- a/src/Calypso-SystemTools-Core/CDSlotNode.extension.st
+++ b/src/Calypso-SystemTools-Core/CDSlotNode.extension.st
@@ -4,11 +4,9 @@ Extension { #name : 'CDSlotNode' }
 CDSlotNode >> asCalypsoVariableOf: aClass [
 
 	| actualClass |
-	actualClass := self classDefinitionNode existingClassIfAbsent: [
-		self error: 'Class is not exists yet'].
-	^actualClass
-		slotNamed: name asSymbol
-		ifFound: [:aSlot |
-			^ClyInstanceVariable on: aSlot definedIn: actualClass]
-		ifNone: [self error: 'Slot is not created yet']
+	actualClass := self classDefinitionNode existingClassIfAbsent: [ self error: 'Class is not exists yet' ].
+	^ actualClass
+		  slotNamed: self name asSymbol
+		  ifFound: [ :aSlot | ^ ClyInstanceVariable on: aSlot definedIn: actualClass ]
+		  ifNone: [ self error: 'Slot is not created yet' ]
 ]

--- a/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
@@ -30,10 +30,12 @@ ClyBrowserMorph >> confirmEmptySystemQuery: aQuery [
 ClyBrowserMorph >> confirmUnusedVariablesInDefiningClass: variables [
 
 	| refQuery classScope |
-	classScope := ClyBothMetaLevelClassScope ofAll: (variables collect: [:each | each definingClass]) in: navigationEnvironment.
+	classScope := ClyBothMetaLevelClassScope
+		              ofAll: (variables collect: [ :each | each definingClass ])
+		              in: self navigationEnvironment.
 	refQuery := ClyVariableReferencesQuery ofAny: variables from: classScope.
 
-	^self confirmEmptySystemQuery: refQuery
+	^ self confirmEmptySystemQuery: refQuery
 ]
 
 { #category : '*Calypso-SystemTools-Core' }

--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyMethodCodeEditorToolMorph.extension.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyMethodCodeEditorToolMorph.extension.st
@@ -50,7 +50,7 @@ ClyMethodCodeEditorToolMorph >> findString: searchedString asSelectorIn: aString
 ClyMethodCodeEditorToolMorph >> selectStringAsInMessageBrowser: criteriaString [
 
 	| interval |
-	interval := (self findAnySelectorInSourceCode: {criteriaString})
-			ifEmpty: [ self findString: criteriaString asSelectorIn: self pendingText].
-	textMorph setSelection: interval
+	interval := (self findAnySelectorInSourceCode: { criteriaString }) ifEmpty: [
+		            self findString: criteriaString asSelectorIn: self pendingText ].
+	self textMorph setSelection: interval
 ]

--- a/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
@@ -150,6 +150,12 @@ ClassDefinitionPrinter >> for: aClass [
 	forClass := aClass
 ]
 
+{ #category : 'accessing' }
+ClassDefinitionPrinter >> forClass [
+
+	^ forClass
+]
+
 { #category : 'public api' }
 ClassDefinitionPrinter >> metaclassDefinitionString [
 	^ self subclassResponsibility

--- a/src/Collections-DoubleLinkedList/DoubleLinkedList.class.st
+++ b/src/Collections-DoubleLinkedList/DoubleLinkedList.class.st
@@ -122,6 +122,18 @@ DoubleLinkedList >> firstLink [
 	^ head
 ]
 
+{ #category : 'accessing' }
+DoubleLinkedList >> head [
+
+	^ head
+]
+
+{ #category : 'accessing' }
+DoubleLinkedList >> head: anObject [
+
+	head := anObject
+]
+
 { #category : 'testing' }
 DoubleLinkedList >> isEmpty [
 	"Return true when I contain no elements, false otherwise."
@@ -235,4 +247,16 @@ DoubleLinkedList >> reverseLinksDo: block [
 		whileFalse: [
 	 		block value: current.
 			current := current previousLink ]
+]
+
+{ #category : 'accessing' }
+DoubleLinkedList >> tail [
+
+	^ tail
+]
+
+{ #category : 'accessing' }
+DoubleLinkedList >> tail: anObject [
+
+	tail := anObject
 ]

--- a/src/Collections-Sequenceable/SharedQueue.class.st
+++ b/src/Collections-Sequenceable/SharedQueue.class.st
@@ -78,6 +78,30 @@ SharedQueue >> isEmpty [
 ]
 
 { #category : 'accessing' }
+SharedQueue >> items [
+
+	^ items
+]
+
+{ #category : 'accessing' }
+SharedQueue >> items: anObject [
+
+	items := anObject
+]
+
+{ #category : 'accessing' }
+SharedQueue >> monitor [
+
+	^ monitor
+]
+
+{ #category : 'accessing' }
+SharedQueue >> monitor: anObject [
+
+	monitor := anObject
+]
+
+{ #category : 'accessing' }
 SharedQueue >> next [
 	^monitor critical: [
 		monitor waitWhile: [ items isEmpty ].

--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -103,6 +103,18 @@ PositionableStream >> boolean: aBoolean [
 	self nextPut: (aBoolean ifTrue: [1] ifFalse: [0])
 ]
 
+{ #category : 'accessing' }
+PositionableStream >> collection [
+
+	^ collection
+]
+
+{ #category : 'accessing' }
+PositionableStream >> collection: anObject [
+
+	collection := anObject
+]
+
 { #category : 'private' }
 PositionableStream >> collectionSpecies [
 	"Answer the species of collection into which the receiver can stream"
@@ -588,6 +600,18 @@ PositionableStream >> readInto: aCollection startingAt: startIndex count: n [
 			ifNil: [ ^ i ]
 			ifNotNil: [ :obj | aCollection at: startIndex + i put: obj ] ].
 	^ n
+]
+
+{ #category : 'accessing' }
+PositionableStream >> readLimit [
+
+	^ readLimit
+]
+
+{ #category : 'accessing' }
+PositionableStream >> readLimit: anObject [
+
+	readLimit := anObject
 ]
 
 { #category : 'initialization' }

--- a/src/Collections-Streams/WriteStream.class.st
+++ b/src/Collections-Streams/WriteStream.class.st
@@ -343,3 +343,15 @@ WriteStream >> withAttributes: attributes do: strmBlock [
 	"No-op here is overriden in TextStream for font emphasis"
 	^ strmBlock value
 ]
+
+{ #category : 'accessing' }
+WriteStream >> writeLimit [
+
+	^ writeLimit
+]
+
+{ #category : 'accessing' }
+WriteStream >> writeLimit: anObject [
+
+	writeLimit := anObject
+]

--- a/src/Collections-Unordered-Tests/SetTest.class.st
+++ b/src/Collections-Unordered-Tests/SetTest.class.st
@@ -171,6 +171,12 @@ SetTest >> firstCollection [
 	^ firstCollection
 ]
 
+{ #category : 'accessing' }
+SetTest >> full [
+
+	^ full
+]
+
 { #category : 'requirements' }
 SetTest >> integerCollectionWithoutEqualElements [
 " return a collection of integer without equal elements"

--- a/src/Collections-Unordered/Bag.class.st
+++ b/src/Collections-Unordered/Bag.class.st
@@ -133,6 +133,12 @@ Bag >> associationsDo: aBlock [
 ]
 
 { #category : 'accessing' }
+Bag >> contents [
+
+	^ contents
+]
+
+{ #category : 'accessing' }
 Bag >> counts [
 	"Returns the amount of occurrences of each element."
 	"#(11 22 22 33 11 11 11) asBag counts >>>  #(4 2 1)"

--- a/src/Collections-Weak-Tests/WeakValueDictionary.extension.st
+++ b/src/Collections-Weak-Tests/WeakValueDictionary.extension.st
@@ -4,5 +4,5 @@ Extension { #name : 'WeakValueDictionary' }
 WeakValueDictionary >> privateAssociations [
 	"I am a method used for test to return the WeakValueAssociations instead of Associations."
 
-	^ array select: [ :each | each value isNotNil ]
+	^ self array select: [ :each | each value isNotNil ]
 ]

--- a/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
@@ -13,14 +13,14 @@ CmdCommandActivator >> registerContextMenuItemsFor: aCommandItem withBuilder: aB
 
 	self canExecuteCommand ifFalse: [ ^self ].
 
-	command registerContextMenuItemsFor: aCommandItem withBuilder: aBuilder
+	self command registerContextMenuItemsFor: aCommandItem withBuilder: aBuilder
 ]
 
 { #category : '*Commander-Activators-ContextMenu' }
 CmdCommandActivator >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 
 	CmdShortcutActivation
-		activeInstancesFor: command class inContext: context
+		activeInstancesFor: self command class inContext: self context
 		do: [ :shortcut |
 			aMenuItemMorph keyText: (shortcut keyCombination acceptVisitor: OSPlatform current shortcutPrinter)]
 ]

--- a/src/Commander-Activators-ContextMenu/CmdCommandMenuItem.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandMenuItem.extension.st
@@ -15,5 +15,5 @@ CmdCommandMenuItem >> registerContextMenuItemsWithBuilder: aBuilder [
 { #category : '*Commander-Activators-ContextMenu' }
 CmdCommandMenuItem >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 
-	activator setUpShortcutTipForMenuItem: aMenuItemMorph
+	self activator setUpShortcutTipForMenuItem: aMenuItemMorph
 ]

--- a/src/Commander-Activators-ContextMenu/CmdMenu.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdMenu.extension.st
@@ -6,7 +6,7 @@ CmdMenu >> buildContextMenuFor: aMorph [
 	| menu |
 	menu := MorphicUIManager new newMenuIn: aMorph for: aMorph.
 
-	rootGroup buildContextMenu: menu.
+	self rootGroup buildContextMenu: menu.
 
 	menu hasSubmorphs ifTrue: [
 		menu lastSubmorph isMenuLineMorph ifTrue: [

--- a/src/Commander-Activators-ContextMenu/CmdMenuGroup.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdMenuGroup.extension.st
@@ -16,7 +16,7 @@ CmdMenuGroup >> buildContextSubMenuIn: aMenu [
 		           newMenuIn: aMenu defaultTarget
 		           for: aMenu defaultTarget.
 
-	contents do: [ :each | each buildContextMenu: submenu ].
+	self contents do: [ :each | each buildContextMenu: submenu ].
 
 	submenu hasItems ifTrue: [
 		aMenu add: self name icon: self icon subMenu: submenu.
@@ -28,7 +28,7 @@ CmdMenuGroup >> inlineContextMenuItemsInto: aMenu [
 
 	aMenu addLine.
 
-	contents do: [ :each | each buildContextMenu: aMenu ].
+	self contents do: [ :each | each buildContextMenu: aMenu ].
 
 	aMenu addLine
 ]
@@ -54,7 +54,7 @@ CmdMenuGroup >> registerContextSubMenuWithBuilder: aBuilder [
 
 	(aBuilder item: self name)
 		order: self order;
-		parent: parentGroup name;
+		parent: self parentGroup name;
 		target: self;
 		icon: self icon;
 		help: self description

--- a/src/Commander-Activators-DragAndDrop/CmdCompositeToolContext.extension.st
+++ b/src/Commander-Activators-DragAndDrop/CmdCompositeToolContext.extension.st
@@ -3,16 +3,14 @@ Extension { #name : 'CmdCompositeToolContext' }
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdCompositeToolContext >> allowsDropExecutionOf: aCommand [
 
-	^existingContexts anySatisfy: [ :each |
-		each allowsDropExecutionOf: aCommand ]
+	^ self existingContexts anySatisfy: [ :each | each allowsDropExecutionOf: aCommand ]
 ]
 
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdCompositeToolContext >> applyDropResultOf: aCommand [
 
 	| activeDropContext |
-	activeDropContext := existingContexts detect: [ :each |
-		each allowsDropExecutionOf: aCommand ].
+	activeDropContext := self existingContexts detect: [ :each | each allowsDropExecutionOf: aCommand ].
 
 	activeDropContext applyDropResultOf: aCommand
 ]
@@ -28,8 +26,7 @@ CmdCompositeToolContext >> prepareDragActivationOf: aCommand [
 CmdCompositeToolContext >> prepareDropExecutionOf: aCommand [
 
 	| activeDropContext |
-	activeDropContext := existingContexts detect: [ :each |
-		each allowsDropExecutionOf: aCommand ].
+	activeDropContext := self existingContexts detect: [ :each | each allowsDropExecutionOf: aCommand ].
 
 	activeDropContext prepareDropExecutionOf: aCommand
 ]

--- a/src/Commander-Activators-DragAndDrop/CmdSimpleToolContext.extension.st
+++ b/src/Commander-Activators-DragAndDrop/CmdSimpleToolContext.extension.st
@@ -2,20 +2,24 @@ Extension { #name : 'CmdSimpleToolContext' }
 
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdSimpleToolContext >> allowsDropExecutionOf: aCommand [
-	^aCommand canBeExecutedInDropContext: tool
+
+	^ aCommand canBeExecutedInDropContext: self tool
 ]
 
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdSimpleToolContext >> applyDropResultOf: aCommand [
-	aCommand applyDropResultInContext: tool
+
+	aCommand applyDropResultInContext: self tool
 ]
 
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdSimpleToolContext >> prepareDragActivationOf: aCommand [
-	aCommand prepareExecutionInDragContext: tool
+
+	aCommand prepareExecutionInDragContext: self tool
 ]
 
 { #category : '*Commander-Activators-DragAndDrop' }
 CmdSimpleToolContext >> prepareDropExecutionOf: aCommand [
-	aCommand prepareExecutionInDropContext: tool
+
+	aCommand prepareExecutionInDropContext: self tool
 ]

--- a/src/Commander-Activators-Mouse/MouseButtonEvent.extension.st
+++ b/src/Commander-Activators-Mouse/MouseButtonEvent.extension.st
@@ -3,9 +3,9 @@ Extension { #name : 'MouseButtonEvent' }
 { #category : '*Commander-Activators-Mouse' }
 MouseButtonEvent >> fixStateForClickAndModifierIssue [
 
-	self isMouseUp ifFalse: [ ^self ].
-	self yellowButtonChanged ifFalse: [ ^self ].
-	self anyModifierKeyPressed ifFalse: [ ^self ].
+	self isMouseUp ifFalse: [ ^ self ].
+	self yellowButtonChanged ifFalse: [ ^ self ].
+	self anyModifierKeyPressed ifFalse: [ ^ self ].
 
-	whichButton := MouseEvent redButton
+	self whichButton: MouseEvent redButton
 ]

--- a/src/Commander-Spec2-Compatibility/CmdCommandActivator.extension.st
+++ b/src/Commander-Spec2-Compatibility/CmdCommandActivator.extension.st
@@ -2,13 +2,12 @@ Extension { #name : 'CmdCommandActivator' }
 
 { #category : '*Commander-Spec2-Compatibility' }
 CmdCommandActivator >> getShortcutTipForMenuItem [
+
 	CmdShortcutActivation
-		activeInstancesFor: command class
-		inContext: context
-		do:
-			[ :shortcut | "this is trick to show shortcut on menu with existing menu support"
-			^ shortcut keyCombination ].
-		^nil
+		activeInstancesFor: self command class
+		inContext: self context
+		do: [ :shortcut | "this is trick to show shortcut on menu with existing menu support" ^ shortcut keyCombination ].
+	^ nil
 ]
 
 { #category : '*Commander-Spec2-Compatibility' }

--- a/src/Commander-Spec2-Compatibility/CmdCommandMenuItem.extension.st
+++ b/src/Commander-Spec2-Compatibility/CmdCommandMenuItem.extension.st
@@ -15,5 +15,6 @@ CmdCommandMenuItem >> addToMenuPresenter: aSpMenuPresenter [
 
 { #category : '*Commander-Spec2-Compatibility' }
 CmdCommandMenuItem >> getShortcutTipForMenuItem [
- 	^activator getShortcutTipForMenuItem
+
+	^ self activator getShortcutTipForMenuItem
 ]

--- a/src/Commander-Spec2-Compatibility/CmdMenu.extension.st
+++ b/src/Commander-Spec2-Compatibility/CmdMenu.extension.st
@@ -2,8 +2,9 @@ Extension { #name : 'CmdMenu' }
 
 { #category : '*Commander-Spec2-Compatibility' }
 CmdMenu >> asSpMenuPresenter [
+
 	| menu |
 	menu := SpMenuPresenter new.
-	rootGroup contents do: [ :each | each addToMenuPresenter: menu  ].
-	^menu
+	self rootGroup contents do: [ :each | each addToMenuPresenter: menu ].
+	^ menu
 ]

--- a/src/Compression/PositionableStream.extension.st
+++ b/src/Compression/PositionableStream.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'PositionableStream' }
 
 { #category : '*Compression' }
 PositionableStream >> asZLibReadStream [
-	^ZLibReadStream on: collection from: position+1 to: readLimit
+
+	^ ZLibReadStream on: self collection from: self position + 1 to: self readLimit
 ]

--- a/src/Debugger-Model/Process.extension.st
+++ b/src/Debugger-Model/Process.extension.st
@@ -80,7 +80,7 @@ Process >> return: aContext value: value [
 	"Pop thread down to aContext's sender.  Execute any unwind blocks on the way.  See #popTo: comment and #runUntilErrorOrReturnFrom: for more details."
 
 	self suspendedContext == aContext ifTrue: [
-		^ Processor activeProcess evaluate: [ self suspendedContext: (aContext return: value from: aContext) ] onBehalfOf: self ].
+		^ Processor activeProcess evaluate: [ self suspendedContext: (aContext return: value from: aContext). self suspendedContext ] onBehalfOf: self ].
 	self activateReturn: aContext value: value.
 	^ self complete: aContext
 ]

--- a/src/Debugger-Model/Process.extension.st
+++ b/src/Debugger-Model/Process.extension.st
@@ -65,26 +65,24 @@ Process >> popTo: aContext value: aValue [
 Process >> restartTop [
 	"Rollback top context and replace with new method.  Assumes self is suspended"
 
-	suspendedContext privRefresh
+	self suspendedContext privRefresh
 ]
 
 { #category : '*Debugger-Model' }
 Process >> restartTopWith: method [
 	"Rollback top context and replace with new method.  Assumes self is suspended"
 
-	suspendedContext privRefreshWith: method
+	self suspendedContext privRefreshWith: method
 ]
 
 { #category : '*Debugger-Model' }
 Process >> return: aContext value: value [
 	"Pop thread down to aContext's sender.  Execute any unwind blocks on the way.  See #popTo: comment and #runUntilErrorOrReturnFrom: for more details."
 
-	suspendedContext == aContext ifTrue:
-		[^Processor activeProcess
-			evaluate: [suspendedContext := aContext return: value from: aContext]
-			onBehalfOf: self].
+	self suspendedContext == aContext ifTrue: [
+		^ Processor activeProcess evaluate: [ self suspendedContext: (aContext return: value from: aContext) ] onBehalfOf: self ].
 	self activateReturn: aContext value: value.
-	^self complete: aContext
+	^ self complete: aContext
 ]
 
 { #category : '*Debugger-Model' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -20,8 +20,7 @@ Context >> findSecondToOldestSimilarSender [
 Context >> findSimilarSender [
 	"Return the closest sender with the same method, return nil if none found"
 
-	^ self sender findContextSuchThat: [ :context | 
-		context compiledCode == method ]
+	^ self sender findContextSuchThat: [ :context | context compiledCode == self method ]
 ]
 
 { #category : '*Debugging-Core' }

--- a/src/Debugging-Core/InstructionStream.extension.st
+++ b/src/Debugging-Core/InstructionStream.extension.st
@@ -41,7 +41,7 @@ InstructionStream >> followingBytecode [
 InstructionStream >> followingPc [
 	"Answer the pc of the following bytecode."
 
-	^self nextPc: (self method at: pc)
+	^ self nextPc: (self method at: self pc)
 ]
 
 { #category : '*Debugging-Core' }
@@ -70,7 +70,7 @@ InstructionStream >> previousPc [
 InstructionStream >> thirdByte [
 	"Answer the third byte of the current bytecode."
 
-	^self method at: pc + 2
+	^ self method at: self pc + 2
 ]
 
 { #category : '*Debugging-Core' }

--- a/src/Debugging-Utils-Tests/ProcessMonitorTestServiceTest.extension.st
+++ b/src/Debugging-Utils-Tests/ProcessMonitorTestServiceTest.extension.st
@@ -2,45 +2,60 @@ Extension { #name : 'ProcessMonitorTestServiceTest' }
 
 { #category : '*Debugging-Utils-Tests' }
 ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
-	| process haltWasPassed halt |
 
+	| process haltWasPassed halt |
 	haltWasPassed := false.
 	halt := Halt new.
-	process := self fork: [ Processor activeProcess suspend. halt signal ].
-	testService handleNewProcess: process.
+	process := self fork: [
+			           Processor activeProcess suspend.
+			           halt signal ].
+	self testService handleNewProcess: process.
 
-	process on: Halt do: [ :actual |
-		actual == halt ifFalse: [ actual pass ]. "it allows to debug if it works wrongly"
-		self assert: actual equals: halt. haltWasPassed := true ].
+	process
+		on: Halt
+		do: [ :actual |
+				actual == halt ifFalse: [ actual pass ]. "it allows to debug if it works wrongly"
+				self assert: actual equals: halt.
+				haltWasPassed := true ].
 	process resume.
 
 	self assert: haltWasPassed.
 	self assert: process isTerminated description: 'process should be terminated now'.
-	self deny: (testService suspendedBackgroundFailures includesKey: process)
+	self deny: (self testService suspendedBackgroundFailures includesKey: process)
 ]
 
 { #category : '*Debugging-Utils-Tests' }
 ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenHaltIsSignaled [
+
 	| executed |
 	executed := false.
-	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
+	self fork: [
+			self testService suspendBackgroundFailure: Error new.
+			executed := true ].
 
-	testService handleException: Halt new.
+	self testService handleException: Halt new.
 
 	self assert: executed.
-	self deny: testService shouldSuspendBackgroundFailures
+	self deny: self testService shouldSuspendBackgroundFailures
 ]
 
 { #category : '*Debugging-Utils-Tests' }
 ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenHaltIsSignaledInBackground [
+
 	| processWithHalt executed |
 	executed := false.
-	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
-	processWithHalt := self fork: [ Processor activeProcess suspend. Halt new signal ].
+	self fork: [
+			self testService suspendBackgroundFailure: Error new.
+			executed := true ].
+	processWithHalt := self fork: [
+			                   Processor activeProcess suspend.
+			                   Halt new signal ].
 
-	processWithHalt on: Halt do: [ :actual | ].
+	processWithHalt
+		on: Halt
+		do: [ :actual |  ].
 	processWithHalt resume.
 
 	self assert: executed.
-	self deny: testService shouldSuspendBackgroundFailures
+	self deny: self testService shouldSuspendBackgroundFailures
 ]

--- a/src/Debugging-Utils-Tests/TestExecutionEnvironmentTest.extension.st
+++ b/src/Debugging-Utils-Tests/TestExecutionEnvironmentTest.extension.st
@@ -2,15 +2,17 @@ Extension { #name : 'TestExecutionEnvironmentTest' }
 
 { #category : '*Debugging-Utils-Tests' }
 TestExecutionEnvironmentTest >> testNotifyTestServicesAboutHalt [
-	| errorPassed expectedException|
+
+	| errorPassed expectedException |
 	errorPassed := false.
 	expectedException := Halt new messageText: 'test halt'.
 	self runWithNoHandlers: [
-		[self runTestWith: [ expectedException signal]] on: Halt do: [:actualException |
-			errorPassed := true.
-			self assert: actualException equals: expectedException.
-			self assert: (testService signaledExceptions includes: actualException)].
-	].
+			[ self runTestWith: [ expectedException signal ] ]
+				on: Halt
+				do: [ :actualException |
+						errorPassed := true.
+						self assert: actualException equals: expectedException.
+						self assert: (self testService signaledExceptions includes: actualException) ] ].
 
 	self assert: errorPassed
 ]

--- a/src/EmbeddedFreeType-Tests/FreeTypeFontProvider.extension.st
+++ b/src/EmbeddedFreeType-Tests/FreeTypeFontProvider.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'FreeTypeFontProvider' }
 
 { #category : '*EmbeddedFreeType-Tests' }
 FreeTypeFontProvider >> includesInstaller: anEmbeddedFreeTypeFontInstaller [
-	^ fontInstallers identityIncludes: anEmbeddedFreeTypeFontInstaller
+
+	^ self fontInstallers identityIncludes: anEmbeddedFreeTypeFontInstaller
 ]

--- a/src/Epicea/EpGenericRefactoring.class.st
+++ b/src/Epicea/EpGenericRefactoring.class.st
@@ -35,3 +35,9 @@ EpGenericRefactoring >> initializeWith: aRBRefactoring [
 	self initialize.
 	storeString := aRBRefactoring storeString
 ]
+
+{ #category : 'initialization' }
+EpGenericRefactoring >> storeString [
+
+	^ storeString
+]

--- a/src/Epicea/RBRenameInstanceVariableRefactoring.extension.st
+++ b/src/Epicea/RBRenameInstanceVariableRefactoring.extension.st
@@ -2,10 +2,8 @@ Extension { #name : 'RBRenameInstanceVariableRefactoring' }
 
 { #category : '*Epicea-Refactorings' }
 RBRenameInstanceVariableRefactoring >> asEpiceaEvent [
-	^ EpRenameInstanceVariableRefactoring
-		rename: variableName
-		to: newName
-		in: class name
+
+	^ EpRenameInstanceVariableRefactoring rename: self variableName to: self newName in: self class name
 ]
 
 { #category : '*Epicea-Refactorings' }

--- a/src/Epicea/RGElementDefinition.extension.st
+++ b/src/Epicea/RGElementDefinition.extension.st
@@ -11,5 +11,5 @@ RGElementDefinition >> asEpiceaRingDefinition [
 { #category : '*Epicea-Ring' }
 RGElementDefinition >> epiceaCleanUp [
 
-	parent := nil
+	self basicParent: nil
 ]

--- a/src/Extension-New-System/ClyPackageDefinitionTool.class.st
+++ b/src/Extension-New-System/ClyPackageDefinitionTool.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : 'ClyPackageDefinitionTool',
+	#superclass : 'ClyTextEditorToolMorph',
+	#instVars : [
+		'package'
+	],
+	#category : 'Extension-New-System-TextEditors',
+	#package : 'Extension-New-System',
+	#tag : 'TextEditors'
+}
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool class >> browserTabActivation [
+
+	<classAnnotation>
+	^ ClyTabActivationStrategyAnnotation for: Package asCalypsoItemContext
+]
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool class >> tabOrder [
+
+	^ 1
+]
+
+{ #category : 'operations' }
+ClyPackageDefinitionTool >> applyChanges [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool >> defaultIconName [
+
+	^ #package
+]
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool >> defaultTitle [
+
+	^ package name
+]
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool >> editingText [
+
+	^ package description
+]
+
+{ #category : 'accessing' }
+ClyPackageDefinitionTool >> setUpModelFromContext [
+
+	super setUpModelFromContext.
+
+	package := context selectedItems first actualObject
+]

--- a/src/Extension-New-System/ExtensionNewSystem.class.st
+++ b/src/Extension-New-System/ExtensionNewSystem.class.st
@@ -1,0 +1,231 @@
+"
+`migration script :`
+forScript := ExtensionNewSystem new.
+
+forScript createAllLocalExtensionObjects. 
+
+forbiddenPackages := #( 
+   'OpalCompiler' 
+   'Kernel' 
+   'Collections' 
+   'Morphic' 
+   'UnifiedFFI' 
+   'ThreadedFFI' 
+   'FreeType' 
+	'AST-Core'
+	'FileSystem'
+	'Rubric'
+	'Text'
+	'Spec2-Commander2'
+).
+
+localExtensionWithNoPragmas := (forScript localExtensionMethods reject: [ :m | (m pragmas isNotEmpty) ]). 
+
+methodsToCompile := localExtensionWithNoPragmas reject: [ :method | 
+    forbiddenPackages anySatisfy: [ :forbiddenName | (method package name beginsWith: forbiddenName) or: 
+        [ method methodClass package name beginsWith: forbiddenName ] ] 
+]. ""size 916""
+
+
+
+forScript compileMethodsForCollection: methodsToCompile.
+""to separate class already having getter and those which don't""
+forScript := ExtensionNewSystem new.  
+methodsToAnalyze := forScript localExtensionMethodsWithInstVar.  
+easyMethods := OrderedCollection new. 
+complexMethods := OrderedCollection new.  
+
+methodsToAnalyze do: [ :method |  
+    | targetClass ast isComplex |  
+    targetClass := method methodClass.  
+    ast := method ast.  
+    isComplex := false.  
+    
+    ast instanceVariableNodes do: [ :node |  
+        | varName |  
+        varName := node name.  
+        
+        (targetClass includesSelector: varName asSymbol) ifTrue: [  
+            | existingGetterAst firstStatement returnedNode |  
+            existingGetterAst := (targetClass lookupSelector: varName asSymbol) ast.  
+            
+            existingGetterAst statements ifNotEmpty: [ :statements |
+                firstStatement := statements first.
+                
+                (statements size > 1 
+                    or: [ firstStatement isReturn not 
+                    or: [ returnedNode := firstStatement value.
+                          (returnedNode isVariable and: [ returnedNode name = varName ]) not ]]) 
+                            ifTrue: [ isComplex := true ]
+            ] ifEmpty: [ isComplex := true ].
+        ] ifFalse: [ 
+            isComplex := true 
+        ]
+    ].  
+    
+    isComplex  
+        ifTrue: [ complexMethods add: method ]  
+        ifFalse: [ easyMethods add: method ] 
+].  
+
+{  
+    (#easy -> easyMethods).  
+    (#complex -> complexMethods) 
+} inspect.
+"
+Class {
+	#name : 'ExtensionNewSystem',
+	#superclass : 'Object',
+	#instVars : [
+		'allExtensionMethods',
+		'sendersMap',
+		'localExtensionMethods',
+		'localExtensionByPackage',
+		'allExtensionObjectsSymbol',
+		'localExtensionMethodsWithInstVar'
+	],
+	#category : 'Extension-New-System',
+	#package : 'Extension-New-System'
+}
+
+{ #category : 'accessing' }
+ExtensionNewSystem >> allExtensionMethods [
+
+	^ allExtensionMethods
+]
+
+{ #category : 'accessing' }
+ExtensionNewSystem >> allExtensionObjectsSymbol [
+
+	^ allExtensionObjectsSymbol
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> compileAllLocalExtensionMethods [
+
+	self compileMethodsForCollection: localExtensionMethods
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> compileMethodsForCollection: anExtensionMethodsList [
+
+	| cpt |
+	cpt := 1.
+	SystemAnnouncer uniqueInstance suspendAllWhile: [
+			anExtensionMethodsList do: [ :method |
+					| nameOfTheExtensionObject targetExtensionClass |
+					[
+						nameOfTheExtensionObject := self findExtensionObjectNameWithMethod: method.
+						targetExtensionClass := Smalltalk at: nameOfTheExtensionObject asSymbol.
+						targetExtensionClass compile: method sourceCode classified: 'extensions'.
+						method methodClass removeSelector: method selector.
+						Stdio stdout
+							nextPutAll: cpt asString , ' : ' , method name asString;
+							lf;
+							flush.
+						cpt := cpt + 1 ]
+						on: Error
+						do: [ :error |
+								Stdio stdout
+									nextPutAll: 'Migration ignorée pour : ' , method printString , ' ' , error description;
+									lf ] ] ].
+	Stdio stdout
+		nextPutAll: 'installation done';
+		lf;
+		flush
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> compileMethodsInTheirExtensionObjectForPackage: aPackage [
+
+	| anExtensionMethodsList |
+	anExtensionMethodsList := localExtensionByPackage at: aPackage.
+	self compileMethodsForCollection: anExtensionMethodsList
+]
+
+{ #category : 'extensionObjects' }
+ExtensionNewSystem >> createAllLocalExtensionObjects [
+
+	allExtensionObjectsSymbol := Set new.
+	localExtensionMethods do: [ :method |
+			| nameOfTheExtensionObject |
+			nameOfTheExtensionObject := self findExtensionObjectNameWithMethod: method.
+			(allExtensionObjectsSymbol includes: nameOfTheExtensionObject) ifFalse: [
+					(Extension << nameOfTheExtensionObject asSymbol)
+						extendedClass: method methodClass;
+						package: method package name;
+						install.
+					allExtensionObjectsSymbol add: nameOfTheExtensionObject ] ]
+]
+
+{ #category : 'extensionObjects' }
+ExtensionNewSystem >> findExtensionObjectNameWithMethod: method [
+
+	| targetClass targetPackage nameOfTheExtensionObject |
+	targetClass := method methodClass.
+	targetPackage := (method package name copyReplaceAll: '-' with: '') copyReplaceAll: ' ' with: ''.
+	nameOfTheExtensionObject := 'ExtensionOf' , targetPackage , 'On' , (targetClass name copyReplaceAll: ' ' with: '').
+
+	^ nameOfTheExtensionObject
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> generateSendersMap [
+
+	| selectorsOfExtensionMethods |
+	selectorsOfExtensionMethods := (allExtensionMethods collect: [ :m | m selector ]) asSet.
+	sendersMap := Dictionary new.
+	SystemNavigation default allBehaviorsDo: [ :class |
+			class methodsDo: [ :aMethod |
+					aMethod messages do: [ :msg |
+						(selectorsOfExtensionMethods includes: msg) ifTrue: [
+							(sendersMap at: msg ifAbsentPut: [ OrderedCollection new ]) add: aMethod ] ] ] ]
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> initialize [
+
+	| mSenders |
+	super initialize.
+	allExtensionMethods := PackageOrganizer default packages flatCollect: [ :p | p extensionMethods ].
+	self generateSendersMap.
+	self localExtensionMethods.
+	localExtensionMethods := allExtensionMethods select: [ :m |
+			                         mSenders := sendersMap at: m selector ifAbsent: [ #(  ) ].
+			                         mSenders allSatisfy: [ :sender | sender package = m package ] ].
+	localExtensionByPackage := localExtensionMethods groupedBy: [ :m | m package name ].
+	localExtensionMethodsWithInstVar := localExtensionMethods select: [ :m |
+		                                    m ast variableNodes anySatisfy: [ :node | node isInstanceVariable ] ]
+]
+
+{ #category : 'accessing' }
+ExtensionNewSystem >> localExtensionByPackage [
+
+	^ localExtensionByPackage
+]
+
+{ #category : 'initialization' }
+ExtensionNewSystem >> localExtensionMethods [
+
+	^ localExtensionMethods
+]
+
+{ #category : 'as yet unclassified' }
+ExtensionNewSystem >> localExtensionMethodsWithInstVar [
+
+	^ localExtensionMethodsWithInstVar
+]
+
+{ #category : 'extensionObjects' }
+ExtensionNewSystem >> removeAllLocalExtensionObjects [
+
+	allExtensionObjectsSymbol
+		do: [ :o | (Smalltalk at: o asSymbol) removeFromSystem ];
+		removeAll
+]
+
+{ #category : 'accessing' }
+ExtensionNewSystem >> sendersMap [
+
+	^ sendersMap
+]

--- a/src/Extension-New-System/IceMCDefinitionImporter.extension.st
+++ b/src/Extension-New-System/IceMCDefinitionImporter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'IceMCDefinitionImporter' }
+
+{ #category : '*Extension-New-System' }
+IceMCDefinitionImporter >> visitExtensionDefinition: aMCExtensionDefinition [
+
+	^ nil
+]

--- a/src/Extension-New-System/Package.extension.st
+++ b/src/Extension-New-System/Package.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : 'Package' }
+
+{ #category : '*Extension-New-System' }
+Package >> description [
+
+	| stream |
+	stream := String new writeStream.
+
+	stream
+		nextPutAll: 'Package << #';
+		nextPutAll: self name;
+		cr;
+		tab;
+		nextPutAll: 'imports: { '.
+
+	self importedExtensions ifNotEmpty: [ :imports |
+		imports do: [ :i | stream nextPutAll: '#' , i name asString ] separatedBy: [ stream nextPutAll: ' . ' ] ].
+
+	stream nextPutAll: ' }'.
+
+	^ stream contents
+]

--- a/src/Extension-New-System/package.st
+++ b/src/Extension-New-System/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Extension-New-System' }

--- a/src/FileSystem-Core-Tests/AsyncFile.extension.st
+++ b/src/FileSystem-Core-Tests/AsyncFile.extension.st
@@ -7,27 +7,27 @@ AsyncFile >> test: byteCount fileName: fileName [
 	| buf1 buf2 bytesWritten bytesRead |
 	buf1 := String new: byteCount withAll: $x.
 	buf2 := String new: byteCount.
-	self open: fileName  asFileReference fullName forWrite: true.
-	self primWriteStart: fileHandle
+	self open: fileName asFileReference fullName forWrite: true.
+	self
+		primWriteStart: self fileHandle
 		fPosition: 0
 		fromBuffer: buf1
 		at: 1
 		count: byteCount.
-	semaphore wait.
-	bytesWritten := self primWriteResult: fileHandle.
+	self semaphore wait.
+	bytesWritten := self primWriteResult: self fileHandle.
 	self close.
 
 	self open: fileName asFileReference fullName forWrite: false.
-	self primReadStart: fileHandle fPosition: 0 count: byteCount.
-	semaphore wait.
-	bytesRead :=
-		self primReadResult: fileHandle
-			intoBuffer: buf2
-			at: 1
-			count: byteCount.
+	self primReadStart: self fileHandle fPosition: 0 count: byteCount.
+	self semaphore wait.
+	bytesRead := self
+		             primReadResult: self fileHandle
+		             intoBuffer: buf2
+		             at: 1
+		             count: byteCount.
 	self close.
 
-	buf1 = buf2 ifFalse: [self error: 'buffers do not match'].
-	^ 'wrote ', bytesWritten printString, ' bytes; ',
-	   'read ', bytesRead printString, ' bytes'
+	buf1 = buf2 ifFalse: [ self error: 'buffers do not match' ].
+	^ 'wrote ' , bytesWritten printString , ' bytes; ' , 'read ' , bytesRead printString , ' bytes'
 ]

--- a/src/Files/AsyncFile.class.st
+++ b/src/Files/AsyncFile.class.st
@@ -46,6 +46,24 @@ AsyncFile >> fileHandle [
 	^ fileHandle
 ]
 
+{ #category : 'accessing' }
+AsyncFile >> fileHandle: anObject [
+
+	fileHandle := anObject
+]
+
+{ #category : 'accessing' }
+AsyncFile >> name [
+
+	^ name
+]
+
+{ #category : 'accessing' }
+AsyncFile >> name: anObject [
+
+	name := anObject
+]
+
 { #category : 'open/close' }
 AsyncFile >> open: fullFileName forWrite: aBoolean [
 	"Open a file of the given name, and return a handle for that file. Answer the receiver if the primitive succeeds, nil otherwise.
@@ -156,6 +174,18 @@ AsyncFile >> readByteCount: byteCount fromFilePosition: fPosition onCompletionDo
 	] forkAt: Processor userInterruptPriority
 ]
 
+{ #category : 'accessing' }
+AsyncFile >> semaphore [
+
+	^ semaphore
+]
+
+{ #category : 'accessing' }
+AsyncFile >> semaphore: anObject [
+
+	semaphore := anObject
+]
+
 { #category : 'write and read' }
 AsyncFile >> waitForCompletion [
 
@@ -181,4 +211,16 @@ AsyncFile >> writeBuffer: buffer atFilePosition: fPosition onCompletionDo: aBloc
 		n = buffer size ifFalse: [^ self error: 'did not write the entire buffer'].
 		aBlock value.
 	] forkAt: Processor userInterruptPriority
+]
+
+{ #category : 'accessing' }
+AsyncFile >> writeable [
+
+	^ writeable
+]
+
+{ #category : 'accessing' }
+AsyncFile >> writeable: anObject [
+
+	writeable := anObject
 ]

--- a/src/Fonts-Infrastructure/LogicalFontManager.class.st
+++ b/src/Fonts-Infrastructure/LogicalFontManager.class.st
@@ -122,6 +122,18 @@ LogicalFontManager >> bestFontFor: aLogicalFont whenFindingAlternativeIgnoreAll:
 	^nil
 ]
 
+{ #category : 'accessing' }
+LogicalFontManager >> fontProviders [
+
+	^ fontProviders
+]
+
+{ #category : 'accessing' }
+LogicalFontManager >> fontProviders: anObject [
+
+	fontProviders := anObject
+]
+
 { #category : 'initialization' }
 LogicalFontManager >> initialize [
 	super initialize.

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -507,6 +507,12 @@ FormCanvas >> paragraph: para bounds: bounds color: c scale: scale [
 	para displayOn: (self copyClipRect: bounds) using: scanner at: origin+ bounds topLeft
 ]
 
+{ #category : 'accessing' }
+FormCanvas >> port [
+
+	^ port
+]
+
 { #category : 'copying' }
 FormCanvas >> postCopy [
 	"The copy share same underlying Form but with its own grafPort."

--- a/src/FreeType-Graphics/BitBlt.extension.st
+++ b/src/FreeType-Graphics/BitBlt.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : 'BitBlt' }
 
 { #category : '*FreeType-Graphics' }
-BitBlt >> combinationRule [
-	"Answer the receiver's combinationRule"
-
-	^ combinationRule
-]
-
-{ #category : '*FreeType-Graphics' }
 BitBlt >> copyBitsColor: argbColorSmallInteger alpha: argbAlphaSmallInteger gammaTable: gammaByteArray ungammaTable: ungammaByteArray [
 	"This entry point to BitBlt supplies an extra argument to specify the fore color
 	argb value for operation 41. This is split into an alpha value and an rgb value,

--- a/src/FreeType-Tests/LogicalFontManager.extension.st
+++ b/src/FreeType-Tests/LogicalFontManager.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'LogicalFontManager' }
 
 { #category : '*FreeType-Tests' }
 LogicalFontManager >> identityIncludesFontProvider: aFreeTypeFontProvider [
-	^ fontProviders identityIncludes: aFreeTypeFontProvider
+
+	^ self fontProviders identityIncludes: aFreeTypeFontProvider
 ]

--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -198,6 +198,12 @@ FreeTypeFontProvider >> fontInfoFor: aLogicalFont familyName: familyName [
 	^member fileInfo
 ]
 
+{ #category : 'accessing' }
+FreeTypeFontProvider >> fontInstallers [
+
+	^ fontInstallers
+]
+
 { #category : 'file paths' }
 FreeTypeFontProvider >> getWindowsFontFolderPath [
 	"Answer the windows font folder path.

--- a/src/Fuel-Core-Tests/BlockClosure.extension.st
+++ b/src/Fuel-Core-Tests/BlockClosure.extension.st
@@ -8,16 +8,13 @@ BlockClosure >> assertWellMaterializedInto: aBlockClosure in: aTestCase [
 	aTestCase assert: self numArgs = aBlockClosure numArgs.
 	aTestCase assert: self startpcOrOuterCode = aBlockClosure startpcOrOuterCode.
 
-	outerContext
-		ifNil: [ self assert: aBlockClosure outerContext isNil ]
-		ifNotNil: [ self isClean
+	self outerContext ifNil: [ self assert: aBlockClosure outerContext isNil ] ifNotNil: [
+			self isClean
 				ifTrue: [ "self assert: self receiver = aBlockClosure receiver."
-					self assert: ( self method isEqualRegardlessTrailerTo: aBlockClosure method ).
-					self assert: aBlockClosure outerContext sender isNil.
-					self assert: aBlockClosure outerContext arguments isEmpty
-					]
-				ifFalse: [ outerContext assertWellMaterializedInto: aBlockClosure outerContext in: aTestCase ]
-			]
+						self assert: (self method isEqualRegardlessTrailerTo: aBlockClosure method).
+						self assert: aBlockClosure outerContext sender isNil.
+						self assert: aBlockClosure outerContext arguments isEmpty ]
+				ifFalse: [ self outerContext assertWellMaterializedInto: aBlockClosure outerContext in: aTestCase ] ]
 ]
 
 { #category : '*Fuel-Core-Tests' }

--- a/src/Fuel-Core-Tests/Context.extension.st
+++ b/src/Fuel-Core-Tests/Context.extension.st
@@ -6,16 +6,16 @@ Context >> assertWellMaterializedInto: aMethodContext in: aTestCase [
 	aTestCase assert: self ~~ aMethodContext.
 	aTestCase assert: self class == aMethodContext class.
 	aTestCase assert: self temporaryVariableNames = aMethodContext temporaryVariableNames.
-	aTestCase assert: pc = aMethodContext pc.
-	aTestCase assert: stackp = aMethodContext stackPtr.
-	closureOrNil
+	aTestCase assert: self pc = aMethodContext pc.
+	aTestCase assert: self stackp = aMethodContext stackPtr.
+	self closure
 		ifNil: [ aTestCase assert: aMethodContext closure isNil ]
-		ifNotNil: [ closureOrNil assertWellMaterializedInto: aMethodContext closure in: aTestCase ].
-	aTestCase assert: receiver = aMethodContext receiver.
-	aTestCase assert: (method isEqualRegardlessTrailerTo: aMethodContext compiledCode).
-	sender
+		ifNotNil: [ self closure assertWellMaterializedInto: aMethodContext closure in: aTestCase ].
+	aTestCase assert: self receiver = aMethodContext receiver.
+	aTestCase assert: (self method isEqualRegardlessTrailerTo: aMethodContext compiledCode).
+	self sender
 		ifNil: [ aTestCase assert: aMethodContext sender isNil ]
-		ifNotNil: [ sender assertWellMaterializedInto: aMethodContext sender in: aTestCase ]
+		ifNotNil: [ self sender assertWellMaterializedInto: aMethodContext sender in: aTestCase ]
 ]
 
 { #category : '*Fuel-Core-Tests' }

--- a/src/Fuel-Core/BlockClosure.extension.st
+++ b/src/Fuel-Core/BlockClosure.extension.st
@@ -13,7 +13,7 @@ BlockClosure >> cleanCopy [
 BlockClosure >> cleanOuterContext [
 	"Clean my outerContext preserving just the receiver and method, which are the only needed by a clean block closure. outerContext can already be nil if the block was compiled without context"
 
-	outerContext ifNotNil: [ outerContext := outerContext cleanCopy ]
+	self outerContext ifNotNil: [ self outerContext: self outerContext cleanCopy ]
 ]
 
 { #category : '*Fuel-Core' }

--- a/src/Fuel-Core/Class.extension.st
+++ b/src/Fuel-Core/Class.extension.st
@@ -1,38 +1,6 @@
 Extension { #name : 'Class' }
 
 { #category : '*Fuel-Core' }
-Class >> basicClassPool [
-	"Answer nil or the dictionary of class variables."
-
-	^classPool
-]
-
-{ #category : '*Fuel-Core' }
-Class >> basicEnvironment [
-
-	^ environment
-]
-
-{ #category : '*Fuel-Core' }
-Class >> basicSharedPools [
-	"Answer nil or a Set of the pool dictionaries declared in the receiver."
-
-	^sharedPools
-]
-
-{ #category : '*Fuel-Core' }
-Class >> basicSubclasses [
-
-	^ subclasses
-]
-
-{ #category : '*Fuel-Core' }
-Class >> basicSubclasses: anArray [
-
-	subclasses := anArray
-]
-
-{ #category : '*Fuel-Core' }
 Class >> fuelAccept: aGeneralMapper [
 
 	^aGeneralMapper visitClass: self

--- a/src/Fuel-Core/Context.extension.st
+++ b/src/Fuel-Core/Context.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : 'Context' }
 
 { #category : '*Fuel-Core' }
-Context >> cleanCopy [ 
+Context >> cleanCopy [
 
-	^ self class 
-		sender: nil 
-		receiver: receiver 
-		method: method
-		arguments: #()
+	^ self class
+		  sender: nil
+		  receiver: self receiver
+		  method: self method
+		  arguments: #(  )
 ]
 
 { #category : '*Fuel-Core' }

--- a/src/Fuel-Core/PositionableStream.extension.st
+++ b/src/Fuel-Core/PositionableStream.extension.st
@@ -1,30 +1,32 @@
 Extension { #name : 'PositionableStream' }
 
 { #category : '*Fuel-Core' }
-PositionableStream >> fuelNextWordsInto: aWordObject [ 
+PositionableStream >> fuelNextWordsInto: aWordObject [
 	"This method is the same as nextWordsInto: but the restoreEndianness is only done if needed"
+
 	| blt pos source byteSize |
 	byteSize := aWordObject byteSize.
-	
-	((self position bitAnd: 3) = 0 and: [ (collection basicSize bitAnd: 3) = 0])
-		ifTrue: [source := collection.
-			pos := self position.
-			self skip: byteSize]
-		ifFalse: ["forced to copy it into a buffer"
-			source := self next: byteSize.
-			pos := 0].
+
+	((self position bitAnd: 3) = 0 and: [ (self collection basicSize bitAnd: 3) = 0 ])
+		ifTrue: [
+				source := self collection.
+				pos := self position.
+				self skip: byteSize ]
+		ifFalse: [ "forced to copy it into a buffer"
+				source := self next: byteSize.
+				pos := 0 ].
 
 	"Now use BitBlt to copy the bytes to the bitmap."
-	blt := (BitBlt
-				toForm: (Form new hackBits: aWordObject))
-				sourceForm: (Form new hackBits: source).
+	blt := (BitBlt toForm: (Form new hackBits: aWordObject)) sourceForm: (Form new hackBits: source).
 	blt combinationRule: Form over. "store"
-	blt sourceX: 0;
-		 sourceY: pos // 4;
-		 height: byteSize // 4;
-		 width: 4.
-	blt destX: 0;
-		 destY: 0.
+	blt
+		sourceX: 0;
+		sourceY: pos // 4;
+		height: byteSize // 4;
+		width: 4.
+	blt
+		destX: 0;
+		destY: 0.
 	blt copyBits.
 
 	^ aWordObject

--- a/src/Fuel-Core/Rectangle.extension.st
+++ b/src/Fuel-Core/Rectangle.extension.st
@@ -10,6 +10,7 @@ Rectangle >> fuelAccept: aGeneralMapper [
 
 { #category : '*Fuel-Core' }
 Rectangle >> fuelSetOrigin: originPoint corner: cornerPoint [
-	origin := originPoint.
-	corner := cornerPoint
+
+	self origin: originPoint.
+	self corner: cornerPoint
 ]

--- a/src/Fuel-Core/Set.extension.st
+++ b/src/Fuel-Core/Set.extension.st
@@ -7,7 +7,7 @@ Set >> addIfNotPresent: anObject ifPresentDo: aBlock [
 
 	| index |
 	index := self scanFor: anObject.
-	(array at: index) 
+self array at: index
 		ifNil: [self atNewIndex: index put: anObject asCollectionElement]
 		ifNotNil: [ aBlock value ].
 	^ anObject

--- a/src/Fuel-Core/Set.extension.st
+++ b/src/Fuel-Core/Set.extension.st
@@ -7,7 +7,7 @@ Set >> addIfNotPresent: anObject ifPresentDo: aBlock [
 
 	| index |
 	index := self scanFor: anObject.
-self array at: index
+	(self array at: index)
 		ifNil: [self atNewIndex: index put: anObject asCollectionElement]
 		ifNotNil: [ aBlock value ].
 	^ anObject

--- a/src/Fuel-Core/TraitedMetaclass.extension.st
+++ b/src/Fuel-Core/TraitedMetaclass.extension.st
@@ -9,10 +9,12 @@ TraitedMetaclass >> fuelAccept: aGeneralMapper [
 TraitedMetaclass >> fuelSetTraitComposition: aTraitComposition [
 	"prevent checks while the composition hasn't been
 	fully materialized yet"
-	composition := aTraitComposition
+
+	self composition: aTraitComposition
 ]
 
 { #category : '*Fuel-Core' }
 TraitedMetaclass >> localMethodDict: aMethodDictionary [
-	localMethods := aMethodDictionary
+
+	self localMethods: aMethodDictionary
 ]

--- a/src/Fuel-Core/WeakKeyAssociation.extension.st
+++ b/src/Fuel-Core/WeakKeyAssociation.extension.st
@@ -8,5 +8,6 @@ WeakKeyAssociation >> fuelCheckEphemeronSupport [
 
 { #category : '*Fuel-Core' }
 WeakKeyAssociation >> fuelWasMourned [
-	^ (self container includesKey: key) not
+
+	^ (self container includesKey: self key) not
 ]

--- a/src/Fuel-Core/WriteStream.extension.st
+++ b/src/Fuel-Core/WriteStream.extension.st
@@ -4,17 +4,19 @@ Extension { #name : 'WriteStream' }
 WriteStream >> nextBytesPutAll: aCollection [
 	"Append the bytes of aCollection to the sequence of bytes accessible 
 	by the receiver. Answer aCollection."
- 
- 	| newEnd |
- 	collection class instSpec == aCollection class instSpec ifFalse:
- 		[^ super nextPutAll: aCollection ].
- 
- 	newEnd := position + aCollection size.
- 	newEnd > writeLimit ifTrue:
- 		[self growTo: newEnd + 10].
- 
- 	collection replaceFrom: position+1 to: newEnd  with: aCollection startingAt: 1.
- 	position := newEnd.
-	
+
+	| newEnd |
+	self collection class instSpec == aCollection class instSpec ifFalse: [ ^ super nextPutAll: aCollection ].
+
+	newEnd := self position + aCollection size.
+	newEnd > self writeLimit ifTrue: [ self growTo: newEnd + 10 ].
+
+	self collection
+		replaceFrom: self position + 1
+		to: newEnd
+		with: aCollection
+		startingAt: 1.
+	self position: newEnd.
+
 	^ aCollection
 ]

--- a/src/Graphics-Canvas/ColorMappingCanvas.class.st
+++ b/src/Graphics-Canvas/ColorMappingCanvas.class.st
@@ -156,6 +156,18 @@ ColorMappingCanvas >> mapColor: aColor [
 	^aColor
 ]
 
+{ #category : 'accessing' }
+ColorMappingCanvas >> myCanvas [
+
+	^ myCanvas
+]
+
+{ #category : 'accessing' }
+ColorMappingCanvas >> myCanvas: anObject [
+
+	myCanvas := anObject
+]
+
 { #category : 'initialization' }
 ColorMappingCanvas >> on: aCanvas [
 	myCanvas := aCanvas

--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -425,6 +425,18 @@ Form >> balancedPatternFor: aColor depth: aDepth [
 		with: mask1 * pv3 + (mask2 * pv1)
 ]
 
+{ #category : 'accessing' }
+Form >> basicDepth [
+
+	^ depth
+]
+
+{ #category : 'accessing' }
+Form >> basicDepth: anObject [
+
+	depth := anObject
+]
+
 { #category : 'color mapping' }
 Form >> bitPatternFor: aColor [
 	"Return the pixel word for representing the given color on the receiver"
@@ -1295,6 +1307,12 @@ Form >> hasBeenModified: aBool [
 { #category : 'accessing' }
 Form >> height [
 	^ height
+]
+
+{ #category : 'accessing' }
+Form >> height: anObject [
+
+	height := anObject
 ]
 
 { #category : 'file in/out' }
@@ -2383,6 +2401,12 @@ Form >> veryDeepCopyWith: deepCopier [
 { #category : 'accessing' }
 Form >> width [
 	^ width
+]
+
+{ #category : 'accessing' }
+Form >> width: anObject [
+
+	width := anObject
 ]
 
 { #category : 'transitions' }

--- a/src/Graphics-Files/Form.extension.st
+++ b/src/Graphics-Files/Form.extension.st
@@ -53,31 +53,21 @@ Form >> readResourceFrom: aStream [
 	Must be specific to the receiver so that no code is filed out."
 
 	| bitsSize msb |
-	(aStream next: 4) asString = self resourceTag
-		ifFalse:
-			[aStream position: aStream position - 4.
-			^self readNativeResourceFrom: aStream].
-	width := aStream nextNumber: 4.
-	height := aStream nextNumber: 4.
-	depth := aStream nextNumber: 4.
+	(aStream next: 4) asString = self resourceTag ifFalse: [
+			aStream position: aStream position - 4.
+			^ self readNativeResourceFrom: aStream ].
+	self width: (aStream nextNumber: 4).
+	self height: (aStream nextNumber: 4).
+	self basicDepth: (aStream nextNumber: 4).
 	bitsSize := aStream nextNumber: 4.
-	bitsSize = 0
-		ifFalse:
-			[bits := aStream next: bitsSize.
-			^self].
+	bitsSize = 0 ifFalse: [
+			self bits: (aStream next: bitsSize).
+			^ self ].
 	msb := (aStream nextNumber: 4) = 1.
 	bitsSize := aStream nextNumber: 4.
-	bits := Bitmap new: self bitsSize.
-	(Form
-		extent: width @ height
-		depth: depth
-		bits: (aStream next: bitsSize * 4)) displayOn: self.
-	msb = EndianDetector isBigEndian
-		ifFalse:
-			[Bitmap
-				swapBytesIn: bits
-				from: 1
-				to: bits size]
+	self bits: (Bitmap new: self bitsSize).
+	(Form extent: self width @ self height depth: self basicDepth bits: (aStream next: bitsSize * 4)) displayOn: self.
+	msb = EndianDetector isBigEndian ifFalse: [ Bitmap swapBytesIn: self bits from: 1 to: self bits size ]
 ]
 
 { #category : '*Graphics-Files' }
@@ -89,17 +79,19 @@ Form >> resourceTag [
 Form >> storeResourceOn: aStream [
 	"Store a resource representation of the receiver on aStream.
 	Must be specific to the receiver so that no code is filed out."
+
 	self hibernate.
 	aStream nextPutAll: self resourceTag asByteArray. "tag"
-	aStream nextNumber: 4 put: width.
-	aStream nextNumber: 4 put: height.
-	aStream nextNumber: 4 put: depth.
-	(bits isMemberOf: ByteArray) ifFalse:
-		"must store bitmap"
-		[aStream nextNumber: 4 put: 0. "tag"
-		aStream nextNumber: 4 put: (EndianDetector isBigEndian ifTrue:[1] ifFalse: [0])].
-	aStream nextNumber: 4 put: bits size.
-	aStream nextPutAll: bits
+	aStream nextNumber: 4 put: self width.
+	aStream nextNumber: 4 put: self height.
+	aStream nextNumber: 4 put: self basicDepth.
+	(self bits isMemberOf: ByteArray) ifFalse: [ "must store bitmap"
+			aStream nextNumber: 4 put: 0. "tag"
+			aStream nextNumber: 4 put: (EndianDetector isBigEndian
+					 ifTrue: [ 1 ]
+					 ifFalse: [ 0 ]) ].
+	aStream nextNumber: 4 put: self bits size.
+	aStream nextPutAll: self bits
 ]
 
 { #category : '*Graphics-Files' }
@@ -134,8 +126,9 @@ Form fromUser writeJPEGfileNamed: 'yourPatch.jpeg' progressive: true
 { #category : '*Graphics-Files' }
 Form >> writeOnMovie: file [
 	"Write just my bits on the file."
+
 	self unhibernate.
-	bits writeUncompressedOn: file
+	self bits writeUncompressedOn: file
 ]
 
 { #category : '*Graphics-Files' }

--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -4,21 +4,23 @@ Extension { #name : 'BitBlt' }
 BitBlt >> basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale [
 
 	| xTable |
-
-	destY := aPoint y.
-	destX := aPoint x.
+	self destY: aPoint y.
+	self destX: aPoint x.
 
 	"the following are not really needed, but theBitBlt primitive will fail if not set"
-	sourceX ifNil: [sourceX := 100].
-	width ifNil: [width := 100].
+	self sourceX ifNil: [ self sourceX: 100 ].
+	self width ifNil: [ self width: 100 ].
 	xTable := font xTable.
-	scale = 1 ifFalse: [
-		xTable := xTable collect: [ :x | x * scale ] ].
+	scale = 1 ifFalse: [ xTable := xTable collect: [ :x | x * scale ] ].
 
-	self primDisplayString: aString from: startIndex to: stopIndex
-			map: font characterToGlyphMap xTable: xTable
-			kern: kernDelta * scale.
-	^ destX@destY
+	self
+		primDisplayString: aString
+		from: startIndex
+		to: stopIndex
+		map: font characterToGlyphMap
+		xTable: xTable
+		kern: kernDelta * scale.
+	^ self destX @ self destY
 ]
 
 { #category : '*Graphics-Fonts' }
@@ -56,21 +58,42 @@ BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint strik
 	| answer prevRule secondPassMap |
 	"If combinationRule is rgbMul, we might need the special two-pass technique for component alpha blending.
 	If not, do it simply"
-	combinationRule = 37 "rgbMul" ifFalse: [
-		^self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale ].
+	self combinationRule = 37 ifFalse: [
+			^ self
+				  basicDisplayString: aString
+				  from: startIndex
+				  to: stopIndex
+				  at: aPoint
+				  strikeFont: font
+				  kern: kernDelta
+				  scale: scale ]. "rgbMul"
 
 	"We need to do a second pass. The colormap set is for use in the second pass."
-	secondPassMap := colorMap.
-	colorMap := sourceForm depth ~= destForm depth
-		ifTrue: [ self cachedFontColormapFrom: sourceForm depth to: destForm depth ].
-	answer := self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale.
-	colorMap := secondPassMap.
+	secondPassMap := self colorMap.
+	self colorMap: (self sourceForm depth ~= self destForm depth ifTrue: [
+			 self cachedFontColormapFrom: self sourceForm depth to: self destForm depth ]).
+	answer := self
+		          basicDisplayString: aString
+		          from: startIndex
+		          to: stopIndex
+		          at: aPoint
+		          strikeFont: font
+		          kern: kernDelta
+		          scale: scale.
+	self colorMap: secondPassMap.
 	secondPassMap ifNotNil: [
-		prevRule := combinationRule.
-		combinationRule := 20. "rgbAdd"
-		self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale.
-		combinationRule := prevRule ].
-	^answer
+			prevRule := self combinationRule.
+			self combinationRule: 20. "rgbAdd"
+			self
+				basicDisplayString: aString
+				from: startIndex
+				to: stopIndex
+				at: aPoint
+				strikeFont: font
+				kern: kernDelta
+				scale: scale.
+			self combinationRule: prevRule ].
+	^ answer
 ]
 
 { #category : '*Graphics-Fonts' }
@@ -81,39 +104,42 @@ BitBlt >> installFont: aFont foregroundColor: foregroundColor backgroundColor: b
 
 { #category : '*Graphics-Fonts' }
 BitBlt >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
+
 	| lastSourceDepth targetColor |
-	sourceForm ifNotNil:[lastSourceDepth := sourceForm depth].
-	sourceForm := aStrikeFont glyphs.
-	scale = 1 ifFalse: [
-		sourceForm := sourceForm scaledToSize: sourceForm extent * scale ].
+	self sourceForm ifNotNil: [ lastSourceDepth := self sourceForm depth ].
+	self sourceForm: aStrikeFont glyphs.
+	scale = 1 ifFalse: [ self sourceForm: (self sourceForm scaledToSize: self sourceForm extent * scale) ].
 
 	"Ignore any halftone pattern since we use a color map approach here"
-	halftoneForm := nil.
-	sourceY := 0.
-	height := aStrikeFont height * scale.
+	self halftoneForm: nil.
+	self sourceY: 0.
+	self height: aStrikeFont height * scale.
 
-	sourceForm depth = 1 ifTrue: [
-		self combinationRule: Form paint.
-		(colorMap isNotNil and:[lastSourceDepth = sourceForm depth]) ifFalse: [
-			"Set up color map for a different source depth (color font)"
-			"Uses caching for reasonable efficiency"
-			colorMap := self cachedFontColormapFrom: sourceForm depth to: destForm depth.
-			colorMap at: 1 put: (destForm pixelValueFor: backgroundColor)].
-		colorMap at: 2 put: (destForm pixelValueFor: foregroundColor).
-	]
-	ifFalse: [
-			destForm depth > 8 ifTrue: [
-				"rgbMul is equivalent to component alpha blend if text is black (only faster, hehe)"
-				self combinationRule: 37.		"RGBMul"
-				colorMap := (destForm depth = 32 or: [ (foregroundColor = Color black) not ]) ifTrue: [
-					"rgbMul / rgbAdd IS component alpha blend for any color of text (neat trick, eh!)"
-					"This colorMap is to be used on the second pass with rule 20 (rgbAdd)
-					See #displayString:from:to:at:strikeFont:kern:"
-					"Note: In 32bpp we always need the second pass, as the source could have transparent pixels, and we need to add to the alpha channel"
-					self colorConvertingMap: foregroundColor from: sourceForm depth to: destForm depth keepSubPixelAA: true]]
-			ifFalse: [
-				self combinationRule: 25.		"Paint"
-				targetColor := foregroundColor = Color black ifFalse: [ foregroundColor ].
-				colorMap := self colorConvertingMap: targetColor from: sourceForm depth to: destForm depth keepSubPixelAA: true]
-		]
+	self sourceForm depth = 1
+		ifTrue: [
+				self combinationRule: Form paint.
+				(self colorMap isNotNil and: [ lastSourceDepth = self sourceForm depth ]) ifFalse: [ "Set up color map for a different source depth (color font)""Uses caching for reasonable efficiency"
+						self colorMap: (self cachedFontColormapFrom: self sourceForm depth to: self destForm depth).
+						self colorMap at: 1 put: (self destForm pixelValueFor: backgroundColor) ].
+				self colorMap at: 2 put: (self destForm pixelValueFor: foregroundColor) ]
+		ifFalse: [
+				self destForm depth > 8
+					ifTrue: [ "rgbMul is equivalent to component alpha blend if text is black (only faster, hehe)"
+							self combinationRule: 37. "RGBMul"
+							self colorMap:
+								((self destForm depth = 32 or: [ (foregroundColor = Color black) not ]) ifTrue: [ "rgbMul / rgbAdd IS component alpha blend for any color of text (neat trick, eh!)""This colorMap is to be used on the second pass with rule 20 (rgbAdd)
+					See #displayString:from:to:at:strikeFont:kern:""Note: In 32bpp we always need the second pass, as the source could have transparent pixels, and we need to add to the alpha channel"
+										 self
+											 colorConvertingMap: foregroundColor
+											 from: self sourceForm depth
+											 to: self destForm depth
+											 keepSubPixelAA: true ]) ]
+					ifFalse: [
+							self combinationRule: 25. "Paint"
+							targetColor := foregroundColor = Color black ifFalse: [ foregroundColor ].
+							self colorMap: (self
+									 colorConvertingMap: targetColor
+									 from: self sourceForm depth
+									 to: self destForm depth
+									 keepSubPixelAA: true) ] ]
 ]

--- a/src/Graphics-Fonts/GrafPort.extension.st
+++ b/src/Graphics-Fonts/GrafPort.extension.st
@@ -2,30 +2,28 @@ Extension { #name : 'GrafPort' }
 
 { #category : '*Graphics-Fonts' }
 GrafPort >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
-	super installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale.
+
+	super
+		installStrikeFont: aStrikeFont
+		foregroundColor: foregroundColor
+		backgroundColor: backgroundColor
+		scale: scale.
 	aStrikeFont glyphs depth = 1 ifTrue: [
-		alpha := foregroundColor privateAlpha.
-		"dynamically switch between blend modes to support translucent text"
-		"To handle the transition from TTCFont to StrikeFont, rule 34 must be taken into account."
-		alpha = 255 ifTrue:[
-			combinationRule = 30 ifTrue: [combinationRule := Form over].
-			combinationRule = 31 ifTrue: [combinationRule := Form paint].
-			combinationRule = 34 ifTrue: [combinationRule := Form paint].
-			combinationRule = 41 ifTrue: [combinationRule := Form paint]. "41 is  SPRmode"
-		] ifFalse:[
-			combinationRule = Form over ifTrue: [combinationRule := 30].
-			combinationRule = Form paint ifTrue: [combinationRule := 31].
-			combinationRule = 34 ifTrue: [combinationRule := 31].
-			combinationRule = 41 ifTrue: [combinationRule := 31]. "41 is SPR mode"
-		]
-	].
-	lastFont := aStrikeFont.
-	lastFontForegroundColor := foregroundColor.
-	lastFontBackgroundColor := backgroundColor
-]
-
-{ #category : '*Graphics-Fonts' }
-GrafPort >> lastFont [
-
-	^ lastFont
+			self alpha: foregroundColor privateAlpha.
+			"dynamically switch between blend modes to support translucent text"
+			"To handle the transition from TTCFont to StrikeFont, rule 34 must be taken into account."
+			self alpha = 255
+				ifTrue: [
+						self combinationRule = 30 ifTrue: [ self combinationRule: Form over ].
+						self combinationRule = 31 ifTrue: [ self combinationRule: Form paint ].
+						self combinationRule = 34 ifTrue: [ self combinationRule: Form paint ].
+						self combinationRule = 41 ifTrue: [ self combinationRule: Form paint ] "41 is  SPRmode" ]
+				ifFalse: [
+						self combinationRule = Form over ifTrue: [ self combinationRule: 30 ].
+						self combinationRule = Form paint ifTrue: [ self combinationRule: 31 ].
+						self combinationRule = 34 ifTrue: [ self combinationRule: 31 ].
+						self combinationRule = 41 ifTrue: [ self combinationRule: 31 ] "41 is SPR mode" ] ].
+	self lastFont: aStrikeFont.
+	self lastFontForegroundColor: foregroundColor.
+	self lastFontBackgroundColor: backgroundColor
 ]

--- a/src/Graphics-Primitives/BitBlt.class.st
+++ b/src/Graphics-Primitives/BitBlt.class.st
@@ -370,6 +370,13 @@ BitBlt >> colorMap: map [
 ]
 
 { #category : 'accessing' }
+BitBlt >> combinationRule [
+	"Answer the receiver's combinationRule"
+
+	^ combinationRule
+]
+
+{ #category : 'accessing' }
 BitBlt >> combinationRule: anInteger [
 	"Set the receiver's combination rule to be the argument, anInteger, a
 	number in the range 0-15."
@@ -585,6 +592,12 @@ BitBlt >> destForm [
 ]
 
 { #category : 'accessing' }
+BitBlt >> destForm: anObject [
+
+	destForm := anObject
+]
+
+{ #category : 'accessing' }
 BitBlt >> destOrigin: aPoint [
 	"Set the receiver's destination top left coordinates to be those of the
 	argument, aPoint."
@@ -611,6 +624,12 @@ BitBlt >> destRect: aRectangle [
 ]
 
 { #category : 'accessing' }
+BitBlt >> destX [
+
+	^ destX
+]
+
+{ #category : 'accessing' }
 BitBlt >> destX: anInteger [
 	"Set the top left x coordinate of the receiver's destination form to be the
 	argument, anInteger."
@@ -624,6 +643,12 @@ BitBlt >> destX: x destY: y width: w height: h [
 	destY := y.
 	width := w.
 	height := h
+]
+
+{ #category : 'accessing' }
+BitBlt >> destY [
+
+	^ destY
 ]
 
 { #category : 'accessing' }
@@ -786,6 +811,12 @@ BitBlt >> halftoneForm: aBitmap [
 	"Sets the receivers half tone form. See class commment."
 
 	halftoneForm := aBitmap
+]
+
+{ #category : 'accessing' }
+BitBlt >> height [
+
+	^ height
 ]
 
 { #category : 'accessing' }
@@ -980,9 +1011,21 @@ BitBlt >> sourceRect: aRectangle [
 ]
 
 { #category : 'accessing' }
+BitBlt >> sourceX [
+
+	^ sourceX
+]
+
+{ #category : 'accessing' }
 BitBlt >> sourceX: anInteger [
 	"Set the receiver's source form top left x to be the argument, anInteger."
 	sourceX := anInteger
+]
+
+{ #category : 'accessing' }
+BitBlt >> sourceY [
+
+	^ sourceY
 ]
 
 { #category : 'accessing' }
@@ -1001,6 +1044,12 @@ BitBlt >> tallyMap [
 BitBlt >> tallyMap: aBitmap [
 	"Install the map used for tallying pixels"
 	colorMap := aBitmap
+]
+
+{ #category : 'accessing' }
+BitBlt >> width [
+
+	^ width
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Primitives/GrafPort.class.st
+++ b/src/Graphics-Primitives/GrafPort.class.st
@@ -17,6 +17,18 @@ Class {
 }
 
 { #category : 'accessing' }
+GrafPort >> alpha [
+
+	^ alpha
+]
+
+{ #category : 'accessing' }
+GrafPort >> alpha: anObject [
+
+	alpha := anObject
+]
+
+{ #category : 'accessing' }
 GrafPort >> alphaBits: a [
 	alpha := a
 ]
@@ -205,8 +217,32 @@ GrafPort >> image: aForm at: aPoint sourceRect: sourceRect rule: rule alpha: sou
 ]
 
 { #category : 'accessing' }
+GrafPort >> lastFont [
+
+	^ lastFont
+]
+
+{ #category : 'accessing' }
+GrafPort >> lastFont: anObject [
+
+	lastFont := anObject
+]
+
+{ #category : 'accessing' }
+GrafPort >> lastFontBackgroundColor: anObject [
+
+	lastFontBackgroundColor := anObject
+]
+
+{ #category : 'accessing' }
 GrafPort >> lastFontForegroundColor [
 	^lastFontForegroundColor
+]
+
+{ #category : 'accessing' }
+GrafPort >> lastFontForegroundColor: anObject [
+
+	lastFontForegroundColor := anObject
 ]
 
 { #category : 'drawing support' }

--- a/src/Growl/UITheme.extension.st
+++ b/src/Growl/UITheme.extension.st
@@ -9,7 +9,7 @@ UITheme >> growlBorderColorFor: aGrowlMorph [
 { #category : '*Growl' }
 UITheme >> growlContentsColorFor: aGrowlMorph [
 
-	^ colorPalette growlContentsColorFor: aGrowlMorph
+	^ self colorPalette growlContentsColorFor: aGrowlMorph
 ]
 
 { #category : '*Growl' }

--- a/src/Growl/UIThemePalette.extension.st
+++ b/src/Growl/UIThemePalette.extension.st
@@ -3,6 +3,5 @@ Extension { #name : 'UIThemePalette' }
 { #category : '*Growl' }
 UIThemePalette >> growlContentsColorFor: aGrowlMorph [
 
-	^ paletteDictionary at: #growlContentsColorFor:
-		  ifAbsentPut: [ colorConfigurator growlContentsColorFor: aGrowlMorph ]
+	^ self paletteDictionary at: #growlContentsColorFor: ifAbsentPut: [ self colorConfigurator growlContentsColorFor: aGrowlMorph ]
 ]

--- a/src/Kernel-BytecodeEncoders/InstructionStream.extension.st
+++ b/src/Kernel-BytecodeEncoders/InstructionStream.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'InstructionStream' }
 InstructionStream >> secondByte [
 	"Answer the second byte of the current bytecode."
 
-	^self method at: pc + 1
+	^ self method at: self pc + 1
 ]
 
 { #category : '*Kernel-BytecodeEncoders' }

--- a/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
@@ -462,3 +462,11 @@ ExtensionTest >> test20CleanExtendedBehaviorsCleansAliases [
 
 	self deny: (scopedSelector extendedBehaviors includes: objectClass)
 ]
+
+{ #category : 'tests - runtime' }
+ExtensionTest >> test21ExtensionMethodCanNotAccessInstanceVariable [
+
+	pointClass addInstVarNamed: 'x'.
+
+	self should: [ self compile: 'getX ^ x' on: extensionOnPoint ] raise: OCCompilationError
+]

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -190,6 +190,13 @@ Class >> allSharedPools [
 			aSet addAll: self sharedPools; yourself]
 ]
 
+{ #category : 'accessing' }
+Class >> basicClassPool [
+	"Answer nil or the dictionary of class variables."
+
+	^classPool
+]
+
 { #category : 'class variables' }
 Class >> basicDeclareClassVariable: aClassVariable [
 	"Add aClassVariable to the receiver. Two cases are handled here:
@@ -214,6 +221,31 @@ Class >> basicDeclareClassVariable: aClassVariable [
 		self undeclaredRegistry removeKey: existingVar name.
 		existingVar becomeForward: aClassVariable ].
 	self classPool add: aClassVariable
+]
+
+{ #category : 'accessing' }
+Class >> basicEnvironment [
+
+	^ environment
+]
+
+{ #category : 'accessing' }
+Class >> basicSharedPools [
+	"Answer nil or a Set of the pool dictionaries declared in the receiver."
+
+	^sharedPools
+]
+
+{ #category : 'accessing' }
+Class >> basicSubclasses [
+
+	^ subclasses
+]
+
+{ #category : 'accessing' }
+Class >> basicSubclasses: anArray [
+
+	subclasses := anArray
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -1927,6 +1927,12 @@ Context >> stackTraceString [
 ]
 
 { #category : 'private' }
+Context >> stackp [
+
+	^ stackp
+]
+
+{ #category : 'private' }
 Context >> stackp: newStackp [
 	"Storing into the stack pointer is a potentially dangerous thing.
 	This primitive stores nil into any cells that become accessible as a result,

--- a/src/Kernel-CodeModel/Extension.class.st
+++ b/src/Kernel-CodeModel/Extension.class.st
@@ -91,13 +91,19 @@ Extension >> removeFromSystem: logged [
 
 { #category : 'accessing - method dictionary' }
 Extension >> removeSelector: aSelector logged: logged [
+	"System usually request method removal using a Symbol. However, with the conch system, the actual key in the method dictionary might be a ScopedSelector. 
+	We must translate the symbol to its scoped equivalent (if needed) to prevent a KeyNotFound error in the super call"
 
-	super removeSelector: aSelector logged: logged.
-	
+	| targetSelector |
+	targetSelector := (self methodDict includesKey: aSelector)
+		                  ifTrue: [ aSelector ]
+		                  ifFalse: [ self package visibleSelectorForSymbol: aSelector asSymbol ].
+
+	super removeSelector: targetSelector logged: logged.
+
 	"In some tests we removed the extension method by hand, breaking some invariants.
 	We should take a look a that"
-	(extendedClass includesSelector: aSelector)
-		ifTrue: [ extendedClass removeMethod: (extendedClass >> aSelector) ]
+	(extendedClass includesSelector: aSelector) ifTrue: [ extendedClass removeMethod: extendedClass >> aSelector ]
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/Extension.class.st
+++ b/src/Kernel-CodeModel/Extension.class.st
@@ -5,10 +5,25 @@ Class {
 		'extendedClass',
 		'userPackages'
 	],
+	#classInstVars : [
+		'AllowMigration'
+	],
 	#category : 'Kernel-CodeModel-Extensions',
 	#package : 'Kernel-CodeModel',
 	#tag : 'Extensions'
 }
+
+{ #category : 'accessing' }
+Extension class >> allowMigration [
+
+	^ AllowMigration ifNil: [ true ]
+]
+
+{ #category : 'accessing' }
+Extension class >> allowMigration: aBoolean [
+
+	^ AllowMigration := aBoolean
+]
 
 { #category : 'accessing' }
 Extension >> addUserPackage: aPackage [

--- a/src/Kernel-CodeModel/Extension.class.st
+++ b/src/Kernel-CodeModel/Extension.class.st
@@ -5,7 +5,7 @@ Class {
 		'extendedClass',
 		'userPackages'
 	],
-	#classInstVars : [
+	#classVars : [
 		'AllowMigration'
 	],
 	#category : 'Kernel-CodeModel-Extensions',

--- a/src/Kernel-CodeModel/OCExtensionMethodInstaller.class.st
+++ b/src/Kernel-CodeModel/OCExtensionMethodInstaller.class.st
@@ -33,6 +33,9 @@ OCExtensionMethodInstaller >> install: method into: extension compiler: compiler
 	literalIndex > 0 ifTrue: [
 		"Then, patching the literal should fix also sends to this selector in the method"
 		method literalAt: literalIndex put: scopedSelector ].
+	"Also set the extension class into the method.
+	The method belongs to the extension and not to the extended class."
+	method methodClass: extension.
 	
 	super install: method into: extension compiler: compiler.
 	

--- a/src/Kernel-CodeModel/OCExtensionMethodInstaller.class.st
+++ b/src/Kernel-CodeModel/OCExtensionMethodInstaller.class.st
@@ -19,7 +19,7 @@ OCExtensionMethodInstaller >> initialize [
 { #category : 'installing' }
 OCExtensionMethodInstaller >> install: method into: extension compiler: compiler [
 
-	| literalIndex scopedSelector visibleExtensions methodCopyInExtendedClass selectorSymbol packagesToRecompile |
+	| literalIndex scopedSelector visibleExtensions methodCopyInExtendedClass selectorSymbol packagesToRecompile existingMethod isLegacyExtension |
 
 	selectorSymbol := method selector.
 	scopedSelector := extension internScopedSelector: selectorSymbol.
@@ -41,13 +41,18 @@ OCExtensionMethodInstaller >> install: method into: extension compiler: compiler
 	
 	"If the extension overwrites a normal method, then install a conflict method"
 	visibleExtensions := scopedSelector extensionsOn: extension extendedClass.
-	methodCopyInExtendedClass := (extension extendedClass methodDictionary includesKey: selectorSymbol)
-		                             ifTrue: [
-				                             ConflictMethod new
-					                             overwrittenSelector: selectorSymbol;
-					                             conflictingClass: extension extendedClass;
-					                             conflictingExtensions: visibleExtensions;
-					                             yourself ]
+	
+	
+	existingMethod := extension extendedClass methodDict at: selectorSymbol ifAbsent: [ nil ].
+	isLegacyExtension := Extension allowMigration and: [existingMethod notNil and: [ existingMethod isExtension ]].
+
+	methodCopyInExtendedClass := ((extension extendedClass methodDictionary includesKey: selectorSymbol) and: [ isLegacyExtension not ])
+    										ifTrue: [ 
+        										ConflictMethod new
+            										overwrittenSelector: selectorSymbol;
+            										conflictingClass: extension extendedClass;
+            										conflictingExtensions: visibleExtensions;
+            										yourself ]
 		                             ifFalse: [
 				                             visibleExtensions size > 1
 					                             ifTrue: [

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -507,16 +507,21 @@ Package >> linesOfCode [
 
 { #category : 'accessing' }
 Package >> methods [
-	"Return all the methods defined in this package. Including extension methods (i.e., methods defined on a class that is not defined by me)"
+	"Return all the methods defined in this package. Including extension methods (i.e., methods defined on a class that is not defined by me)
+	We looking for the method by its symbol first, reaching for the scoped selector if absent. 
+	Ideally, the package system should be unaware of internal scoping mechanisms"
 
 	| methods |
 	methods := OrderedCollection new.
 
-	extensionSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class >> selector ]) ].
+	extensionSelectors keysAndValuesDo: [ :class :selectors |
+			methods addAll:
+				(selectors collect: [ :selector |
+					 class methodDict at: selector ifAbsent: [ class >> (self visibleSelectorForSymbol: selector) ] ]) ].
 	self definedClasses do: [ :class |
-		methods
-			addAll: class definedMethods;
-			addAll: class classSide definedMethods ].
+			methods
+				addAll: class definedMethods;
+				addAll: class classSide definedMethods ].
 
 	^ methods
 ]

--- a/src/Kernel-CodeModel/ScopedSelector.class.st
+++ b/src/Kernel-CodeModel/ScopedSelector.class.st
@@ -78,7 +78,8 @@ ScopedSelector >> bindAliasIn: aClass [
 	existingMethod := aClass methodDict at: self symbol ifAbsent: [ nil ].
 	isLegacyExtension := Extension allowMigration and: [existingMethod notNil and: [ existingMethod isExtension ] ].
 
-	locallyDefined := (aClass includesSelector: self symbol) and: [ isLegacyExtension not ].methodsInConflict := locallyDefined
+	locallyDefined := (aClass includesSelector: self symbol) and: [ isLegacyExtension not ].
+	methodsInConflict := locallyDefined
 		ifTrue: [ 1 ]
 		ifFalse: [ 0 ].
 	methodsInConflict := methodsInConflict + allVisibleExtensionsForThisClass size.

--- a/src/Kernel-CodeModel/ScopedSelector.class.st
+++ b/src/Kernel-CodeModel/ScopedSelector.class.st
@@ -71,12 +71,14 @@ ScopedSelector >> bindAliasIn: aClass [
 	If many extensions are available on the same class, with the same name => conflict.
 	If there is an extension"
 
-	| theAliasedMethod allVisibleExtensionsForThisClass locallyDefined methodsInConflict |
+	| theAliasedMethod allVisibleExtensionsForThisClass locallyDefined methodsInConflict existingMethod isLegacyExtension |
 	allVisibleExtensionsForThisClass := self visibleExtensionsOn: aClass.
 
 	"Prevent conflicts!"
-	locallyDefined := aClass includesSelector: self symbol.
-	methodsInConflict := locallyDefined
+	existingMethod := aClass methodDict at: self symbol ifAbsent: [ nil ].
+	isLegacyExtension := Extension allowMigration and: [existingMethod notNil and: [ existingMethod isExtension ] ].
+
+	locallyDefined := (aClass includesSelector: self symbol) and: [ isLegacyExtension not ].methodsInConflict := locallyDefined
 		ifTrue: [ 1 ]
 		ifFalse: [ 0 ].
 	methodsInConflict := methodsInConflict + allVisibleExtensionsForThisClass size.

--- a/src/Kernel-CodeModel/ScopedSelector.class.st
+++ b/src/Kernel-CodeModel/ScopedSelector.class.st
@@ -208,6 +208,12 @@ ScopedSelector >> keywords [
 ]
 
 { #category : 'accessing' }
+ScopedSelector >> localizedForPresenter: aSpLabelPresenter [
+
+	^ self asString localizedForPresenter: aSpLabelPresenter
+]
+
+{ #category : 'accessing' }
 ScopedSelector >> lookupAliasedMethodOnReceiverClass: aClass [
 
 	^ self lookupAliasedMethodOnReceiverClass: aClass lookupClass: nil

--- a/src/Kernel-Extended-Tests/RecursionStopperTest.extension.st
+++ b/src/Kernel-Extended-Tests/RecursionStopperTest.extension.st
@@ -5,5 +5,5 @@ RecursionStopperTest >> testThreadSafe [
 
 	self threadSafe.
 
-	self assert: fork isNil
+	self assert: self fork isNil
 ]

--- a/src/Kernel-Tests-WithCompiler/DateTest.extension.st
+++ b/src/Kernel-Tests-WithCompiler/DateTest.extension.st
@@ -5,8 +5,8 @@ DateTest >> testStoring [
 
 	| expected actual |
 	expected := '''2 June 1973'' asDate'.
-	actual := june2nd1973 storeString.
+	actual := self june2nd1973 storeString.
 	self
 		assert: actual equals: expected;
-		assert: (OpalEvaluator new evaluate: expected) equals: june2nd1973. "Evaluating expected to avoid surprises when evaluating"
+		assert: (OpalEvaluator new evaluate: expected) equals: self june2nd1973. "Evaluating expected to avoid surprises when evaluating"
 ]

--- a/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
+++ b/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
@@ -9,6 +9,18 @@ Class {
 	#tag : 'Classes'
 }
 
+{ #category : 'accessing' }
+AbstractClassDescriptionAnnouncementTest >> numberOfAnnouncements [
+
+	^ numberOfAnnouncements
+]
+
+{ #category : 'accessing' }
+AbstractClassDescriptionAnnouncementTest >> numberOfAnnouncements: anObject [
+
+	numberOfAnnouncements := anObject
+]
+
 { #category : 'running' }
 AbstractClassDescriptionAnnouncementTest >> setUp [
 

--- a/src/Kernel-Tests/AbstractClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/AbstractClassDescriptionTest.class.st
@@ -9,6 +9,18 @@ Class {
 	#tag : 'Classes'
 }
 
+{ #category : 'accessing' }
+AbstractClassDescriptionTest >> class [
+
+	^ class
+]
+
+{ #category : 'accessing' }
+AbstractClassDescriptionTest >> class: anObject [
+
+	class := anObject
+]
+
 { #category : 'helpers' }
 AbstractClassDescriptionTest >> classNameForTests [
 

--- a/src/Kernel-Tests/AbstractClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/AbstractClassDescriptionTest.class.st
@@ -9,18 +9,6 @@ Class {
 	#tag : 'Classes'
 }
 
-{ #category : 'accessing' }
-AbstractClassDescriptionTest >> class [
-
-	^ class
-]
-
-{ #category : 'accessing' }
-AbstractClassDescriptionTest >> class: anObject [
-
-	class := anObject
-]
-
 { #category : 'helpers' }
 AbstractClassDescriptionTest >> classNameForTests [
 
@@ -48,4 +36,16 @@ AbstractClassDescriptionTest >> tearDown [
 
 	self packageOrganizer removePackage: self packageNameForTests.
 	super tearDown
+]
+
+{ #category : 'accessing' }
+AbstractClassDescriptionTest >> testedClass [
+
+	^ class
+]
+
+{ #category : 'accessing' }
+AbstractClassDescriptionTest >> testedClass: anObject [
+
+	class := anObject
 ]

--- a/src/Kernel-Tests/RecursionStopperTest.class.st
+++ b/src/Kernel-Tests/RecursionStopperTest.class.st
@@ -22,6 +22,12 @@ RecursionStopperTest class >> defaultTimeLimit [
 ]
 
 { #category : 'accessing' }
+RecursionStopperTest >> fork [
+
+	^ fork
+]
+
+{ #category : 'accessing' }
 RecursionStopperTest >> mixedMethod [
 
 	RecursionStopper during: [

--- a/src/Kernel/Mutex.class.st
+++ b/src/Kernel/Mutex.class.st
@@ -44,3 +44,27 @@ Mutex >> initialize [
 	super initialize.
 	semaphore := Semaphore forMutualExclusion
 ]
+
+{ #category : 'accessing' }
+Mutex >> owner [
+
+	^ owner
+]
+
+{ #category : 'accessing' }
+Mutex >> owner: anObject [
+
+	owner := anObject
+]
+
+{ #category : 'accessing' }
+Mutex >> semaphore [
+
+	^ semaphore
+]
+
+{ #category : 'accessing' }
+Mutex >> semaphore: anObject [
+
+	semaphore := anObject
+]

--- a/src/Kernel/Point.class.st
+++ b/src/Kernel/Point.class.st
@@ -761,9 +761,21 @@ Point >> x [
 ]
 
 { #category : 'accessing' }
+Point >> x: anObject [
+
+	x := anObject
+]
+
+{ #category : 'accessing' }
 Point >> y [
 	"Answer the y coordinate."
 	"(100@200) y >>> 200"
 
 	^ y
+]
+
+{ #category : 'accessing' }
+Point >> y: anObject [
+
+	y := anObject
 ]

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -371,6 +371,13 @@ Rectangle >> corner [
 ]
 
 { #category : 'accessing' }
+Rectangle >> corner: anObject [
+	"Answer the point at the bottom right corner of the receiver."
+
+	corner := anObject
+]
+
+{ #category : 'accessing' }
 Rectangle >> corners [
 	"Return an array of corner points in the order of a quadrilateral spec for WarpBlt."
 
@@ -658,6 +665,13 @@ Rectangle >> origin [
 	"Answer the point at the top left corner of the receiver."
 
 	^origin
+]
+
+{ #category : 'accessing' }
+Rectangle >> origin: anObject [
+	"Answer the point at the top left corner of the receiver."
+
+	origin := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Math-Operations-Extensions/Point.extension.st
+++ b/src/Math-Operations-Extensions/Point.extension.st
@@ -145,10 +145,11 @@ Point >> rotateBy: direction centerAt: c [
 
 { #category : '*Math-Operations-Extensions' }
 Point >> setR: rho degrees: degrees [
+
 	| radians |
 	radians := degrees asFloat degreesToRadians.
-	x := rho asFloat * radians cos.
-	y := rho asFloat * radians sin
+	self x: rho asFloat * radians cos.
+	self y: rho asFloat * radians sin
 ]
 
 { #category : '*Math-Operations-Extensions' }

--- a/src/Monticello-Model/MCClassDefinition.class.st
+++ b/src/Monticello-Model/MCClassDefinition.class.st
@@ -52,6 +52,12 @@ MCClassDefinition >> addVariables: aCollection ofType: aClass [
 ]
 
 { #category : 'accessing' }
+MCClassDefinition >> basicVariables [
+
+	^ variables
+]
+
+{ #category : 'accessing' }
 MCClassDefinition >> category [
 
 	^ self tagName
@@ -640,6 +646,12 @@ MCClassDefinition >> unload [
 { #category : 'accessing' }
 MCClassDefinition >> variables [
 	^ variables ifNil: [ variables := OrderedCollection  new ]
+]
+
+{ #category : 'accessing' }
+MCClassDefinition >> variables: anObject [
+
+	variables := anObject
 ]
 
 { #category : 'installing' }

--- a/src/Monticello-Tests/MCServerRegistry.extension.st
+++ b/src/Monticello-Tests/MCServerRegistry.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'MCServerRegistry' }
 
 { #category : '*Monticello-Tests' }
-MCServerRegistry >> removeCredentialsFor: aString [ 
+MCServerRegistry >> removeCredentialsFor: aString [
 
-	registry removeKey: aString.
+	self registry removeKey: aString
 ]

--- a/src/MonticelloRemoteRepositories/MCGitBasedNetworkRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCGitBasedNetworkRepository.class.st
@@ -336,6 +336,12 @@ MCGitBasedNetworkRepository >> asRepositorySpec [
 		  yourself
 ]
 
+{ #category : 'accessing' }
+MCGitBasedNetworkRepository >> basicRepoPath [
+
+	^ repoPath
+]
+
 { #category : 'private' }
 MCGitBasedNetworkRepository >> calculateRepositoryDirectory [
 

--- a/src/MonticelloRemoteRepositories/MCServerRegistry.class.st
+++ b/src/MonticelloRemoteRepositories/MCServerRegistry.class.st
@@ -35,6 +35,12 @@ MCServerRegistry >> on: repositoryUrl beUser: nameString withPassword: passwordS
 	registry at: repositoryUrl put: credentials.
 ]
 
+{ #category : 'accessing' }
+MCServerRegistry >> registry [
+
+	^ registry
+]
+
 { #category : 'private' }
 MCServerRegistry >> repositoryAt: urlString credentialsDo: aBlock [
 

--- a/src/Morphic-Base/FormCanvas.extension.st
+++ b/src/Morphic-Base/FormCanvas.extension.st
@@ -2,6 +2,7 @@ Extension { #name : 'FormCanvas' }
 
 { #category : '*Morphic-Base' }
 FormCanvas >> drawString: aString from: firstIndex to: lastIndex autoBoundAt: aPoint font: fontOrNil color: c [
+
 	| font textStyle portRect bounds character width carriageReturn lineWidth lineHeight |
 	carriageReturn := Character cr.
 	width := lineWidth := 0.
@@ -9,35 +10,35 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex autoBoundAt: aP
 	textStyle := font textStyle.
 	lineHeight := textStyle lineGrid.
 	1 to: aString size do: [ :i |
-		character := aString at: i.
-		width := character = carriageReturn
-			ifTrue: [ lineWidth := lineWidth max: width.
-				lineHeight := lineHeight + textStyle lineGrid.
-				0 ]
-			ifFalse: [ width + (font widthOf: character) ] ].
+			character := aString at: i.
+			width := character = carriageReturn
+				         ifTrue: [
+						         lineWidth := lineWidth max: width.
+						         lineHeight := lineHeight + textStyle lineGrid.
+						         0 ]
+				         ifFalse: [ width + (font widthOf: character) ] ].
 	lineWidth := lineWidth max: width.
 	bounds := aPoint extent: lineWidth @ lineHeight.
 
-	port colorMap: nil.
-	portRect := port clipRect.
-	port
-		clipByX1: bounds left + origin x
-		y1: bounds top + origin y
-		x2: bounds right + origin x
-		y2: bounds bottom + origin y.
-	port combinationRule: Form paint.
-	port fill: bounds fillColor: Color white rule: Form paint.
-	font installOn: port foregroundColor: c backgroundColor: Color white.
-	aString lines
-		doWithIndex: [ :line :index |
+	self port colorMap: nil.
+	portRect := self port clipRect.
+	self port
+		clipByX1: bounds left + self origin x
+		y1: bounds top + self origin y
+		x2: bounds right + self origin x
+		y2: bounds bottom + self origin y.
+	self port combinationRule: Form paint.
+	self port fill: bounds fillColor: Color white rule: Form paint.
+	font installOn: self port foregroundColor: c backgroundColor: Color white.
+	aString lines doWithIndex: [ :line :index |
 			font
 				displayString: line
-				on: port
+				on: self port
 				from: 1
 				to: line size
-				at: bounds topLeft + origin + (0 @ (index - 1) * textStyle lineGrid)
+				at: bounds topLeft + self origin + (0 @ (index - 1) * textStyle lineGrid)
 				kern: 0 ].
-	port clipRect: portRect
+	self port clipRect: portRect
 ]
 
 { #category : '*Morphic-Base' }

--- a/src/Morphic-Base/GradientFillStyle.extension.st
+++ b/src/Morphic-Base/GradientFillStyle.extension.st
@@ -26,23 +26,26 @@ GradientFillStyle >> beRadialGradientIn: aMorph [
 
 { #category : '*Morphic-Base-Balloon' }
 GradientFillStyle >> changeColorAt: rampIndex to: aColor [
+
 	| ramp |
-	ramp := colorRamp copy.
+	ramp := self colorRamp copy.
 	(ramp at: rampIndex) value: aColor.
 
-	colorRamp := ramp.
-	isTranslucent := nil.
-	pixelRamp := nil
+	self colorRamp: ramp
 ]
 
 { #category : '*Morphic-Base-Balloon' }
 GradientFillStyle >> changeColorOf: aMorph rampIndex: rampIndex [
+
 	| originalColor |
-	originalColor := (colorRamp at: rampIndex) value.
+	originalColor := (self colorRamp at: rampIndex) value.
 	Smalltalk ui theme
-		chooseColorIn: self currentWorld title: 'Color' color: originalColor for: [:color |
-		self changeColorAt: rampIndex  to:  color.
-		aMorph changed]
+		chooseColorIn: self currentWorld
+		title: 'Color'
+		color: originalColor
+		for: [ :color |
+				self changeColorAt: rampIndex to: color.
+				aMorph changed ]
 ]
 
 { #category : '*Morphic-Base-Balloon' }
@@ -57,13 +60,14 @@ GradientFillStyle >> changeSecondColorIn: aMorph event: evt [
 
 { #category : '*Morphic-Base-Balloon' }
 GradientFillStyle >> copyWith: aColor atRamp: rampIndex [
+
 	| ramp |
-	ramp := colorRamp copy.
+	ramp := self colorRamp copy.
 	(ramp at: rampIndex) value: aColor.
-	^(self class ramp: ramp)
-			origin: self origin;
-			direction: self direction;
-			normal: self normal;
-			radial: self radial;
-			yourself
+	^ (self class ramp: ramp)
+		  origin: self origin;
+		  direction: self direction;
+		  normal: self normal;
+		  radial: self radial;
+		  yourself
 ]

--- a/src/Morphic-Base/Paragraph.class.st
+++ b/src/Morphic-Base/Paragraph.class.st
@@ -167,6 +167,12 @@ Paragraph >> adjustedFirstCharacterIndex [
 	^ text size - offsetToEnd
 ]
 
+{ #category : 'private' }
+Paragraph >> basicLines [
+
+	^ lines
+]
+
 { #category : 'selection' }
 Paragraph >> buildSelectionBlocksFrom: topLeft to: bottomRight [
 
@@ -271,6 +277,12 @@ Paragraph >> caretRect [
 	 or nil if the last drawing drew a range-selection rather than insertion point."
 
 	^ caretRect
+]
+
+{ #category : 'accessing' }
+Paragraph >> caretRect: anObject [
+
+	caretRect := anObject
 ]
 
 { #category : 'accessing' }
@@ -379,9 +391,21 @@ Paragraph >> composer [
 	^ composer ifNil: [composer := TextComposer new]
 ]
 
+{ #category : 'accessing' }
+Paragraph >> composer: anObject [
+
+	composer := anObject
+]
+
 { #category : 'composition' }
 Paragraph >> compositionRectangle [
 	^ container
+]
+
+{ #category : 'accessing' }
+Paragraph >> container: anObject [
+
+	container := anObject
 ]
 
 { #category : 'selection' }
@@ -522,6 +546,18 @@ Paragraph >> extent [
 	^ container width @ (lines last bottom - lines first top)
 ]
 
+{ #category : 'accessing' }
+Paragraph >> extraSelectionBlocks [
+
+	^ extraSelectionBlocks
+]
+
+{ #category : 'accessing' }
+Paragraph >> extraSelectionBlocks: anObject [
+
+	extraSelectionBlocks := anObject
+]
+
 { #category : 'selection' }
 Paragraph >> extraSelectionChanged [
 	refreshExtraSelection := true
@@ -560,6 +596,12 @@ Paragraph >> findReplaceSelectionColor [
 	^  self theme currentSettings findReplaceSelectionColor
 ]
 
+{ #category : 'accessing' }
+Paragraph >> findReplaceSelectionRegex [
+
+	^ findReplaceSelectionRegex
+]
+
 { #category : 'selection' }
 Paragraph >> findReplaceSelectionRegex: aRegex [
 	findReplaceSelectionRegex := aRegex
@@ -568,6 +610,12 @@ Paragraph >> findReplaceSelectionRegex: aRegex [
 { #category : 'accessing' }
 Paragraph >> firstCharacterIndex [
 	^ firstCharacterIndex
+]
+
+{ #category : 'accessing' }
+Paragraph >> firstCharacterIndex: anObject [
+
+	firstCharacterIndex := anObject
 ]
 
 { #category : 'accessing' }
@@ -673,8 +721,20 @@ Paragraph >> lines [
 ]
 
 { #category : 'accessing' }
+Paragraph >> lines: anObject [
+
+	lines := anObject
+]
+
+{ #category : 'accessing' }
 Paragraph >> maxRightX [
 	^ maxRightX
+]
+
+{ #category : 'accessing' }
+Paragraph >> maxRightX: anObject [
+
+	maxRightX := anObject
 ]
 
 { #category : 'editing' }
@@ -737,6 +797,24 @@ Paragraph >> numberOfLines [
 	^lines size
 ]
 
+{ #category : 'accessing' }
+Paragraph >> offsetToEnd [
+
+	^ offsetToEnd
+]
+
+{ #category : 'accessing' }
+Paragraph >> offsetToEnd: anObject [
+
+	offsetToEnd := anObject
+]
+
+{ #category : 'accessing' }
+Paragraph >> positionWhenComposed [
+
+	^ positionWhenComposed
+]
+
 { #category : 'private' }
 Paragraph >> positionWhenComposed: pos [
 	positionWhenComposed := pos
@@ -784,6 +862,18 @@ Paragraph >> recomposeFrom: start to: stop delta: delta [
 		into: newLines
 		priorLines: lines
 		atY: (lines at: startLine) top
+]
+
+{ #category : 'accessing' }
+Paragraph >> refreshExtraSelection [
+
+	^ refreshExtraSelection
+]
+
+{ #category : 'accessing' }
+Paragraph >> refreshExtraSelection: anObject [
+
+	refreshExtraSelection := anObject
 ]
 
 { #category : 'editing' }
@@ -881,10 +971,34 @@ Paragraph >> selectionRectsFrom: characterBlock1 to: characterBlock2 [
 	^ rects
 ]
 
+{ #category : 'accessing' }
+Paragraph >> selectionStart [
+
+	^ selectionStart
+]
+
+{ #category : 'accessing' }
+Paragraph >> selectionStart: anObject [
+
+	selectionStart := anObject
+]
+
 { #category : 'selection' }
 Paragraph >> selectionStart: startBlock selectionStop: stopBlock [
 	selectionStart := startBlock.
 	selectionStop := stopBlock
+]
+
+{ #category : 'accessing' }
+Paragraph >> selectionStop [
+
+	^ selectionStop
+]
+
+{ #category : 'accessing' }
+Paragraph >> selectionStop: anObject [
+
+	selectionStop := anObject
 ]
 
 { #category : 'accessing' }
@@ -905,6 +1019,12 @@ Paragraph >> string [
 { #category : 'accessing' }
 Paragraph >> text [
 	^ text
+]
+
+{ #category : 'accessing' }
+Paragraph >> text: anObject [
+
+	text := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/ParagraphSelectionBlock.class.st
+++ b/src/Morphic-Base/ParagraphSelectionBlock.class.st
@@ -19,6 +19,12 @@ ParagraphSelectionBlock class >> first: firstCharBlock last: lastCharBlock color
 	^ self new first: firstCharBlock last: lastCharBlock color: aColor
 ]
 
+{ #category : 'accessing' }
+ParagraphSelectionBlock >> color [
+
+	^ color
+]
+
 { #category : 'displaying' }
 ParagraphSelectionBlock >> displayInLine: line on: aCanvas [
 	"Display myself in the passed line."

--- a/src/Morphic-Base/PluggableMenuItemSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuItemSpec.extension.st
@@ -7,17 +7,17 @@ PluggableMenuItemSpec >> asMenuItemMorphFrom: parentMenu isLast: aBoolean [
 	it := self morphClass new.
 	lbl := self label ifNil: [ '' ].
 	"here checked can be nil, true, false"
-	checked ifNotNil: [ lbl := self hasCheckBox -> lbl ].
+	self checked ifNotNil: [ lbl := self hasCheckBox -> lbl ].
 	it contents: lbl.
 	it iconFormSet: self iconFormSet.
 	it keyText: self keyText.
 	it isEnabled: self enabled.
 	it balloonText: self help.
 	(act := self action) ifNotNil: [
-		it
-			target: act receiver;
-			selector: act selector;
-			arguments: act arguments ].
+			it
+				target: act receiver;
+				selector: act selector;
+				arguments: act arguments ].
 	(menu := self subMenu) ifNotNil: [ self enabled ifTrue: [ it subMenu: (menu asMenuMorphOfKind: parentMenu class) ] ].
 
 	parentMenu ifNotNil: [ parentMenu addMorphBack: it ].

--- a/src/Morphic-Base/PragmaMenuBuilder.extension.st
+++ b/src/Morphic-Base/PragmaMenuBuilder.extension.st
@@ -3,7 +3,7 @@ Extension { #name : 'PragmaMenuBuilder' }
 { #category : '*Morphic-Base' }
 PragmaMenuBuilder >> fallbackMenu [
 
-	^ FallbackMenu when: self fails: model
+	^ FallbackMenu when: self fails: self model
 ]
 
 { #category : '*Morphic-Base' }

--- a/src/Morphic-Base/Text.extension.st
+++ b/src/Morphic-Base/Text.extension.st
@@ -43,14 +43,11 @@ Text >> embeddedMorphsFrom: start to: stop [
 
 	| morphs |
 	morphs := IdentitySet new.
-	runs
+	self runs
 		runsFrom: start
 		to: stop
-		do:
-			[:attribs |
-			attribs
-				do: [:attr | attr anchoredMorph ifNotNil: [morphs add: attr anchoredMorph]]].
-	^morphs select: [:m | m isMorph]
+		do: [ :attribs | attribs do: [ :attr | attr anchoredMorph ifNotNil: [ morphs add: attr anchoredMorph ] ] ].
+	^ morphs select: [ :m | m isMorph ]
 ]
 
 { #category : '*Morphic-Base-Widgets' }

--- a/src/Morphic-Base/UITheme.class.st
+++ b/src/Morphic-Base/UITheme.class.st
@@ -911,6 +911,12 @@ UITheme >> classExtensionColor [
 	^ colorPalette classExtensionColor
 ]
 
+{ #category : 'accessing' }
+UITheme >> colorPalette [
+
+	^ colorPalette
+]
+
 { #category : 'label-styles' }
 UITheme >> configureDialogWindowLabelAreaFrameFor: aWindow [
 	"Configure the layout frame for the label area for the given dialog window."

--- a/src/Morphic-Base/UIThemePalette.class.st
+++ b/src/Morphic-Base/UIThemePalette.class.st
@@ -128,6 +128,12 @@ UIThemePalette >> classExtensionColor [
 ]
 
 { #category : 'accessing' }
+UIThemePalette >> colorConfigurator [
+
+	^ colorConfigurator
+]
+
+{ #category : 'accessing' }
 UIThemePalette >> colorConfigurator: aColorConfigurator [
 
 	colorConfigurator := aColorConfigurator
@@ -397,6 +403,12 @@ UIThemePalette >> mouseOverColor [
 UIThemePalette >> paginatorSelectionColor [
 
 	^ paletteDictionary at: #paginatorSelectionColor ifAbsentPut: [ colorConfigurator paginatorSelectionColor ]
+]
+
+{ #category : 'accessing' }
+UIThemePalette >> paletteDictionary [
+
+	^ paletteDictionary
 ]
 
 { #category : 'colors' }

--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -83,6 +83,12 @@ MouseButtonEvent >> whichButton [
 ]
 
 { #category : 'accessing' }
+MouseButtonEvent >> whichButton: anObject [
+
+	whichButton := anObject
+]
+
+{ #category : 'accessing' }
 MouseButtonEvent >> yellowButtonChanged [
 	"Answer true if the yellow mouse button has changed. This is the second mouse button or option+click on the Mac."
 

--- a/src/Morphic-Testing-Support/MenuItemMorph.extension.st
+++ b/src/Morphic-Testing-Support/MenuItemMorph.extension.st
@@ -3,7 +3,8 @@ Extension { #name : 'MenuItemMorph' }
 { #category : '*Morphic-Testing-Support' }
 MenuItemMorph >> itemWithWording: wording [
 	"If any of the receiver's items or submenu items have the given wording (case-blind comparison done), then return it, else return nil."
-	(self contents asString sameAs: wording) ifTrue:[^self].
-	subMenu ifNotNil:[^subMenu itemWithWording: wording].
-	^nil
+
+	(self contents asString sameAs: wording) ifTrue: [ ^ self ].
+	self subMenu ifNotNil: [ ^ self subMenu itemWithWording: wording ].
+	^ nil
 ]

--- a/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
@@ -32,6 +32,11 @@ FTFilterFunction >> colorText: aText [
 	^ aText
 ]
 
+{ #category : 'accessing' }
+FTFilterFunction >> field [
+	^field
+]
+
 { #category : 'updating' }
 FTFilterFunction >> filter [
 	pattern ifNil: [ ^ self ].
@@ -66,6 +71,16 @@ FTFilterFunction >> ghostText [
 	^ 'Filter...'
 ]
 
+{ #category : 'accessing' }
+FTFilterFunction >> initialDataSource [
+	^initialDataSource
+]
+
+{ #category : 'accessing' }
+FTFilterFunction >> initialDataSource: aDataSource [
+	initialDataSource := aDataSource
+]
+
 { #category : 'initialization' }
 FTFilterFunction >> initialize [
 	super initialize.
@@ -77,6 +92,18 @@ FTFilterFunction >> initializeFilter [
 	initialDataSource := table dataSource.
 	isEditingSemaphore := Semaphore new.
 	self spawnFilterUpdateThread
+]
+
+{ #category : 'accessing' }
+FTFilterFunction >> isEditingSemaphore [
+
+	^ isEditingSemaphore
+]
+
+{ #category : 'accessing' }
+FTFilterFunction >> isEditingSemaphore: anObject [
+
+	isEditingSemaphore := anObject
 ]
 
 { #category : 'event handling' }
@@ -95,6 +122,17 @@ FTFilterFunction >> keyStroke: anEvent [
 
 	self showFilterFieldFromKeystrokeEvent: anEvent.
 	^ true
+]
+
+{ #category : 'accessing' }
+FTFilterFunction >> pattern [
+	^pattern
+]
+
+{ #category : 'accessing' }
+FTFilterFunction >> pattern: anObject [
+
+	pattern := anObject
 ]
 
 { #category : 'updating' }

--- a/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTFilterFunction.class.st
@@ -34,7 +34,7 @@ FTFilterFunction >> colorText: aText [
 
 { #category : 'accessing' }
 FTFilterFunction >> field [
-	^field
+	^ field
 ]
 
 { #category : 'updating' }
@@ -73,7 +73,7 @@ FTFilterFunction >> ghostText [
 
 { #category : 'accessing' }
 FTFilterFunction >> initialDataSource [
-	^initialDataSource
+	^ initialDataSource
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -396,6 +396,12 @@ FTTableMorph >> firstVisibleRowIndex [
 ]
 
 { #category : 'event handling' }
+FTTableMorph >> function [
+
+	^ function
+]
+
+{ #category : 'event handling' }
 FTTableMorph >> handleMouseMove: anEvent [
 	"Reimplemented because we really want #mouseMove when a morph is dragged around"
 	anEvent wasHandled ifTrue:[^self]. "not interested"

--- a/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
@@ -47,6 +47,12 @@ FTTreeItem class >> data: aData from: aDataSource [
 		yourself
 ]
 
+{ #category : 'testing' }
+FTTreeItem >> basicChilren [
+
+	^ children
+]
+
 { #category : 'accessing' }
 FTTreeItem >> childAt: anIndex [
 	| tmpIndex |

--- a/src/Morphic-Widgets-FastTable/ScrollBarMorph.extension.st
+++ b/src/Morphic-Widgets-FastTable/ScrollBarMorph.extension.st
@@ -3,18 +3,13 @@ Extension { #name : 'ScrollBarMorph' }
 { #category : '*Morphic-Widgets-FastTable' }
 ScrollBarMorph >> canScrollDown [
 
-	^value < 1
+	^ self value < 1
 ]
 
 { #category : '*Morphic-Widgets-FastTable' }
 ScrollBarMorph >> canScrollUp [
 
-	^value > 0
-]
-
-{ #category : '*Morphic-Widgets-FastTable' }
-ScrollBarMorph >> pageDelta [
-	^ pageDelta
+	^ self value > 0
 ]
 
 { #category : '*Morphic-Widgets-FastTable' }

--- a/src/Morphic-Widgets-Pluggable/LazyListMorph.class.st
+++ b/src/Morphic-Widgets-Pluggable/LazyListMorph.class.st
@@ -295,6 +295,12 @@ LazyListMorph >> listChanged [
 ]
 
 { #category : 'initialization' }
+LazyListMorph >> listSource [
+
+	^ listSource
+]
+
+{ #category : 'initialization' }
 LazyListMorph >> listSource: aListSource [
 	"set the source of list items -- typically a PluggableListMorph"
 	listSource := aListSource.

--- a/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
@@ -753,6 +753,11 @@ ScrollBarMorph >> normalThumbFillStyle [
 	^self theme scrollbarNormalThumbFillStyleFor: self
 ]
 
+{ #category : 'accessing' }
+ScrollBarMorph >> pageDelta [
+	^ pageDelta
+]
+
 { #category : 'private - accessing' }
 ScrollBarMorph >> pagingArea [
 	^pagingArea

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -33,10 +33,12 @@ SystemWindow >> isTaskbarPresent [
 SystemWindow >> minimizeAfterGeneratingThumbnail [
 	"Minimize the window after thumbnail generation."
 
-	self isMinimized ifTrue: [^self].
-	isCollapsed := true.
-	paneMorphs
-		do: [:m | m delete; releaseCachedState].
+	self isMinimized ifTrue: [ ^ self ].
+	self isCollapsed: true.
+	self paneMorphs do: [ :m |
+			m
+				delete;
+				releaseCachedState ].
 	self setBoundsWithFlex: (-10 @ -10 extent: 2 @ 2).
 	self hide.
 	self layoutChanged
@@ -46,12 +48,11 @@ SystemWindow >> minimizeAfterGeneratingThumbnail [
 SystemWindow >> restoreBeforeGeneratingThumbnail [
 	"Restore the window without activating unlocking or stepping."
 
-	self isMinimized ifFalse: [^self].
-	isCollapsed := false.
+	self isMinimized ifFalse: [ ^ self ].
+	self isCollapsed: false.
 	self show.
-	self setBoundsWithFlex: fullFrame.
-	paneMorphs reverseDo: [:m |
-		self addMorph: m].
+	self setBoundsWithFlex: self fullFrame.
+	self paneMorphs reverseDo: [ :m | self addMorph: m ].
 	self layoutChanged
 ]
 
@@ -290,10 +291,10 @@ SystemWindow >> taskbarCloseHiddenWindows [
 	(ConfirmationRequest signal: 'Do you really want to close all windows hidden behind other windows?') ifFalse: [ ^ self ].
 	windows := (self world submorphs select: [ :each | each isSystemWindow ]) reversed.
 	invisible := windows withIndexSelect: [ :win :index |
-			             bounds := win fullBoundsInWorld.
+			             self bounds: win fullBoundsInWorld.
 			             parts := OrderedCollection new.
 			             other := (windows copyFrom: index + 1 to: windows size) collect: [ :each | each fullBoundsInWorld ].
-			             bounds allAreasOutsideList: other do: [ :each | parts add: each ].
+			             self bounds allAreasOutsideList: other do: [ :each | parts add: each ].
 			             parts isEmpty ].
 	invisible do: [ :each | each close ]
 ]

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1867,6 +1867,12 @@ SystemWindow >> isCollapsed [
 	^ isCollapsed
 ]
 
+{ #category : 'resize/collapse' }
+SystemWindow >> isCollapsed: anObject [
+
+	isCollapsed := anObject
+]
+
 { #category : 'testing' }
 SystemWindow >> isDisplayed [
 	"Answer true if I am currently displayed in the World"

--- a/src/OSWindow-SDL2/Rectangle.extension.st
+++ b/src/OSWindow-SDL2/Rectangle.extension.st
@@ -3,5 +3,9 @@ Extension { #name : 'Rectangle' }
 { #category : '*OSWindow-SDL2' }
 Rectangle >> asSDLRect [
 
-	^SDL_Rect newX: origin x rounded y: origin y rounded w: (corner x - origin x) rounded h: (corner y - origin y) rounded
+	^ SDL_Rect
+		  newX: self origin x rounded
+		  y: self origin y rounded
+		  w: (self corner x - self origin x) rounded
+		  h: (self corner y - self origin y) rounded
 ]

--- a/src/OpalCompiler-Core/OCBlockNode.extension.st
+++ b/src/OpalCompiler-Core/OCBlockNode.extension.st
@@ -68,7 +68,7 @@ OCBlockNode >> pcsForNode: aNode [
 { #category : '*OpalCompiler-Core' }
 OCBlockNode >> resetBcToASTCache [
 
-	bcToASTCache := nil
+	self basicBcToASTCache: nil
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/OCPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/OCPragmaNode.extension.st
@@ -25,9 +25,8 @@ OCPragmaNode >> asIRPrimitive [
 
 { #category : '*OpalCompiler-Core' }
 OCPragmaNode >> asPragma [
-	^ Pragma
-		selector: selector
-		arguments: (arguments collect: [ :each | each value ]) asArray
+
+	^ Pragma selector: self selector arguments: (self arguments collect: [ :each | each value ]) asArray
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/PharoDocComment/SHTextStyler.extension.st
+++ b/src/PharoDocComment/SHTextStyler.extension.st
@@ -17,15 +17,14 @@ SHTextStyler >> styleDocExpression: aPharoDocExpression in: aComment [
 
 	off := aComment start.
 	expressionText withIndexDo: [ :char :ij |
-		| index attr |
-		index := ij + off.
-		attr := expressionText attributesAt: ij.
-		charAttr at: index put: attr.
-		(expressionText at: ij) = $" ifTrue: [
-			"Because doublequote are escaped in the original source code,
+			| index attr |
+			index := ij + off.
+			attr := expressionText attributesAt: ij.
+			self charAttr at: index put: attr.
+			(expressionText at: ij) = $" ifTrue: [ "Because doublequote are escaped in the original source code,
 			just highlight both character the same and increase the original source offset"
-			charAttr at: index + 1 put: attr.
-			off := off + 1 ] ]
+					self charAttr at: index + 1 put: attr.
+					off := off + 1 ] ]
 ]
 
 { #category : '*PharoDocComment' }

--- a/src/Random-Tests/SetTest.extension.st
+++ b/src/Random-Tests/SetTest.extension.st
@@ -4,9 +4,9 @@ Extension { #name : 'SetTest' }
 SetTest >> testAtRandom [
 	| rand |
 	rand := Random new.
-	full add: 3.
-	full add: 2.
-	full add: 4.
-	full add: 1.
-	self assert: (full includes: (full atRandom: rand))
+	self full add: 3.
+	self full add: 2.
+	self full add: 4.
+	self full add: 1.
+	self assert: (self full includes: (self full atRandom: rand))
 ]

--- a/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
@@ -50,17 +50,6 @@ RBClassHierarchyEnvironment >> basisObjects [
 	^ { class }
 ]
 
-{ #category : 'accessing' }
-RBClassHierarchyEnvironment >> class [
-
-	^ class
-]
-
-{ #category : 'accessing' }
-RBClassHierarchyEnvironment >> class: aClass [
-	class := aClass
-]
-
 { #category : 'testing' }
 RBClassHierarchyEnvironment >> definesClass: aClass [
 	^ (aClass == class or:
@@ -85,4 +74,15 @@ RBClassHierarchyEnvironment >> includesClass: aClass [
 	^ (aClass == class or:
 		[ (class inheritsFrom: aClass) or:
 			[ aClass inheritsFrom: class ] ]) and: [super includesClass: aClass]
+]
+
+{ #category : 'accessing' }
+RBClassHierarchyEnvironment >> refactoredClass [
+
+	^ class
+]
+
+{ #category : 'accessing' }
+RBClassHierarchyEnvironment >> refactoredClass: aClass [
+	class := aClass
 ]

--- a/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
@@ -50,6 +50,11 @@ RBClassHierarchyEnvironment >> basisObjects [
 	^ { class }
 ]
 
+{ #category : 'accessing' }
+RBClassHierarchyEnvironment >> class: aClass [
+	class := aClass
+]
+
 { #category : 'testing' }
 RBClassHierarchyEnvironment >> definesClass: aClass [
 	^ (aClass == class or:
@@ -80,9 +85,4 @@ RBClassHierarchyEnvironment >> includesClass: aClass [
 RBClassHierarchyEnvironment >> refactoredClass [
 
 	^ class
-]
-
-{ #category : 'accessing' }
-RBClassHierarchyEnvironment >> refactoredClass: aClass [
-	class := aClass
 ]

--- a/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
@@ -51,6 +51,12 @@ RBClassHierarchyEnvironment >> basisObjects [
 ]
 
 { #category : 'accessing' }
+RBClassHierarchyEnvironment >> class [
+
+	^ class
+]
+
+{ #category : 'accessing' }
 RBClassHierarchyEnvironment >> class: aClass [
 	class := aClass
 ]

--- a/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
@@ -24,6 +24,12 @@ RBPushDownClassVariableRefactoring >> breakingChangePreconditions [
     ^ { self preconditionHasNoReferences }
 ]
 
+{ #category : 'initialization' }
+RBPushDownClassVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
 { #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> preconditionHasNoReferences [
 
@@ -43,12 +49,6 @@ RBPushDownClassVariableRefactoring >> preconditionHasSubclass [
 { #category : 'transforming' }
 RBPushDownClassVariableRefactoring >> privateTransform [
 	^ transformation privateTransform
-]
-
-{ #category : 'initialization' }
-RBPushDownClassVariableRefactoring >> model: aRBNamespace [
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-Transformations/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBPushDownInstanceVariableRefactoring.class.st
@@ -24,6 +24,12 @@ RBPushDownInstanceVariableRefactoring >> breakingChangePreconditions [
 	^ { self preconditionReferencesInstanceVariable }
 ]
 
+{ #category : 'initialization' }
+RBPushDownInstanceVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
 { #category : 'preconditions' }
 RBPushDownInstanceVariableRefactoring >> preconditionReferencesInstanceVariable [
 
@@ -39,12 +45,6 @@ RBPushDownInstanceVariableRefactoring >> preconditions [
 { #category : 'transforming' }
 RBPushDownInstanceVariableRefactoring >> privateTransform [
 	^ transformation privateTransform
-]
-
-{ #category : 'initialization' }
-RBPushDownInstanceVariableRefactoring >> model: aRBNamespace [
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-Transformations/RBVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBVariableRefactoring.class.st
@@ -33,6 +33,12 @@ RBVariableRefactoring class >> variable: aVarName class: aClass [
 		yourself
 ]
 
+{ #category : 'accessing' }
+RBVariableRefactoring >> class [
+
+	^ class
+]
+
 { #category : 'initialization' }
 RBVariableRefactoring >> refactoredClassName [
 	^ class name

--- a/src/Refactoring-Transformations/RBVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBVariableRefactoring.class.st
@@ -34,7 +34,7 @@ RBVariableRefactoring class >> variable: aVarName class: aClass [
 ]
 
 { #category : 'accessing' }
-RBVariableRefactoring >> class [
+RBVariableRefactoring >> refactoredClass [
 
 	^ class
 ]

--- a/src/Refactoring-Transformations/RePullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RePullUpInstanceVariableRefactoring.class.st
@@ -28,15 +28,23 @@ RePullUpInstanceVariableRefactoring >> breakingChangePreconditions [
 			   true ]) }
 ]
 
+{ #category : 'initialization' }
+RePullUpInstanceVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
 { #category : 'transforming' }
 RePullUpInstanceVariableRefactoring >> privateTransform [
 	^ transformation privateTransform
 ]
 
-{ #category : 'initialization' }
-RePullUpInstanceVariableRefactoring >> model: aRBNamespace [
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
+{ #category : 'preconditions' }
+RePullUpInstanceVariableRefactoring >> subclassesNotDefiningTheVariable [
+	
+	^ class allSubclasses 
+			reject: [ :each | each directlyDefinesInstanceVariable: variableName ]
+			 
 ]
 
 { #category : 'initialization' }
@@ -46,12 +54,4 @@ RePullUpInstanceVariableRefactoring >> variable: aVarName class: aClassName [
 		model: self model
 		instanceVariable: aVarName
 		class: aClassName
-]
-
-{ #category : 'preconditions' }
-RePullUpInstanceVariableRefactoring >> subclassesNotDefiningTheVariable [
-	
-	^ class allSubclasses 
-			reject: [ :each | each directlyDefinesInstanceVariable: variableName ]
-			 
 ]

--- a/src/Refactoring-Transformations/RePullUpSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RePullUpSharedVariableRefactoring.class.st
@@ -29,15 +29,15 @@ RePullUpSharedVariableRefactoring >> breakingChangePreconditions [
 		   true ]) }
 ]
 
-{ #category : 'transforming' }
-RePullUpSharedVariableRefactoring >> privateTransform [
-	^ transformation privateTransform
-]
-
 { #category : 'initialization' }
 RePullUpSharedVariableRefactoring >> model: aRBNamespace [
 	super model: aRBNamespace.
 	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'transforming' }
+RePullUpSharedVariableRefactoring >> privateTransform [
+	^ transformation privateTransform
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-Transformations/ReRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveClassRefactoring.class.st
@@ -73,18 +73,18 @@ ReRemoveClassRefactoring >> classNames: aClassNameCollection [
 				  classNames: classNames
 ]
 
-{ #category : 'accessing' }
-ReRemoveClassRefactoring >> model: aRBNamespace [
-
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
-]
-
 { #category : 'preconditions' }
 ReRemoveClassRefactoring >> environmentWithUsersOf: aClassable [
 	^ RBClassEnvironment
 		onEnvironment: RBBrowserEnvironment new
 		classes: (self model classesReferencingClass: aClassable)
+]
+
+{ #category : 'accessing' }
+ReRemoveClassRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations/ReRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveInstanceVariableRefactoring.class.st
@@ -40,6 +40,13 @@ ReRemoveInstanceVariableRefactoring >> breakingChangePreconditions [
 	^ { self preconditionHasReferences }
 ]
 
+{ #category : 'accessing' }
+ReRemoveInstanceVariableRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
 { #category : 'preconditions' }
 ReRemoveInstanceVariableRefactoring >> preconditionHasReferences [
 
@@ -73,13 +80,6 @@ ReRemoveInstanceVariableRefactoring >> privateTransform [
 { #category : 'accessing' }
 ReRemoveInstanceVariableRefactoring >> refactoredClass [
 	^ class
-]
-
-{ #category : 'accessing' }
-ReRemoveInstanceVariableRefactoring >> model: aRBNamespace [
-
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-Transformations/ReRemoveSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveSharedVariableRefactoring.class.st
@@ -43,6 +43,13 @@ ReRemoveSharedVariableRefactoring >> breakingChangePreconditions [
 		   referencesSharedVariable: variableName) not }
 ]
 
+{ #category : 'accessing' }
+ReRemoveSharedVariableRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
 { #category : 'preconditions' }
 ReRemoveSharedVariableRefactoring >> preconditions [
 
@@ -59,13 +66,6 @@ ReRemoveSharedVariableRefactoring >> privateTransform [
 ReRemoveSharedVariableRefactoring >> refactoredClass [
 
 	^ class
-]
-
-{ #category : 'accessing' }
-ReRemoveSharedVariableRefactoring >> model: aRBNamespace [
-
-	super model: aRBNamespace.
-	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'initialization' }

--- a/src/Reflectivity-Examples/OCAssignmentNode.extension.st
+++ b/src/Reflectivity-Examples/OCAssignmentNode.extension.st
@@ -3,6 +3,7 @@ Extension { #name : 'OCAssignmentNode' }
 { #category : '*Reflectivity-Examples' }
 OCAssignmentNode >> tagType: anObject [
 	"record the type of the assigned value"
-	variable propertyAt: #types ifAbsentPut: Set new.
-	(variable propertyAt: #types) add: anObject class
+
+	self variable propertyAt: #types ifAbsentPut: Set new.
+	(self variable propertyAt: #types) add: anObject class
 ]

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilder.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : 'MetaLinkAnonymousClassBuilder' }
 
 { #category : '*Reflectivity-Tests' }
-MetaLinkAnonymousClassBuilder >> migratedObjects [
-	^ migratedObjects
-]
-
-{ #category : '*Reflectivity-Tests' }
 MetaLinkAnonymousClassBuilder >> requestClassOfObject: anObject [
 	^anObject class
 ]

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -23,25 +23,25 @@ BlockClosure >> rfvalue [
 	 whose closure is the receiver and whose caller is the sender of this
 	 message. Supply the copied values to the activation as its copied
 	 temps. Primitive. Essential."
+
 	<primitive: 207>
-	<metaLinkOptions: #( + optionDisabledLink)>
+	<metaLinkOptions: #( #+ optionDisabledLink )>
 	| newContext |
-	numArgs ~= 0 ifTrue:
-		[self numArgsError: 0].
+	self numArgs ~= 0 ifTrue: [ self numArgsError: 0 ].
 	false
-		ifTrue: "Old code to simulate the closure value primitive on VMs that lack it."
-			[newContext := self asContextWithSender: thisContext sender.
-			thisContext privSender: newContext]
-		ifFalse: [self primitiveFailed]
+		ifTrue: [ "Old code to simulate the closure value primitive on VMs that lack it."
+				newContext := self asContextWithSender: thisContext sender.
+				thisContext privSender: newContext ]
+		ifFalse: [ self primitiveFailed ]
 ]
 
 { #category : '*Reflectivity' }
 BlockClosure >> rfvalueNoContextSwitch [
 	"same as valueNoContextSwitch, for recursion stopping metalinks"
+
 	<primitive: 209>
-	<metaLinkOptions: #( + optionDisabledLink)>
-	numArgs ~= 0 ifTrue:
-		[self numArgsError: 0].
+	<metaLinkOptions: #( #+ optionDisabledLink )>
+	self numArgs ~= 0 ifTrue: [ self numArgsError: 0 ].
 	self primitiveFailed
 ]
 

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -25,7 +25,7 @@ BlockClosure >> rfvalue [
 	 temps. Primitive. Essential."
 
 	<primitive: 207>
-	<metaLinkOptions: #( #+ optionDisabledLink )>
+	<metaLinkOptions: #( + optionDisabledLink )>
 	| newContext |
 	self numArgs ~= 0 ifTrue: [ self numArgsError: 0 ].
 	false
@@ -40,7 +40,7 @@ BlockClosure >> rfvalueNoContextSwitch [
 	"same as valueNoContextSwitch, for recursion stopping metalinks"
 
 	<primitive: 209>
-	<metaLinkOptions: #( #+ optionDisabledLink )>
+	<metaLinkOptions: #( + optionDisabledLink )>
 	self numArgs ~= 0 ifTrue: [ self numArgsError: 0 ].
 	self primitiveFailed
 ]

--- a/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
+++ b/src/Reflectivity/MetaLinkAnonymousClassBuilder.class.st
@@ -115,6 +115,11 @@ MetaLinkAnonymousClassBuilder >> migrateObjectToOriginalClass: anObject [
 	class superclass adoptInstance: anObject
 ]
 
+{ #category : 'accessing' }
+MetaLinkAnonymousClassBuilder >> migratedObjects [
+	^ migratedObjects
+]
+
 { #category : 'creation' }
 MetaLinkAnonymousClassBuilder >> newAnonymousSubclassFor: aClass [
 	| anonSubclass |

--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -210,6 +210,12 @@ RGElementDefinition >> actualClass [
 	^ self realClass
 ]
 
+{ #category : 'generic parent api' }
+RGElementDefinition >> basicParent: aRGBehaviorDefinition [
+
+	parent := aRGBehaviorDefinition
+]
+
 { #category : 'class element specific api' }
 RGElementDefinition >> className [
 

--- a/src/Ring-Monticello/MCClassDefinition.extension.st
+++ b/src/Ring-Monticello/MCClassDefinition.extension.st
@@ -60,16 +60,15 @@ MCClassDefinition >> ensureRingDefinitionIn: anRGEnvironment package: anRGPackag
 MCClassDefinition >> ring2LayoutType [
 
 	^ (Dictionary newFrom: {
-		#compiledMethod -> RGCompiledMethodLayout.
-		#bytes -> RGByteLayout.
-		#immediate -> RGImmediateLayout.
-		#words -> RGWordLayout.
-		#week -> RGWeakLayout.
-		#variable -> RGVariableLayout.
-		#ephemeron -> RGEphemeronLayout.
-		#normal -> RGFixedLayout.
-		#weak -> RGWeakLayout.
-		#DoubleByteLayout -> RGDoubleByteLayout.
-		#DoubleWordLayout -> RGDoubleWordLayout
-	}) at: type
+			   (#compiledMethod -> RGCompiledMethodLayout).
+			   (#bytes -> RGByteLayout).
+			   (#immediate -> RGImmediateLayout).
+			   (#words -> RGWordLayout).
+			   (#week -> RGWeakLayout).
+			   (#variable -> RGVariableLayout).
+			   (#ephemeron -> RGEphemeronLayout).
+			   (#normal -> RGFixedLayout).
+			   (#weak -> RGWeakLayout).
+			   (#DoubleByteLayout -> RGDoubleByteLayout).
+			   (#DoubleWordLayout -> RGDoubleWordLayout) }) at: self type
 ]

--- a/src/Ring-TraitsSupport/TaSequence.extension.st
+++ b/src/Ring-TraitsSupport/TaSequence.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'TaSequence' }
 
 { #category : '*Ring-TraitsSupport' }
 TaSequence >> includesElement: anElement [
-	^ members anySatisfy: [ :e | e includesElement: anElement ]
+
+	^ self members anySatisfy: [ :e | e includesElement: anElement ]
 ]

--- a/src/Ring-TraitsSupport/TaSingleComposition.extension.st
+++ b/src/Ring-TraitsSupport/TaSingleComposition.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'TaSingleComposition' }
 
 { #category : '*Ring-TraitsSupport' }
 TaSingleComposition >> includesElement: anElement [
-	^ self == anElement or: [ inner == anElement ]
+	^ self == anElement or: [ self inner == anElement ]
 ]

--- a/src/Rubric/ColorMappingCanvas.extension.st
+++ b/src/Rubric/ColorMappingCanvas.extension.st
@@ -3,8 +3,6 @@ Extension { #name : 'ColorMappingCanvas' }
 { #category : '*Rubric-Editing-Core' }
 ColorMappingCanvas >> rubParagraph: paragraph bounds: bounds color: c [
 	"Draw the given paragraph"
-	myCanvas
-		rubParagraph: paragraph
-		bounds: bounds
-		color: (self mapColor: c)
+
+	self myCanvas rubParagraph: paragraph bounds: bounds color: (self mapColor: c)
 ]

--- a/src/Rubric/TextAction.extension.st
+++ b/src/Rubric/TextAction.extension.st
@@ -5,5 +5,11 @@ TextAction >> rubActOnClick: anEvent for: anObject in: paragraph editor: editor 
 	"sent when a user clicks on a piece of text to which I am applied in an editor"
 
 	"may be self is included in the event or an Object. "
-	^ actOnClickBlock valueWithEnoughArguments: (Array with: self with: anEvent with: anObject with: paragraph with: editor)
+
+	^ self actOnClickBlock valueWithEnoughArguments: (Array
+			   with: self
+			   with: anEvent
+			   with: anObject
+			   with: paragraph
+			   with: editor)
 ]

--- a/src/Rubric/TextMethodLink.extension.st
+++ b/src/Rubric/TextMethodLink.extension.st
@@ -2,9 +2,10 @@ Extension { #name : 'TextMethodLink' }
 
 { #category : '*Rubric-Editing-Core' }
 TextMethodLink >> rubActOnClick: anEvent for: target in: aParagraph editor: anEditor [
-	self flag: #pharoTodo. "Complete implementation with class".
 
-	browseSenders == anEvent shiftPressed
+	self flag: #pharoTodo. "Complete implementation with class"
+
+	self browseSenders == anEvent shiftPressed
 		ifTrue: [ anEditor editor implementorsOf: self selector ]
 		ifFalse: [ anEditor editor sendersOf: self selector ].
 

--- a/src/Rubric/TextStyle.extension.st
+++ b/src/Rubric/TextStyle.extension.st
@@ -4,11 +4,16 @@ Extension { #name : 'TextStyle' }
 TextStyle >> privateTabsArray: anArray [
 	"DefaultTab := anArray first.
 	DefaultTabsArray := anArray."
-	tabsArray := anArray.
-	marginTabsArray := tabsArray collect: [ :t | {t . t } ]
+
+	self tabsArray: anArray.
+	self marginTabsArray: (self tabsArray collect: [ :t |
+				 {
+					 t.
+					 t } ])
 ]
 
 { #category : '*Rubric' }
 TextStyle >> rubTabWidth [
-	 ^ tabsArray first
+
+	^ self tabsArray first
 ]

--- a/src/STON-Core/Bag.extension.st
+++ b/src/STON-Core/Bag.extension.st
@@ -15,7 +15,5 @@ Bag class >> fromSton: stonReader [
 Bag >> stonOn: stonWriter [
 	"Use a map with element-occurrences pairs as representation"
 
-	stonWriter
-		writeObject: self
-		do: [ stonWriter encodeMap: contents ]
+	stonWriter writeObject: self do: [ stonWriter encodeMap: self contents ]
 ]

--- a/src/STON-Core/FileReference.extension.st
+++ b/src/STON-Core/FileReference.extension.st
@@ -2,16 +2,14 @@ Extension { #name : 'FileReference' }
 
 { #category : '*STON-Core' }
 FileReference >> stonOn: stonWriter [
+
 	self fileSystem isDiskFileSystem
-		ifTrue: [ | diskFilePath |
-			"in order to get $/ as delimiter and $. as working directory on all platforms"
-			diskFilePath := path isWorkingDirectory
-				ifTrue: [ '.' ]
-				ifFalse: [ path pathString ].
-			stonWriter
-				writeObject: self
-				named: STONFileReference stonName
-				listSingleton: diskFilePath ]
-		ifFalse: [
-			super stonOn: stonWriter ]
+		ifTrue: [
+				| diskFilePath |
+				"in order to get $/ as delimiter and $. as working directory on all platforms"
+				diskFilePath := self path isWorkingDirectory
+					                ifTrue: [ '.' ]
+					                ifFalse: [ self path pathString ].
+				stonWriter writeObject: self named: STONFileReference stonName listSingleton: diskFilePath ]
+		ifFalse: [ super stonOn: stonWriter ]
 ]

--- a/src/STON-Core/Point.extension.st
+++ b/src/STON-Core/Point.extension.st
@@ -9,6 +9,9 @@ Point >> fromSton: stonReader [
 
 { #category : '*STON-Core' }
 Point >> stonOn: stonWriter [
+
 	stonWriter writeObject: self streamShortList: [ :array |
-		array add: x; add: y ]
+			array
+				add: self x;
+				add: self y ]
 ]

--- a/src/SUnit-Basic-CLI/UnhandledError.extension.st
+++ b/src/SUnit-Basic-CLI/UnhandledError.extension.st
@@ -2,6 +2,6 @@ Extension { #name : 'UnhandledError' }
 
 { #category : '*SUnit-Basic-CLI' }
 UnhandledError >> recordBackgroundFailureOf: aTestCase inHDTestReport: aHDTestReport [
-	
-	exception recordBackgroundFailureOf: aTestCase inHDTestReport: aHDTestReport
+
+	self exception recordBackgroundFailureOf: aTestCase inHDTestReport: aHDTestReport
 ]

--- a/src/SUnit-Tests/TestExecutionEnvironmentTestCase.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTestCase.class.st
@@ -22,6 +22,18 @@ TestExecutionEnvironmentTestCase >> createTestService [
 	self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> executionEnvironment1 [
+
+	^ executionEnvironment
+]
+
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> executionEnvironment: anObject [
+
+	executionEnvironment := anObject
+]
+
 { #category : 'running' }
 TestExecutionEnvironmentTestCase >> newProcess: aName toImmediatelyExecute: aBlock [
 	| newProcess |
@@ -30,6 +42,18 @@ TestExecutionEnvironmentTestCase >> newProcess: aName toImmediatelyExecute: aBlo
 	newProcess priority: Processor activePriority + 1.
 	processes add: newProcess.
 	^newProcess
+]
+
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> processes [
+
+	^ processes
+]
+
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> processes: anObject [
+
+	processes := anObject
 ]
 
 { #category : 'running' }
@@ -91,4 +115,16 @@ TestExecutionEnvironmentTestCase >> testIsEnabledByDefault [
 
 	self assert: testService isEnabled equals: testService isEnabledByDefault.
 	self assert: testService isEnabledByDefault equals: testService class isEnabled
+]
+
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> testService [
+
+	^ testService
+]
+
+{ #category : 'accessing' }
+TestExecutionEnvironmentTestCase >> testService: anObject [
+
+	testService := anObject
 ]

--- a/src/Shout/SHTextStyler.class.st
+++ b/src/Shout/SHTextStyler.class.st
@@ -72,6 +72,18 @@ SHTextStyler >> attributesFor: aSymbol [
 ]
 
 { #category : 'accessing' }
+SHTextStyler >> braceLevel [
+
+	^ braceLevel
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> braceLevel: anObject [
+
+	braceLevel := anObject
+]
+
+{ #category : 'accessing' }
 SHTextStyler >> braceStyleName [
 
 	| level |
@@ -82,6 +94,18 @@ SHTextStyler >> braceStyleName [
 ]
 
 { #category : 'accessing' }
+SHTextStyler >> bracketLevel [
+
+	^ bracketLevel
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> bracketLevel: anObject [
+
+	bracketLevel := anObject
+]
+
+{ #category : 'accessing' }
 SHTextStyler >> bracketStyleName [
 
 	| level |
@@ -89,6 +113,24 @@ SHTextStyler >> bracketStyleName [
 	^ ('block' , (level isZero
 		    ifTrue: [ '' ]
 		    ifFalse: [ level asString ]))
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> charAttr [
+
+	^ charAttr
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> charAttr: anObject [
+
+	charAttr := anObject
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> classOrMetaClass [
+
+	^ classOrMetaClass
 ]
 
 { #category : 'accessing' }
@@ -155,6 +197,18 @@ SHTextStyler >> maximumImbricationStyleSupported [
 	"We style up to 8 level of imbricated parenthesis/brackets/braces."
 
 	^ 8
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> parentheseLevel [
+
+	^ parentheseLevel
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> parentheseLevel: anObject [
+
+	parentheseLevel := anObject
 ]
 
 { #category : 'accessing' }
@@ -285,6 +339,12 @@ SHTextStyler >> styleTempBars: aSequenceNode [
 SHTextStyler >> styledTextFor: aText [
 
 	^ self privateStyle: aText
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> view [
+
+	^ view
 ]
 
 { #category : 'accessing' }
@@ -445,6 +505,12 @@ SHTextStyler >> visitSequenceNode: aSequenceNode [
 SHTextStyler >> visitVariableNode: aVariableNode [
 
 	self addStyle: (self resolveStyleFor: aVariableNode) attributes: (self resolveVariableAttributesFor: aVariableNode) forNode: aVariableNode.
+]
+
+{ #category : 'accessing' }
+SHTextStyler >> workspace [
+
+	^ workspace
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/ClassModificationApplied.class.st
+++ b/src/System-Announcements/ClassModificationApplied.class.st
@@ -27,6 +27,12 @@ ClassModificationApplied >> classAffected [
 ]
 
 { #category : 'accessing' }
+ClassModificationApplied >> modifiedClass [
+
+	^ modifiedClass
+]
+
+{ #category : 'accessing' }
 ClassModificationApplied >> modifiedClass: anObject [
 	modifiedClass := anObject
 ]

--- a/src/System-Changes/ChangeRecord.class.st
+++ b/src/System-Changes/ChangeRecord.class.st
@@ -28,6 +28,12 @@ ChangeRecord >> <= anotherOne [
 	^ self timeStamp <= anotherOne timeStamp
 ]
 
+{ #category : 'accessing' }
+ChangeRecord >> class: anObject [
+
+	class := anObject
+]
+
 { #category : 'testing' }
 ChangeRecord >> classIncludesSelector [
 
@@ -44,6 +50,18 @@ ChangeRecord >> commentClass [
 	commentClass := Smalltalk at: class asSymbol.
 	^meta ifTrue: [commentClass class]
 		ifFalse: [commentClass]
+]
+
+{ #category : 'accessing' }
+ChangeRecord >> file [
+
+	^ file
+]
+
+{ #category : 'accessing' }
+ChangeRecord >> file: anObject [
+
+	file := anObject
 ]
 
 { #category : 'initialization' }
@@ -140,6 +158,12 @@ ChangeRecord >> isMethodNotDefinedInImage [
 ]
 
 { #category : 'accessing' }
+ChangeRecord >> meta: anObject [
+
+	meta := anObject
+]
+
+{ #category : 'accessing' }
 ChangeRecord >> methodClass [
 	| methodClass |
 	type == #method
@@ -170,6 +194,12 @@ ChangeRecord >> position [
 	^ position
 ]
 
+{ #category : 'accessing' }
+ChangeRecord >> position: anObject [
+
+	position := anObject
+]
+
 { #category : 'printing' }
 ChangeRecord >> printOn: aStream [
 
@@ -181,6 +211,12 @@ ChangeRecord >> printOn: aStream [
 ChangeRecord >> protocol [
 
 	^ protocol
+]
+
+{ #category : 'accessing' }
+ChangeRecord >> protocol: anObject [
+
+	protocol := anObject
 ]
 
 { #category : 'accessing' }
@@ -234,4 +270,10 @@ ChangeRecord >> timeStamp [
 { #category : 'accessing' }
 ChangeRecord >> type [
 	^ type
+]
+
+{ #category : 'accessing' }
+ChangeRecord >> type: anObject [
+
+	type := anObject
 ]

--- a/src/System-CommandLine-TextSupport/VTermOutputDriver.extension.st
+++ b/src/System-CommandLine-TextSupport/VTermOutputDriver.extension.st
@@ -20,11 +20,11 @@ VTermOutputDriver >> color256: aColor background: isBackground [
 
 	self csiEscape.
 
-	outStream nextPutAll: (isBackground
-		ifFalse: [ '38;5;' ]
-		ifTrue:  [ '48;5;' ]).
+	self outStream nextPutAll: (isBackground
+			 ifFalse: [ '38;5;' ]
+			 ifTrue: [ '48;5;' ]).
 
-	outStream
+	self outStream
 		print: aColor closestXTermPixelValue;
 		nextPut: $m
 ]

--- a/src/System-Finalization/DoubleLinkedList.extension.st
+++ b/src/System-Finalization/DoubleLinkedList.extension.st
@@ -51,22 +51,19 @@ DoubleLinkedList >> removeMaybeNotExistingLink: link [
 	predecessor := link previousLink.
 	successor := link nextLink.
 	predecessor
-		ifNil: [ 
-			head = link ifFalse: [ 
-				link clearLinks.
-				^ false ].
-			head := successor ]
-		ifNotNil: [ 
-			predecessor nextLink = link 
-				ifFalse: [ 
-				 link clearLinks.
-				 ^ false ].
-			predecessor nextLink: successor ].
-	successor
-		ifNil: [ tail := predecessor ]
-		ifNotNil: [ successor previousLink: predecessor ].
-	
+		ifNil: [
+				self head = link ifFalse: [
+						link clearLinks.
+						^ false ].
+				self head: successor ]
+		ifNotNil: [
+				predecessor nextLink = link ifFalse: [
+						link clearLinks.
+						^ false ].
+				predecessor nextLink: successor ].
+	successor ifNil: [ self tail: predecessor ] ifNotNil: [ successor previousLink: predecessor ].
+
 	link clearLinks.
-	
+
 	^ true
 ]

--- a/src/System-Settings-Browser/SettingTreeBuilder.class.st
+++ b/src/System-Settings-Browser/SettingTreeBuilder.class.st
@@ -31,6 +31,30 @@ SettingTreeBuilder >> button: aSymbol [
 	^ self nodeClass: ActionSettingDeclaration name: aSymbol
 ]
 
+{ #category : 'accessing' }
+SettingTreeBuilder >> currentParent [
+
+	^ currentParent
+]
+
+{ #category : 'accessing' }
+SettingTreeBuilder >> currentParent: anObject [
+
+	currentParent := anObject
+]
+
+{ #category : 'accessing' }
+SettingTreeBuilder >> currentPragma [
+
+	^ currentPragma
+]
+
+{ #category : 'accessing' }
+SettingTreeBuilder >> currentPragma: anObject [
+
+	currentPragma := anObject
+]
+
 { #category : 'tree building' }
 SettingTreeBuilder >> group: aSymbol [
 	^ self nodeClass: PragmaSetting name: aSymbol
@@ -55,6 +79,12 @@ SettingTreeBuilder >> nodeClass: aClass name: aSymbol [
 { #category : 'accessing' }
 SettingTreeBuilder >> nodeList [
 	^ nodeList ifNil: [nodeList := OrderedCollection new]
+]
+
+{ #category : 'accessing' }
+SettingTreeBuilder >> nodeList: anObject [
+
+	nodeList := anObject
 ]
 
 { #category : 'private - tree building' }

--- a/src/System-Settings-Tests/SettingTreeBuilder.extension.st
+++ b/src/System-Settings-Tests/SettingTreeBuilder.extension.st
@@ -2,5 +2,6 @@ Extension { #name : 'SettingTreeBuilder' }
 
 { #category : '*System-Settings-Tests' }
 SettingTreeBuilder >> mocksystemsettings [
-	currentPragma methodClass instanceSide perform: currentPragma methodSelector with: self
+
+	self currentPragma methodClass instanceSide perform: self currentPragma methodSelector with: self
 ]

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -240,14 +240,16 @@ SystemNavigation >> allPrimitiveMethods [
 { #category : 'query' }
 SystemNavigation >> allReferencesTo: aLiteral [
 	"Answer all the methods that refer to aLiteral even deeply embedded in literal array."
-	
+
 	| specialIndex |
 	"for speed we check the special selectors here once per class"
 	^ self allBehaviors flatCollect: [ :class |
-			  | targetLiteral |
-			  targetLiteral := class package visibleSelectorForSymbol: aLiteral.
-			  specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
-			  class thoroughWhichMethodsReferTo: targetLiteral specialIndex: specialIndex ]
+			| targetLiteral |
+			targetLiteral := aLiteral.
+			(targetLiteral isKindOf: Symbol) ifTrue: [ 
+				targetLiteral := class package visibleSelectorForSymbol: aLiteral ].
+			specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
+			class thoroughWhichMethodsReferTo: targetLiteral specialIndex: specialIndex ]
 ]
 
 { #category : 'query' }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -240,12 +240,14 @@ SystemNavigation >> allPrimitiveMethods [
 { #category : 'query' }
 SystemNavigation >> allReferencesTo: aLiteral [
 	"Answer all the methods that refer to aLiteral even deeply embedded in literal array."
-
-
+	
 	| specialIndex |
 	"for speed we check the special selectors here once per class"
-	specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
-	^ self allBehaviors flatCollect: [ :class | class thoroughWhichMethodsReferTo: aLiteral specialIndex: specialIndex ]
+	^ self allBehaviors flatCollect: [ :class |
+			  | targetLiteral |
+			  targetLiteral := class package visibleSelectorForSymbol: aLiteral.
+			  specialIndex := Smalltalk specialSelectorIndexOrNil: aLiteral.
+			  class thoroughWhichMethodsReferTo: targetLiteral specialIndex: specialIndex ]
 ]
 
 { #category : 'query' }

--- a/src/System-Time-Tests/DateTest.class.st
+++ b/src/System-Time-Tests/DateTest.class.st
@@ -13,6 +13,18 @@ Class {
 	#package : 'System-Time-Tests'
 }
 
+{ #category : 'accessing' }
+DateTest >> aTime [
+
+	^ aTime
+]
+
+{ #category : 'accessing' }
+DateTest >> aTime: anObject [
+
+	aTime := anObject
+]
+
 { #category : 'coverage' }
 DateTest >> classToBeTested [
 
@@ -29,6 +41,30 @@ DateTest >> dateClass [
 DateTest >> epoch [
 
 	^ Date year: 1901 month: 1 day: 1
+]
+
+{ #category : 'accessing' }
+DateTest >> january23rd2004 [
+
+	^ january23rd2004
+]
+
+{ #category : 'accessing' }
+DateTest >> january23rd2004: anObject [
+
+	january23rd2004 := anObject
+]
+
+{ #category : 'accessing' }
+DateTest >> june2nd1973 [
+
+	^ june2nd1973
+]
+
+{ #category : 'accessing' }
+DateTest >> june2nd1973: anObject [
+
+	june2nd1973 := anObject
 ]
 
 { #category : 'helpers' }

--- a/src/TaskIt/SharedQueue.extension.st
+++ b/src/TaskIt/SharedQueue.extension.st
@@ -2,10 +2,10 @@ Extension { #name : 'SharedQueue' }
 
 { #category : '*TaskIt' }
 SharedQueue >> fixedSize: aSize nextPut: anObject [
-	monitor
-		critical:
-			[ [ aSize - items size < 1 ] whileTrue: [ items removeFirst ].
-			items addLast: anObject.
-			monitor signal ].
+
+	self monitor critical: [
+			[ aSize - self items size < 1 ] whileTrue: [ self items removeFirst ].
+			self items addLast: anObject.
+			self monitor signal ].
 	^ anObject
 ]

--- a/src/Text-Core/TextStyle.class.st
+++ b/src/Text-Core/TextStyle.class.st
@@ -555,6 +555,12 @@ TextStyle >> marginTabAt: marginIndex side: sideIndex [
 		ifFalse: [ 0 ]
 ]
 
+{ #category : 'accessing' }
+TextStyle >> marginTabsArray: anObject [
+
+	marginTabsArray := anObject
+]
+
 { #category : 'private' }
 TextStyle >> newFontArray: anArray [
 	"Currently there is no supporting protocol for changing these arrays. If an editor wishes to implement margin setting, then a copy of the default should be stored with these instance variables.
@@ -658,6 +664,18 @@ TextStyle >> tabWidth [
 	"Answer the width of a tab."
 
 	^DefaultTab
+]
+
+{ #category : 'accessing' }
+TextStyle >> tabsArray [
+
+	^ tabsArray
+]
+
+{ #category : 'accessing' }
+TextStyle >> tabsArray: anObject [
+
+	tabsArray := anObject
 ]
 
 { #category : 'copying' }

--- a/src/Text-Edition/TextStyle.extension.st
+++ b/src/Text-Edition/TextStyle.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'TextStyle' }
 TextStyle >> addNewFontSize: pointSize [
 	"Add a font in specified size to the array of fonts."
 	| f d newArray t  |
-	fontArray first emphasis ~= 0 ifTrue: [
+	self fontArray first emphasis ~= 0 ifTrue: [
 		t := TextSharedInformation at: self fontArray first familyName asSymbol.
 		t fonts first emphasis = 0 ifTrue: [
 			^ t addNewFontSize: pointSize.
@@ -12,19 +12,19 @@ TextStyle >> addNewFontSize: pointSize [
 	].
 
 	pointSize <= 0 ifTrue: [^ nil].
-	fontArray do: [:s |
+	self fontArray do: [:s |
 		s pointSize = pointSize ifTrue: [^ s].
 	].
-	f := fontArray first class new initialize: fontArray first.
+	f := self fontArray first class new initialize: self fontArray first.
 	f pointSize: pointSize.
-	fontArray first derivativeFonts do: [:proto |
+	self fontArray first derivativeFonts do: [:proto |
 			proto ifNotNil: [
 				d := proto class new initialize: proto.
 				d pointSize: f pointSize.
 				f derivativeFont: d mainFont: proto.
 			].
 	].
-	newArray := ((fontArray copyWith: f) asSortedCollection: [:a :b | a pointSize <= b pointSize]) asArray.
+	newArray := ((self fontArray copyWith: f) asSortedCollection: [:a :b | a pointSize <= b pointSize]) asArray.
 	self newFontArray: newArray.
 	^ self fontOfPointSize: pointSize
 ]
@@ -32,5 +32,5 @@ TextStyle >> addNewFontSize: pointSize [
 { #category : '*Text-Edition' }
 TextStyle >> isTTCStyle [
 
-	^ fontArray first isTTCFont
+	^ self fontArray first isTTCFont
 ]

--- a/src/ThreadedFFI-UFFI/FFIExternalStructureType.extension.st
+++ b/src/ThreadedFFI-UFFI/FFIExternalStructureType.extension.st
@@ -2,20 +2,18 @@ Extension { #name : 'FFIExternalStructureType' }
 
 { #category : '*ThreadedFFI-UFFI' }
 FFIExternalStructureType >> tfExternalType [
+
 	^ TFStructType
-		forClass: objectClass
-		withMembers:
-			(objectClass fieldSpec fields values
-				flatCollect: [ :aField | aField tfExternalTypeForStructureWithArity ])
+		  forClass: self objectClass
+		  withMembers: (self objectClass fieldSpec fields values flatCollect: [ :aField | aField tfExternalTypeForStructureWithArity ])
 ]
 
 { #category : '*ThreadedFFI-UFFI' }
 FFIExternalStructureType >> tfExternalTypeWithArity [
 
-	self pointerArity = 1
-		  ifTrue: [
-			  ^ TFPointerToStructType new
-				  targetClass: objectClass;
+	self pointerArity = 1 ifTrue: [
+			^ TFPointerToStructType new
+				  targetClass: self objectClass;
 				  yourself ].
 
 	^ self pointerArity > 1

--- a/src/ThreadedFFI/FFICallback.extension.st
+++ b/src/ThreadedFFI/FFICallback.extension.st
@@ -27,5 +27,5 @@ FFICallback >> tfPointerAddress [
 { #category : '*ThreadedFFI' }
 FFICallback >> tfPrintString [
 
-	^ block printString
+	^ self block printString
 ]

--- a/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
+++ b/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
@@ -5,20 +5,19 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncedOnlyInTrait [
 
 	| trait |
 	[
-	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         beTrait;
-			         name: 'TraitForTest';
-			         package: self packageNameForTests , '2' ].
+		trait := self class classInstaller make: [ :aBuilder |
+				         aBuilder
+					         beTrait;
+					         name: 'TraitForTest';
+					         package: self packageNameForTests , '2' ].
 
-	class := class classInstaller 
-		update: class
-		to: [ :aBuilder | aBuilder traits: trait ].
+		self class: (self class classInstaller update: self class to: [ :aBuilder | aBuilder traits: trait ]).
 
-	self when: ProtocolAdded do: [ :ann |
-		self assert: ann protocol name equals: #king.
-		self assert: ann classReorganized name equals: 'TraitForTest' ].
+		self when: ProtocolAdded do: [ :ann |
+				self assert: ann protocol name equals: #king.
+				self assert: ann classReorganized name equals: 'TraitForTest' ].
 
-	trait addProtocol: #king.
-	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+		trait addProtocol: #king.
+		self assert: self numberOfAnnouncements equals: 1 ] ensure: [
+		self packageOrganizer removePackage: self packageNameForTests , '2' ]
 ]

--- a/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
+++ b/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
@@ -11,7 +11,7 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncedOnlyInTrait [
 					         name: 'TraitForTest';
 					         package: self packageNameForTests , '2' ].
 
-		self class: (self class classInstaller update: self class to: [ :aBuilder | aBuilder traits: trait ]).
+		self testedClass: (self testedClass classInstaller update: self testedClass to: [ :aBuilder | aBuilder traits: trait ]).
 
 		self when: ProtocolAdded do: [ :ann |
 				self assert: ann protocol name equals: #king.

--- a/src/Traits/FluidClassDefinitionPrinter.extension.st
+++ b/src/Traits/FluidClassDefinitionPrinter.extension.st
@@ -28,9 +28,9 @@ FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
 
 	^ String streamContents: [ :s |
 			  s nextPutAll: 'Trait << '.
-			  s nextPutAll: forClass name.
+			  s nextPutAll: self forClass name.
 
-			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: self forClass on: s ].
 			  s crtab.
 			  s nextPutAll: 'slots: '.
 			  self slotDefinitionsOn: s ]
@@ -45,13 +45,13 @@ FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 			  self msgAndClassNameOn: s.
 
 
-			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: self forClass on: s ].
 			  self slotsOn: s.
 			  s crtab.
 
-			  forClass packageTag ifNotNil: [ :t |
+			  self forClass packageTag ifNotNil: [ :t |
 					  tag := t name.
-					  tag = forClass package name ifFalse: [
+					  tag = self forClass package name ifFalse: [
 							  s
 								  nextPutAll: 'tag: ';
 								  nextPut: $';
@@ -61,34 +61,33 @@ FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 
 			  s
 				  nextPutAll: 'package: ''';
-				  nextPutAll: forClass package name;
+				  nextPutAll: self forClass package name;
 				  nextPutAll: '''' ]
 ]
 
 { #category : '*Traits' }
 FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
 
-	^ String streamContents:
-		[:strm |
-		strm
-			nextPutAll: forClass superclass name;
-			nextPutAll: ' << ';
-			nextPutAll: forClass name.
-		self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: forClass on: strm ].
-		self lastSlotsOn: strm]
+	^ String streamContents: [ :strm |
+			  strm
+				  nextPutAll: self forClass superclass name;
+				  nextPutAll: ' << ';
+				  nextPutAll: self forClass name.
+			  self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: self forClass on: strm ].
+			  self lastSlotsOn: strm ]
 ]
 
 { #category : '*Traits' }
 FluidClassDefinitionPrinter >> traitDefinitionString [
 
 	^ String streamContents: [ :strm |
-			strm nextPutAll: 'Trait'.
-			self msgAndClassNameOn: strm.
-			self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: forClass on: strm ].
+			  strm nextPutAll: 'Trait'.
+			  self msgAndClassNameOn: strm.
+			  self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: self forClass on: strm ].
 
-		   forClass slots ifNotEmpty: [ self slotsOn: strm ].
-			self tagOn: strm.
-			self packageOn: strm ]
+			  self forClass slots ifNotEmpty: [ self slotsOn: strm ].
+			  self tagOn: strm.
+			  self packageOn: strm ]
 ]
 
 { #category : '*Traits' }
@@ -115,13 +114,12 @@ FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName ta
 { #category : '*Traits' }
 FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 
-	^ String streamContents:
-		[:strm |
-		strm
-			nextPutAll: forClass superclass name;
-			nextPutAll: ' << ';
-			nextPutAll: forClass name.
-		
-		self class customizers do: [ :customizer | customizer fluidMetaclassDefinitionFor: forClass on: strm ].
-		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]
+	^ String streamContents: [ :strm |
+			  strm
+				  nextPutAll: self forClass superclass name;
+				  nextPutAll: ' << ';
+				  nextPutAll: self forClass name.
+
+			  self class customizers do: [ :customizer | customizer fluidMetaclassDefinitionFor: self forClass on: strm ].
+			  self forClass slots ifNotEmpty: [ self lastSlotsOn: strm ] ]
 ]

--- a/src/Traits/LegacyClassDefinitionPrinter.extension.st
+++ b/src/Traits/LegacyClassDefinitionPrinter.extension.st
@@ -4,18 +4,18 @@ Extension { #name : 'LegacyClassDefinitionPrinter' }
 LegacyClassDefinitionPrinter >> traitDefinitionString [
 
 	^ String streamContents: [ :s |
-		s
-			nextPutAll: 'Trait named: ';
-			nextPutAll:	forClass name printString;
-			cr; tab;
-			nextPutAll: ' uses: ';
-			nextPutAll: forClass traitComposition traitCompositionExpression;
-			cr;
-			tab;
-			nextPutAll: ' package: ';
-			print: forClass category asString
-			"we do not want the # if category returns a symbol"
-	]
+			  s
+				  nextPutAll: 'Trait named: ';
+				  nextPutAll: self forClass name printString;
+				  cr;
+				  tab;
+				  nextPutAll: ' uses: ';
+				  nextPutAll: self forClass traitComposition traitCompositionExpression;
+				  cr;
+				  tab;
+				  nextPutAll: ' package: ';
+				  print: self forClass category asString
+			  "we do not want the # if category returns a symbol" ]
 ]
 
 { #category : '*Traits' }

--- a/src/Traits/OldPharoClassDefinitionPrinter.extension.st
+++ b/src/Traits/OldPharoClassDefinitionPrinter.extension.st
@@ -4,12 +4,12 @@ Extension { #name : 'OldPharoClassDefinitionPrinter' }
 OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
 
-	forClass instanceSide name == #Trait ifTrue: [ ^ self classDefinitionString ].
+	self forClass instanceSide name == #Trait ifTrue: [ ^ self classDefinitionString ].
 
 	^ String streamContents: [ :s |
 			  s
 				  nextPutAll: 'Trait named: ';
-				  nextPutAll: forClass name printString.
+				  nextPutAll: self forClass name printString.
 
 			  self applyCustomizersOn: s.
 			  self instanceVariablesOn: s.
@@ -20,7 +20,7 @@ OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
 
 	^ String streamContents: [ :strm |
-			  strm print: forClass.
+			  strm print: self forClass.
 
 			  self applyCustomizersOn: strm.
 			  self instanceVariablesOn: strm ]
@@ -29,15 +29,15 @@ OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
 { #category : '*Traits' }
 OldPharoClassDefinitionPrinter >> traitDefinitionString [
 
-	^ forClass needsSlotClassDefinition
-		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitDefinitionString ]
-		ifFalse: [ self basicTraitDefinitionString ]
+	^ self forClass needsSlotClassDefinition
+		  ifTrue: [ (ClassDefinitionPrinter fluid for: self forClass) traitDefinitionString ]
+		  ifFalse: [ self basicTraitDefinitionString ]
 ]
 
 { #category : '*Traits' }
 OldPharoClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 
-	^ forClass needsSlotClassDefinition
-		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitedMetaclassDefinitionString ]
-		ifFalse: [ self basicTraitedMetaclassDefinitionString ]
+	^ self forClass needsSlotClassDefinition
+		  ifTrue: [ (ClassDefinitionPrinter fluid for: self forClass) traitedMetaclassDefinitionString ]
+		  ifFalse: [ self basicTraitedMetaclassDefinitionString ]
 ]

--- a/src/Traits/TraitedMetaclass.class.st
+++ b/src/Traits/TraitedMetaclass.class.st
@@ -60,6 +60,12 @@ TraitedMetaclass >> basicTraitComposition [
 ]
 
 { #category : 'fileout' }
+TraitedMetaclass >> composition: anObject [
+
+	composition := anObject
+]
+
+{ #category : 'fileout' }
 TraitedMetaclass >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter traitedMetaclassDefinitionString
@@ -230,6 +236,12 @@ TraitedMetaclass >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses"
 
 	^ localMethods values
+]
+
+{ #category : 'accessing' }
+TraitedMetaclass >> localMethods: anObject [
+
+	localMethods := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/UnifiedFFI/ExternalType.extension.st
+++ b/src/UnifiedFFI/ExternalType.extension.st
@@ -12,45 +12,47 @@ ExternalType >> offsetReadFieldAt: offsetVariableName [
 	 Private. Used for field definition only.
 	 NOTE: This is used on UFFI to define field accessors that depends on a class variable
 	 (this works like this to allow mapping 32bits and 64bits structures)"
-	self isPointerType ifTrue:
-		[| accessor |
-		accessor := self pointerSize caseOf: {
-						[nil]	->	[#pointerAt:].
-						[4]	->	[#shortPointerAt:].
-						[8]	->	[#longPointerAt:] }.
-		 ^String streamContents:
-			[:s|
-			 referentClass
-				ifNil:
-					[s nextPutAll: '^ExternalData fromHandle: (handle ', accessor, ' ';
-						nextPutAll: offsetVariableName;
-						nextPutAll: ') type: ExternalType ';
-						nextPutAll: (AtomicTypeNames at: self atomicType);
-						nextPutAll: ' asPointerType']
-				ifNotNil:
-					[s nextPutAll: '^';
-						print: referentClass;
-						nextPutAll: ' fromHandle: (handle ', accessor, ' ';
-						nextPutAll: offsetVariableName;
-						nextPut: $)]]].
 
-	self isAtomic ifFalse: "structure type"
-		[^ self offsetReadStructFieldAt: offsetVariableName ].
+	self isPointerType ifTrue: [
+			| accessor |
+			accessor := self pointerSize caseOf: {
+					            ([ nil ] -> [ #pointerAt: ]).
+					            ([ 4 ] -> [ #shortPointerAt: ]).
+					            ([ 8 ] -> [ #longPointerAt: ]) }.
+			^ String streamContents: [ :s |
+					  self referentClass
+						  ifNil: [
+								  s
+									  nextPutAll: '^ExternalData fromHandle: (handle ' , accessor , ' ';
+									  nextPutAll: offsetVariableName;
+									  nextPutAll: ') type: ExternalType ';
+									  nextPutAll: (AtomicTypeNames at: self atomicType);
+									  nextPutAll: ' asPointerType' ]
+						  ifNotNil: [
+								  s
+									  nextPutAll: '^';
+									  print: self referentClass;
+									  nextPutAll: ' fromHandle: (handle ' , accessor , ' ';
+									  nextPutAll: offsetVariableName;
+									  nextPut: $) ] ] ].
+
+	self isAtomic ifFalse: [ "structure type" ^ self offsetReadStructFieldAt: offsetVariableName ].
 
 	"Atomic non-pointer types"
-	^String streamContents:
-		[:s|
-		s nextPutAll:'^handle ';
-			nextPutAll: (AtomicSelectors at: self atomicType);
-			space; nextPutAll: offsetVariableName]
+	^ String streamContents: [ :s |
+			  s
+				  nextPutAll: '^handle ';
+				  nextPutAll: (AtomicSelectors at: self atomicType);
+				  space;
+				  nextPutAll: offsetVariableName ]
 ]
 
 { #category : '*UnifiedFFI' }
 ExternalType >> offsetReadStructFieldAt: offsetVariableName [
-	^ '^ {1} fromHandle: (handle structAt: {2} length: {1} byteSize)'
-		format: {
-			referentClass name.
-			offsetVariableName }
+
+	^ '^ {1} fromHandle: (handle structAt: {2} length: {1} byteSize)' format: {
+			  self referentClass name.
+			  offsetVariableName }
 ]
 
 { #category : '*UnifiedFFI' }
@@ -84,11 +86,11 @@ ExternalType >> offsetWriteFieldAt: offsetVariableName with: valueName [
 
 { #category : '*UnifiedFFI' }
 ExternalType >> offsetWriteStructFieldAt: offsetVariableName with: valueName [
-	^ 'handle structAt: {1} put: {2} getHandle length: {3} byteSize'
-		format: {
-			offsetVariableName.
-			valueName.
-			referentClass name }
+
+	^ 'handle structAt: {1} put: {2} getHandle length: {3} byteSize' format: {
+			  offsetVariableName.
+			  valueName.
+			  self referentClass name }
 ]
 
 { #category : '*UnifiedFFI' }

--- a/src/UnifiedFFI/FFICallback.class.st
+++ b/src/UnifiedFFI/FFICallback.class.st
@@ -85,6 +85,12 @@ FFICallback >> beNull [
 ]
 
 { #category : 'accessing' }
+FFICallback >> block [
+
+	^ block
+]
+
+{ #category : 'accessing' }
 FFICallback >> calloutAPIClass [
 
 	^ calloutAPIClass ifNil: [ super calloutAPIClass ]

--- a/src/Zinc-Resource-Meta-Core/FileSystem.extension.st
+++ b/src/Zinc-Resource-Meta-Core/FileSystem.extension.st
@@ -3,5 +3,6 @@ Extension { #name : 'FileSystem' }
 { #category : '*Zinc-Resource-Meta-Core' }
 FileSystem >> mimeTypesAt: aResolvable [
 	"Return the possible mime types for the given path."
-	^ store mimeTypesAt: (self resolve: aResolvable)
+
+	^ self store mimeTypesAt: (self resolve: aResolvable)
 ]


### PR DESCRIPTION
Improve implementation of some methods to prepare the arriving of new extension.

-- EDIT by @guillep --

This PR further prepares Pharo to the new scoped extension mechanism.
- It adds a first Calypso tool version to show the extensions
- It adds a migration script to start automating the migration process
- It refactors/changes several part of the system where selectors/symbols are treated like strings (which may not be the case anymore)
- It encapsulates instance variables further:
    - extensions cannot access instance variables to not break encapsulation. If they need so, they should go through an accessor
    - move accessors defined as extensions as normal accessors in the accessing protocol

Remaining TODOs for next iterations:
 - see the issue after migration mentioned by @NathanMalenge below
 - encapsulate class variable accesses too