### PR TITLE
Fix 18328. Move asFileName method of String class to package Files

### DIFF
--- a/src/FileSystem-Disk/String.extension.st
+++ b/src/FileSystem-Disk/String.extension.st
@@ -7,16 +7,6 @@ String >> asFileLocatorOrReference [
 ]
 
 { #category : '*FileSystem-Disk' }
-String >> asFileName [
-	"Answer a String made up from the receiver that is an acceptable file name."
-
-	| string checkedString |
-	string := FileSystem disk checkName: self fixErrors: true.
-	checkedString := FilePathEncoder encode: string.
-	^ FilePathEncoder decode: checkedString
-]
-
-{ #category : '*FileSystem-Disk' }
 String >> asFileReference [
 
 	^ FileSystem disk referenceTo: self

--- a/src/Files/String.extension.st
+++ b/src/Files/String.extension.st
@@ -1,6 +1,16 @@
 Extension { #name : 'String' }
 
 { #category : '*Files' }
+String >> asFileName [
+	"Answer a String made up from the receiver that is an acceptable file name."
+
+	| string checkedString |
+	string := FileSystem disk checkName: self fixErrors: true.
+	checkedString := FilePathEncoder encode: string.
+	^ FilePathEncoder decode: checkedString
+]
+
+{ #category : '*Files' }
 String >> asVmPathName [
 	"This method returns self encoded in the encoding the system expects.
 	We default to utf8 as this is the most common encoding, but we should ask the system the current encoding instead.


### PR DESCRIPTION
This PR fixes the next issue: #18328

Just move asFileName method of String class to package Files