### PR TITLE
19476 class builder check if class side slot offsets are correctly updated

### DIFF
--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -189,7 +189,8 @@ SlotMigrationTest >> testChangingFormatKeepsMethod [
 
 { #category : 'tests' }
 SlotMigrationTest >> testClassSlotOffsetsAfterChangeSuperclass [
-	""
+	"Checks the behaviour described in issue #19476
+	Class side slots should update their index when the superclass changes"
 
 	| superclass1 superclass2 class subclass |
 
@@ -222,14 +223,17 @@ SlotMigrationTest >> testClassSlotOffsetsAfterChangeSuperclass [
 		self assert: ((class class allSlots last: 3 ) collect: #name) equals: #(a b x) asOrderedCollection.
 		self assert: ((subclass class allSlots last: 5 ) collect: #name) equals: #(a b x y z) asOrderedCollection.
 		
+		
 		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
 		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
 		
 		class superclass: superclass2.
 		
+		"Superclass slots should change from a b -> c"
 		self assert: ((class class allSlots last: 2 ) collect: #name) equals: #(c x) asOrderedCollection.
 		self assert: ((subclass class allSlots last: 4 ) collect: #name) equals: #(c x y z) asOrderedCollection.
 		
+		"Check that the index of the slots is consistent"
 		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
 		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
 		

--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -188,6 +188,55 @@ SlotMigrationTest >> testChangingFormatKeepsMethod [
 ]
 
 { #category : 'tests' }
+SlotMigrationTest >> testClassSlotOffsetsAfterChangeSuperclass [
+	""
+
+	| superclass1 superclass2 class subclass |
+
+	superclass1 := self make: [ :builder |
+			               builder
+				               name: self aClassName;
+				               superclass: Object;
+				               classSlots: #( a b ) ].
+			
+	superclass2 := self make: [ :builder |
+		               builder
+		               name: self anotherClassName;
+		               superclass: Object;
+		               classSlots: #( c ) ].
+
+
+	class := self make: [ :builder |
+			         builder
+				         name: self yetAnotherClassName ;
+				         superclass: superclass1;
+							classSlots: #(x) ].
+						
+	subclass := self make: [ :builder |
+			         builder
+				         name: self yetYetAnotherClassName ;
+				         superclass: class;
+							classSlots: #(y z) ].
+						
+						
+		self assert: ((class class allSlots last: 3 ) collect: #name) equals: #(a b x) asOrderedCollection.
+		self assert: ((subclass class allSlots last: 5 ) collect: #name) equals: #(a b x y z) asOrderedCollection.
+		
+		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
+		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
+		
+		class superclass: superclass2.
+		
+		self assert: ((class class allSlots last: 2 ) collect: #name) equals: #(c x) asOrderedCollection.
+		self assert: ((subclass class allSlots last: 4 ) collect: #name) equals: #(c x y z) asOrderedCollection.
+		
+		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
+		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
+		
+
+]
+
+{ #category : 'tests' }
 SlotMigrationTest >> testMigrateSlotWithInitialize [
 	"We create a class without slots, instantiate, then add a lot that wants to intialize the instance"
 	aClass := self makeWithLayout: FixedLayout andSlots: { }.

--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -193,51 +193,48 @@ SlotMigrationTest >> testClassSlotOffsetsAfterChangeSuperclass [
 	Class side slots should update their index when the superclass changes"
 
 	| superclass1 superclass2 class subclass |
-
 	superclass1 := self make: [ :builder |
 			               builder
 				               name: self aClassName;
 				               superclass: Object;
 				               classSlots: #( a b ) ].
-			
+
 	superclass2 := self make: [ :builder |
-		               builder
-		               name: self anotherClassName;
-		               superclass: Object;
-		               classSlots: #( c ) ].
+			               builder
+				               name: self anotherClassName;
+				               superclass: Object;
+				               classSlots: #( c ) ].
 
 
 	class := self make: [ :builder |
 			         builder
-				         name: self yetAnotherClassName ;
+				         name: self yetAnotherClassName;
 				         superclass: superclass1;
-							classSlots: #(x) ].
-						
-	subclass := self make: [ :builder |
-			         builder
-				         name: self yetYetAnotherClassName ;
-				         superclass: class;
-							classSlots: #(y z) ].
-						
-						
-		self assert: ((class class allSlots last: 3 ) collect: #name) equals: #(a b x) asOrderedCollection.
-		self assert: ((subclass class allSlots last: 5 ) collect: #name) equals: #(a b x y z) asOrderedCollection.
-		
-		
-		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
-		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
-		
-		class superclass: superclass2.
-		
-		"Superclass slots should change from a b -> c"
-		self assert: ((class class allSlots last: 2 ) collect: #name) equals: #(c x) asOrderedCollection.
-		self assert: ((subclass class allSlots last: 4 ) collect: #name) equals: #(c x y z) asOrderedCollection.
-		
-		"Check that the index of the slots is consistent"
-		1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
-		1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
-		
+				         classSlots: #( x ) ].
 
+	subclass := self make: [ :builder |
+			            builder
+				            name: self yetYetAnotherClassName;
+				            superclass: class;
+				            classSlots: #( y z ) ].
+
+
+	self assert: ((class class allSlots last: 3) collect: #name) equals: #( a b x ) asOrderedCollection.
+	self assert: ((subclass class allSlots last: 5) collect: #name) equals: #( a b x y z ) asOrderedCollection.
+
+
+	1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
+	1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ].
+
+	class superclass: superclass2.
+
+	"Superclass slots should change from a b -> c"
+	self assert: ((class class allSlots last: 2) collect: #name) equals: #( c x ) asOrderedCollection.
+	self assert: ((subclass class allSlots last: 4) collect: #name) equals: #( c x y z ) asOrderedCollection.
+
+	"Check that the index of the slots is consistent"
+	1 to: class class allSlots size do: [ :each | self assert: (class class allSlots at: each) index equals: each ].
+	1 to: subclass class allSlots size do: [ :each | self assert: (subclass class allSlots at: each) index equals: each ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Fix #19476
Adds a test method to SlotMigrationTest to check slot offsets after the superclass is changed. Given a class `class` with some class slots:
- Creates two superclasses `superclass1` and `superclass2` with different numbers of class slots.
- Tests that the order, the index and the offsets of the slots are correctly updated when `class` changes from one superclass to the other.
- Also checks that the class slots are updated in a subclass of `class` called `subclass`.
