### PR TITLE
[P14] 17513-ASTMessageNode-does-not-understand-sourceNodeForPC--when-renaming-parser-class

### DIFF
--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -38,5 +38,7 @@ CompiledCode >> sourceNodeForPC: aPC [
 		ifPresent: [ :bcToASTCache |
 			^ bcToASTCache nodeForPC: aPC ].
 
-	^ sourceNode sourceNodeForPC: aPC
+	^ sourceNode isBlock 
+		ifTrue: [sourceNode sourceNodeForPC: aPC]
+		ifFalse: [ sourceNode ]
 ]


### PR DESCRIPTION
Fixes #17513
It handles the case when the returned node is not a block node