### PR TITLE
Removed deprecation rewriting for SmalltalkImage >> os

### DIFF
--- a/src/Deprecated14/SmalltalkImage.extension.st
+++ b/src/Deprecated14/SmalltalkImage.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'SmalltalkImage' }
 SmalltalkImage >> os [
 	"Answer the object to query about os."
 
-	self deprecated: 'Use `OSPlatform current` instead' transformWith: '`@rcv os' -> 'OSPlatform current'.
+	self deprecated: 'Use `OSPlatform current` instead'.
 	^ OSPlatform current
 ]
 


### PR DESCRIPTION
Deprecation rewriting was causing an error when trying to install a baseline with Metacello (see the general chat in the discord server)