### PR TITLE
Pragma cache should filter for obsoletes

### DIFF
--- a/src/Kernel-CodeModel/Pragma.class.st
+++ b/src/Kernel-CodeModel/Pragma.class.st
@@ -39,7 +39,7 @@ Pragma class >> addToCache: aPragma [
 Pragma class >> all [
 	"all pragmas whose methods are currently installed in the system"
 	^ self pragmaCache values flattened select: [ :each |
-		  each method isInstalled ]
+		  each method isInstalled and: [ each method methodClass isObsolete not ]]
 ]
 
 { #category : 'finding' }
@@ -53,7 +53,7 @@ Pragma class >> allNamed: aSymbol [
 	pragmas ifEmpty: [ self pragmaCache removeKey: aSymbol ifAbsent: [  ] ].
 	"we check if the pragma is really from an installed method
 	(others will be cleaned up by the gc when the method is garbadge collected)"
-	^ (pragmas select: [ :each | each method isInstalled ]) asArray
+	^ (pragmas select: [ :each | each method isInstalled and: [ each method methodClass isObsolete not ]]) asArray
 ]
 
 { #category : 'finding' }

--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -36,6 +36,27 @@ PragmaTest >> testAllNamed [
 	self assert: (Pragma allNamed: #nonExistingPragma) isEmpty
 ]
 
+{ #category : 'tests - cache' }
+PragmaTest >> testAllNamedObsolete [
+	"We test that the cache query never returns Pragmas from Obsolete classes"
+	
+	| classForTesting |
+	
+	classForTesting := self class classInstaller make: [ :builder | 
+			builder 
+				superclass: Object;
+				name: #MyPragmaCacheTestClass
+			 ].
+	
+	classForTesting compile: 'methodWithPraga <myPragmaCacheTestPragma>'.
+	
+	self deny: (Pragma allNamed: #myPragmaCacheTestPragma) isEmpty.
+
+	classForTesting removeFromSystem.
+	
+	self assert: (Pragma allNamed: #myPragmaCacheTestPragma) isEmpty
+]
+
 { #category : 'tests' }
 PragmaTest >> testArgumentAt [
 	| pragma |


### PR DESCRIPTION
Filter the pragmas returned from the cache  (remove obsoletes) testAllNamedObsolete failed before, is green now

fixes #18752