### PR TITLE
Fix loading of baselines with imports

### DIFF
--- a/src/Metacello-Core/MetacelloRecordTarget.class.st
+++ b/src/Metacello-Core/MetacelloRecordTarget.class.st
@@ -59,7 +59,7 @@ MetacelloRecordTarget >> packageSpecsInLoadOrderFrom: aVersionSpec [
 
 	| loadOrder specsToLoad packageNames importNames importSpec importProjectSpecs importProjectNameMap |
 	loadOrder := aVersionSpec packageSpecsInLoadOrder.
-	importNames := packageNames := ((self listLoadableSpecsFrom: aVersionSpec) collect: [ :spec | spec name ]) asSet.
+	importNames := (packageNames := ((self listLoadableSpecsFrom: aVersionSpec) collect: [ :spec | spec name ]) asSet) copy.
 
 	aVersionSpec hasImports ifFalse: [ ^ loadOrder select: [ :spec | packageNames includes: spec name ] ].
 


### PR DESCRIPTION
During my cleaning of Metacello I cleaned a lot of unecessary copy but it seems that one was required. 

Adding it back.

Fixes #19878

*done on my free time*