### PR TITLE
Fix 19869: don't export action settings, don't let one broken entry block startup, and don't leave a stale tail when rewriting the export file

### DIFF
--- a/src/StartupPreferences-Tests/StartupActionTest.class.st
+++ b/src/StartupPreferences-Tests/StartupActionTest.class.st
@@ -1,0 +1,95 @@
+Class {
+	#name : 'StartupActionTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'loader',
+		'savedActions',
+		'savedErrors'
+	],
+	#category : 'StartupPreferences-Tests-Startup',
+	#package : 'StartupPreferences-Tests',
+	#tag : 'Startup'
+}
+
+{ #category : 'running' }
+StartupActionTest >> brokenAction [
+
+	^ StartupAction
+		name: 'Broken action'
+		code: '(Smalltalk globals at: #Object) perform: #thisSelectorDoesNotExist'
+		runOnce: true
+]
+
+{ #category : 'running' }
+StartupActionTest >> setUp [
+	"#execute writes into the live singleton, whose actions dictionary is part of
+	 the running image and holds the user's real startup history. Save and restore
+	 it rather than clearing it outright."
+
+	super setUp.
+	loader := StartupPreferencesLoader default.
+	savedActions := loader actions copy.
+	savedErrors := loader errors copy.
+	loader cleanSavedActionsAndErrors
+]
+
+{ #category : 'running' }
+StartupActionTest >> tearDown [
+
+	loader cleanSavedActionsAndErrors.
+	"#actions is a Dictionary, so #addAll: needs a keyed collection — passing an
+	 Array of associations would make Dictionary>>addAll: iterate index->element."
+	loader actions addAll: savedActions.
+	loader errors addAll: savedErrors.
+	super tearDown
+]
+
+{ #category : 'running' }
+StartupActionTest >> testBrokenActionDoesNotRaise [
+	"#execute does not propagate a failure raised by the action's own code. One bad
+	 entry in a shared preferences file would otherwise abort the whole startup
+	 sequence (see #19869)."
+
+	self brokenAction execute
+]
+
+{ #category : 'running' }
+StartupActionTest >> testBrokenActionIsNotMarkedAsExecuted [
+	"A failed action stays unexecuted. #add: keys actions by name in a dictionary that
+	 is saved with the image and never resets this flag, so an action marked executed
+	 is never attempted again -- across image saves, and after the exported file has
+	 been corrected."
+
+	| action |
+	action := self brokenAction.
+	action execute.
+	self deny: action hasBeenExecuted
+]
+
+{ #category : 'running' }
+StartupActionTest >> testBrokenActionIsRecordedInErrors [
+	"The failure is recorded in StartupPreferencesLoader default errors, paired with
+	 the action that raised it. Swallowing the exception is only acceptable because
+	 it stays observable here."
+
+	| action |
+	action := self brokenAction.
+	action execute.
+	self assert: loader errors size equals: 1.
+	self assert: loader errors first second identicalTo: action
+]
+
+{ #category : 'running' }
+StartupActionTest >> testSuccessfulActionIsMarkedAsExecuted [
+	"An action whose code completes is marked executed and records no error. With
+	 #testBrokenActionIsNotMarkedAsExecuted this pins both outcomes of the
+	 #hasBeenExecuted assignment."
+
+	| action executed |
+	executed := false.
+	action := StartupAction name: 'Working action' code: [ executed := true ] runOnce: true.
+	action execute.
+	self assert: executed.
+	self assert: action hasBeenExecuted.
+	self assert: loader errors isEmpty
+]

--- a/src/StartupPreferences-Tests/StartupPreferencesLoaderTest.class.st
+++ b/src/StartupPreferences-Tests/StartupPreferencesLoaderTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : 'StartupPreferencesLoaderTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'dir',
+		'loader'
+	],
+	#category : 'StartupPreferences-Tests-Startup',
+	#package : 'StartupPreferences-Tests',
+	#tag : 'Startup'
+}
+
+{ #category : 'running' }
+StartupPreferencesLoaderTest >> setUp [
+	"Only the file-writing path is exercised here, which touches neither the
+	 actions dictionary nor the errors collection, so the live singleton needs no
+	 saving and restoring."
+
+	super setUp.
+	dir := FileSystem memory root / 'prefs'.
+	loader := StartupPreferencesLoader default
+]
+
+{ #category : 'running' }
+StartupPreferencesLoaderTest >> testRewritingWithShorterContentLeavesNoStaleTail [
+	"Rewriting an existing script with shorter content leaves exactly the new
+	 content. #writeStreamDo: does not truncate, so the tail of the longer previous
+	 file would otherwise remain and stop the whole file from parsing at startup,
+	 taking every setting in it down (see #19869). Exercised through the private
+	 write method because it is the single write point for every #addAtStartupIn*
+	 variant, and the public ones all target real folders on disk."
+
+	| long short |
+	long := (1 to: 10) collect: [ :i |
+		StartupAction name: 'Action ', i printString code: 'Object new' runOnce: true ].
+	short := { StartupAction name: 'Action 1' code: 'Object new' runOnce: true }.
+
+	loader addAtStartup: long inDirectory: dir named: 'test.st'.
+	loader addAtStartup: short inDirectory: dir named: 'test.st'.
+
+	self
+		assert: (dir / 'test.st') contents
+		equals: (loader buildStreamFor: short).
+
+	"The previous version is archived outside the '*.st' glob that
+	 StartupPreferencesHandler collects, so the folder still holds one startup script."
+	self assert: (dir filesMatching: '*.st') size equals: 1
+]

--- a/src/StartupPreferences/StartupAction.class.st
+++ b/src/StartupPreferences/StartupAction.class.st
@@ -62,8 +62,14 @@ StartupAction >> execute [
 				ifFalse: [[ self class compiler evaluate: self code ]].
 	correctlyExecuted := true.
 	block on: Halt, Error do: [ :ex |
+		"A broken StartupAction -- e.g. one referencing a selector that does not
+		 exist, see #19869 -- must never interrupt the rest of the startup
+		 sequence nor open a blocking Debugger on an end user's machine. Record
+		 it for diagnosis, mark it as not executed so a later corrected export
+		 can still apply, and move on."
 		StartupPreferencesLoader default errors add: {ex. self}.
-		ex pass ].
+		correctlyExecuted := false.
+		ex return ].
 	self hasBeenExecuted: correctlyExecuted
 ]
 

--- a/src/StartupPreferences/StartupPreferencesLoader.class.st
+++ b/src/StartupPreferences/StartupPreferencesLoader.class.st
@@ -232,10 +232,14 @@ StartupPreferencesLoader >> add: anAction [
 	^ action
 ]
 
-{ #category : 'private' }
+{ #category : 'adding' }
 StartupPreferencesLoader >> addAtStartup: aCollection inDirectory: aFileReference named: fileName [
+
+	| file |
 	aFileReference ensureCreateDirectory.
-	aFileReference / fileName writeStreamDo: [ :stream | stream nextPutAll: (self buildStreamFor: aCollection) ]
+	file := aFileReference / fileName.
+	self backUpAndRemove: file.
+	file writeStreamDo: [ :stream | stream nextPutAll: (self buildStreamFor: aCollection) ]
 ]
 
 { #category : 'script generation' }
@@ -288,6 +292,34 @@ StartupPreferencesLoader >> addTemplateForStartupInDirectory: aFileReference nam
 					stream nextPutAll: self templateString ] ]
 		ifTrue: [ InformativeNotification signal: 'This file already exists' ].
 	(aFileReference / fileName) inspect
+]
+
+{ #category : 'adding' }
+StartupPreferencesLoader >> backUpAndRemove: aFileReference [
+	"Move an existing startup script aside before it gets rewritten, keeping the
+	 previous version as a backup.
+
+	 #writeStreamDo: does not truncate, so writing shorter content over a longer
+	 existing file leaves the previous tail on disk. That tail then fails to parse
+	 at startup and takes every setting in the file down with it (see #19869).
+
+	 The backup deliberately drops the .st extension. StartupPreferencesHandler
+	 collects startup scripts with #filesMatching: '*.st', so a backup still named
+	 .st would be loaded on the next startup alongside the current file, and would
+	 replay exactly the entries it exists to preserve a copy of.
+
+	 Mirrors SystemSettingsPersistence>>removeFileReference, which solves the same
+	 problem for the 'Store Settings' pipeline and picks 'old.txt' for the same
+	 reason."
+
+	| backup |
+	aFileReference ifAbsent: [ ^ self ].
+	backup := aFileReference withExtension: 'old.txt'.
+	"#renameTo: fails if the destination already exists."
+	backup ensureDelete.
+	"#renameTo: mutates its receiver's path, so rename a copy and leave
+	 aFileReference pointing at the now-free original path."
+	aFileReference copy renameTo: backup basename
 ]
 
 { #category : 'private' }

--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -22,6 +22,16 @@ ActionSettingDeclaration >> actionLabel: anObject [
 ]
 
 { #category : 'accessing' }
+ActionSettingDeclaration >> hasValue [
+	"An action setting (a button) holds no persistable value — it triggers a
+	 side-effecting action when invoked. It must never be included in an
+	 exported startup script, and its 'current value' must never be computed
+	 by actually invoking the action (see #19869)."
+
+	^ false
+]
+
+{ #category : 'accessing' }
 ActionSettingDeclaration >> realValue [
 	"Private - Morphic requirement. To be deleted when morphic gets removed"
 

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -150,13 +150,14 @@ SettingDeclaration >> emptyList [
 { #category : 'export' }
 SettingDeclaration >> exportSettingAction [
 	"Return the startup actions that set this setting when the value differs from the default.
-	
+
 	Returns: a StartupAction or nil if no changes
-	
+
 	It is up to the caller to filter nil results"
 
 	target isClass ifFalse: [ ^ nil ].
 	self isTransient ifTrue: [ ^ nil ].
+	self hasValue ifFalse: [ ^ nil ].
 
 	^ (self hasDefault not or: [ self default ~= self findCurrentSettingValue ])
 		  ifTrue: [ self startupAction ]

--- a/src/System-Settings-Tests/MockSettings.class.st
+++ b/src/System-Settings-Tests/MockSettings.class.st
@@ -108,6 +108,21 @@ MockSettings class >> defaultDirectoryName: aFileReference [
 ]
 
 { #category : 'settings' }
+MockSettings class >> mockAction [ 
+	"Mimics a real action setting: a unary action method with no matching
+	 keyword setter — this is the shape that #19869 exported incorrectly."
+
+	^ self
+]
+
+{ #category : 'settings' }
+MockSettings class >> mockActionNodeOn: aBuilder [ 
+	<mocksystemsettings>
+	(aBuilder button: #mockAction)
+		label: 'Mock action setting'
+]
+
+{ #category : 'settings' }
 MockSettings class >> monticelloSettingsOn: aBuilder [
 	<mocksystemsettings>
 	(aBuilder group: #monticello)

--- a/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
+++ b/src/System-Settings-Tests/SystemSettingsPersistenceTest.class.st
@@ -88,6 +88,25 @@ SystemSettingsPersistenceTest >> testAccessibleRealValues [
 ]
 
 { #category : 'tests' }
+SystemSettingsPersistenceTest >> testActionSettingIsNotExported [
+	"An action/button setting has no persistable value, so #exportSettingAction
+	 answers nil for it. Exporting one invokes the action as a side effect through
+	 #findCurrentSettingValue, and emits a keyword selector that does not exist
+	 (see #19869)."
+
+	| actionNode |
+	actionNode := systemSettings nodeNamed: #mockAction.
+
+	"Guard: make sure a nil result really comes from #hasValue and not from an
+	 earlier guard in #exportSettingAction, which would make this test vacuous."
+	self assert: actionNode item target isClass.
+	self deny: actionNode item isTransient.
+
+	self deny: actionNode item hasValue.
+	self assert: actionNode item exportSettingAction isNil
+]
+
+{ #category : 'tests' }
 SystemSettingsPersistenceTest >> testAllStoredSettings [
 	"There is no preference file. It should not generate an error."
 
@@ -299,6 +318,19 @@ SystemSettingsPersistenceTest >> testUpdateAllSettings [
 	systemSettings updateSettingNodes.
 	self assert: self booleanSettingNode realValue equals: false.
 	self assert: self rangeSettingNode realValue equals: 55
+]
+
+{ #category : 'tests' }
+SystemSettingsPersistenceTest >> testValueHoldingSettingIsStillExported [ 
+	"A setting that does hold a value still exports. This is the other side of the
+	 #hasValue guard, which must filter out action settings and nothing else.
+	 #booleanSetting is declared without a #default:, so #hasDefault is false and it
+	 exports unconditionally."
+
+	| node |
+	node := systemSettings nodeNamed: #booleanSetting.
+	self assert: node item hasValue.
+	self assert: node item exportSettingAction isNotNil
 ]
 
 { #category : 'tests - loading' }


### PR DESCRIPTION
This PR fixes: #19869 which seems to have started in build 731

Hello guys, I’m starting to familiarize myself with “pair programming with AI,” and I worked on this issue to test out some of my own ideas on how to use it, because Pharo is perfect to it.
All 3 commits I'm proposing are very detailed.
Feel free to let me know if this fix was helpful, if it’s too detailed (issue, commits and pr), if it makes sense or if this is a valid approach or not, thanks
At least the bug has been fixed :)

### Summary

Three small, independent commits, one per defect described in #19869:

1. **Write side** — Export no longer generates a `StartupAction` for action/button settings, which have no value to export.
2. **Replay side** — a `StartupAction` that fails is recorded and skipped instead of interrupting the rest of the startup sequence.
3. **File side** — the export file is moved aside before being rewritten, so a shorter export cannot leave the tail of a longer previous one behind.

Commit 1 fixes the cause. Commit 2 keeps an already-poisoned image bootable. Commit 3 fixes a distinct corruption that commit 2 cannot catch, because it happens at parse time before any `StartupAction` exists.

### Alternatives considered

- **Redesign `StartupAction` into a structured, versioned format** (class + selector + arguments, instead of generating and `compiler evaluate:`-ing a `perform:with:` string), as suggested in the issue. Directionally right — it would also allow detecting a renamed or removed selector *before* replaying. Out of scope: a much larger, higher-risk change for a bug with a small, uncontroversial cause. Worth its own issue.
- **Fix only the write side and stop there.** Rejected: it does nothing for anyone who already exported on 731–735, and nothing at all for defect 3.
- **Use `isTransient: true` on `ActionSettingDeclaration`**, mirroring what build 731 did for `SpIconPacksFetchPresenter`. Rejected in favour of `hasValue`: `isTransient` is a per-instance opt-out that must be set on every button; `hasValue` is a per-class contract that covers the whole category, present and future, which is exactly the gap that caused this bug.
- **Keep `ex pass` and wrap `file fileIn` in `load:` instead.** That would contain a parse failure to one file, but would not stop a single broken *entry* from killing every other setting in the same file. Commits 2 and 3 address the two failure modes at their actual causes instead.
- **Delete the old file instead of renaming it** in commit 3. Simpler, and leaves no `.old.txt` siblings — but a write failing midway would then lose the previous export with nothing to fall back on, and anyone hitting this bug would lose the corrupted file that shows what went wrong. Renaming costs one extra file per exported group and matches what `SystemSettingsPersistence` already does in the same feature area.
- **Fix `FileReference>>writeStream` to truncate.** This is the real, general defect — `writeStreamDo:` never truncates anywhere in the image, and `truncateTo:` has no senders. But it has 100+ call sites across 40+ packages and changing it is far beyond fixing #19869. 
 
### Related

- Reported in #19869 (this PR fixes it).
- Defect 1 traced to PR #19847 / commit `f0f40f1f0ec97e3d8abd1b10c20cb3fb2e2d67e7`, first shipped in Pharo 14.0 build 731.
- #18558 shares the `hasValue` mechanism but concerns a different pipeline and an open design question; not resolved here. Separate reply on that issue.
- Follow-ups filed separately: `hasBeenExecuted` never resets; stale actions and stale files are never removed; `writeStreamDo:` does not truncate.