### PR TITLE
Fix: debug point icon refresh from source code

### DIFF
--- a/src/Calypso-SystemPlugins-DebugPoints-Browser/DebugPointIconStyler.class.st
+++ b/src/Calypso-SystemPlugins-DebugPoints-Browser/DebugPointIconStyler.class.st
@@ -99,8 +99,13 @@ DebugPointIconStyler >> icon: dp [
 
 { #category : 'defaults' }
 DebugPointIconStyler >> iconBlockEdit: dp [
-		 ^ [ :seg | dp remove.
-	   seg delete ]
+
+	^ [ :seg |
+		  | interval |
+		  interval := seg interval.
+		  dp remove.
+		  renderer textModel announce: (RubConfigurationChange new configurationBlock: [ :scrolledTextMorph |
+				   (scrolledTextMorph textArea segments select: [ :s | s interval = interval ]) do: [ :s | s delete ] ]) ]
 ]
 
 { #category : 'defaults' }


### PR DESCRIPTION
`iconBlockEdit:` only deleted the segment that triggered the click (seg delete) — the sibling display segment was left in the editor, so the icon stayed visible until the method was restyled from scratch (e.g. by switching methods and back). Fix: instead of deleting only the clicked segment, re-announce a RubConfigurationChange on renderer textModel to delete every segment sharing the same interval. This removes both the display and "Remove" segments in one go.