### PR TITLE
Fix refreshing block for source code search

### DIFF
--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -242,8 +242,13 @@ SystemNavigation >> browseMessageList: messageList name: label [
 
 { #category : '*Tool-Base' }
 SystemNavigation >> browseMessageList: messageList name: labelString autoSelect: autoSelectString [
-	"By default it never refreshes"
-	^self browseMessageList: messageList name: labelString autoSelect: autoSelectString refreshingBlock: [ :method | false ]
+
+	^ self
+		  browseMessageList: messageList
+		  name: labelString
+		  autoSelect: autoSelectString
+		  refreshingBlock: [ :method |
+			  autoSelectString ifNil: [ true ] ifNotNil: [ method sourceCode includesSubstring: autoSelectString caseSensitive: false ] ]
 ]
 
 { #category : '*Tool-Base' }


### PR DESCRIPTION
There was a bug in the method browser: when searching source code that has multiple occurences in a single method, the removal of one occurence caused the removal of the method in the browser, although there was remaining occurences.
Fix: pass the good refreshing block in there, as it was never refreshed