### PR TITLE
Fixed Compiler is too lax. Now pseudovariables are not allowed to be var or argument names

### DIFF
--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1778,7 +1778,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| self | self := 1. ^ self';
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1787,7 +1786,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1796,7 +1794,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1845,7 +1842,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :self | self + 1 ]';
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:
@@ -1854,7 +1850,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:
@@ -1863,7 +1858,6 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
-			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:

--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1778,6 +1778,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| self | self := 1. ^ self';
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1786,6 +1787,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1794,6 +1796,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 1;
 			         notices:
@@ -1842,6 +1845,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :self | self + 1 ]';
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:
@@ -1850,6 +1854,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:
@@ -1858,6 +1863,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
+			         isScripting: false;
 			         isFaulty: true;
 			         value: 2;
 			         notices:

--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1778,7 +1778,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| self | self := 1. ^ self';
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 1;
 			         notices:
 				         #( #( 3 6 3 'self is a reserved word and cannot be used as a temporary variable name' ) )).
@@ -1786,7 +1786,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 1;
 			         notices:
 				         #( #( 3 7 3 'super is a reserved word and cannot be used as a temporary variable name' ) )).
@@ -1794,7 +1794,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 1;
 			         notices:
 				         #( #( 3 13 3 'thisContext is a reserved word and cannot be used as a temporary variable name' ) )).
@@ -1809,7 +1809,7 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '00000111103355554446';
 			         styled: 'pppp AAAA ^ aaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 6 9 6 'self is a reserved word and cannot be used as a parameter name' ) )).
@@ -1818,7 +1818,7 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '0000011111033555554446';
 			         styled: 'pppp AAAAA ^ aaaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 6 10 6 'super is a reserved word and cannot be used as a parameter name' ) )).
@@ -1827,7 +1827,7 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '0000011111111111033555555555554446';
 			         styled: 'pppp AAAAAAAAAAA ^ aaaaaaaaaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 6 16 6 'thisContext is a reserved word and cannot be used as a parameter name' ) )).
@@ -1842,7 +1842,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :self | self + 1 ]';
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 4 7 4 'self is a reserved word and cannot be used as a parameter name' ) )).
@@ -1850,7 +1850,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 4 8 4 'super is a reserved word and cannot be used as a parameter name' ) )).
@@ -1858,7 +1858,7 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
-			         isFaulty: true;
+			         isFaulty: false;
 			         value: 2;
 			         notices:
 				         #( #( 4 14 4 'thisContext is a reserved word and cannot be used as a parameter name' ) )).

--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1779,25 +1779,19 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
 			         isFaulty: false;
-			         value: 1;
-			         notices:
-				         #( #( 3 6 3 'self is a reserved word and cannot be used as a temporary variable name' ) )).
+			         value: 1).
 		        (self new
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
 			         isFaulty: false;
-			         value: 1;
-			         notices:
-				         #( #( 3 7 3 'super is a reserved word and cannot be used as a temporary variable name' ) )).
+			         value: 1).
 		        (self new
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
 			         isFaulty: false;
-			         value: 1;
-			         notices:
-				         #( #( 3 13 3 'thisContext is a reserved word and cannot be used as a temporary variable name' ) )).
+			         value: 1).
 		        (self new
 			         source: '| Object | Object := 1. ^ Object';
 			         nodeAt: '00111111000444444222230055666666';
@@ -1843,25 +1837,19 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
 			         isFaulty: false;
-			         value: 2;
-			         notices:
-				         #( #( 4 7 4 'self is a reserved word and cannot be used as a parameter name' ) )).
+			         value: 2).
 		        (self new
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
 			         isFaulty: false;
-			         value: 2;
-			         notices:
-				         #( #( 4 8 4 'super is a reserved word and cannot be used as a parameter name' ) )).
+			         value: 2).
 		        (self new
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
 			         isFaulty: false;
-			         value: 2;
-			         notices:
-				         #( #( 4 14 4 'thisContext is a reserved word and cannot be used as a parameter name' ) )).
+			         value: 2).
 		        (self new
 			         source: '[ :Object | Object + 1 ]';
 			         nodeAt: '000111111000444444333500';

--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1778,20 +1778,26 @@ OCCodeSnippet class >> badSemantic [
 			         source: '| self | self := 1. ^ self';
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
+			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 6 3 'Name already defined' ) )).
+			         notices:
+				         #( #( 3 6 3 'self is a reserved word and cannot be used as a temporary variable name' ) )).
 		        (self new
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
+			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 7 3 'Name already defined' ) )).
+			         notices:
+				         #( #( 3 7 3 'super is a reserved word and cannot be used as a temporary variable name' ) )).
 		        (self new
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
+			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 13 3 'Name already defined' ) )).
+			         notices:
+				         #( #( 3 13 3 'thisContext is a reserved word and cannot be used as a temporary variable name' ) )).
 		        (self new
 			         source: '| Object | Object := 1. ^ Object';
 			         nodeAt: '00111111000444444222230055666666';
@@ -1803,22 +1809,28 @@ OCCodeSnippet class >> badSemantic [
 			         nodeAt: '00000111103355554446';
 			         styled: 'pppp AAAA ^ aaaa s n';
 			         isScripting: false;
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 9 6 'Name already defined' ) )).
+			         notices:
+				         #( #( 6 9 6 'self is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: 'foo: super ^ super + 1';
 			         nodeAt: '0000011111033555554446';
 			         styled: 'pppp AAAAA ^ aaaaa s n';
 			         isScripting: false;
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 10 6 'Name already defined' ) )).
+			         notices:
+				         #( #( 6 10 6 'super is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: 'foo: thisContext ^ thisContext + 1';
 			         nodeAt: '0000011111111111033555555555554446';
 			         styled: 'pppp AAAAAAAAAAA ^ aaaaaaaaaaa s n';
 			         isScripting: false;
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 16 6 'Name already defined' ) )).
+			         notices:
+				         #( #( 6 16 6 'thisContext is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: 'foo: Object ^ Object + 1';
 			         nodeAt: '000001111110335555554446';
@@ -1830,20 +1842,26 @@ OCCodeSnippet class >> badSemantic [
 			         source: '[ :self | self + 1 ]';
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 7 4 'Name already defined' ) )).
+			         notices:
+				         #( #( 4 7 4 'self is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 8 4 'Name already defined' ) )).
+			         notices:
+				         #( #( 4 8 4 'super is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
+			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 14 4 'Name already defined' ) )).
+			         notices:
+				         #( #( 4 14 4 'thisContext is a reserved word and cannot be used as a parameter name' ) )).
 		        (self new
 			         source: '[ :Object | Object + 1 ]';
 			         nodeAt: '000111111000444444333500';

--- a/src/Monticello-BackwardCompatibility/MCClassTraitDefinition.class.st
+++ b/src/Monticello-BackwardCompatibility/MCClassTraitDefinition.class.st
@@ -137,7 +137,8 @@ MCClassTraitDefinition >> loadWithLoader: aLoader [
 
 	| compiler |
 	compiler := self class compiler
-		strict: aLoader isStrict.
+		strict: aLoader isStrict;
+		permitShadowing: true.
 	
 	aLoader targetEnvironment ifNotNil: [
 		compiler environment: aLoader targetEnvironment ].

--- a/src/Monticello-BackwardCompatibility/MCClassTraitDefinition.class.st
+++ b/src/Monticello-BackwardCompatibility/MCClassTraitDefinition.class.st
@@ -137,8 +137,7 @@ MCClassTraitDefinition >> loadWithLoader: aLoader [
 
 	| compiler |
 	compiler := self class compiler
-		permitFaulty: aLoader isStrict not;
-		permitUndeclared: aLoader isStrict not.
+		strict: aLoader isStrict.
 	
 	aLoader targetEnvironment ifNotNil: [
 		compiler environment: aLoader targetEnvironment ].

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -227,6 +227,7 @@ MCMethodDefinition >> loadWithLoader: aLoader [
 
 	compiler := actualClass compiler
 		            strict: aLoader isStrict;
+						permitShadowing: true;
 		            source: source.
 
 	method := compiler compileOrFail.

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -226,8 +226,7 @@ MCMethodDefinition >> loadWithLoader: aLoader [
 	actualClass ifNil: [ Error signal: 'Class not found: ' , className printString ].
 
 	compiler := actualClass compiler
-		            permitFaulty: aLoader isStrict not;
-		            permitUndeclared: aLoader isStrict not;
+		            strict: aLoader isStrict;
 		            source: source.
 
 	method := compiler compileOrFail.

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -78,9 +78,7 @@ Behavior >> compile: sourceCode methodInstaller: methodInstaller [
 	sourceCode ifEmpty: [ Error signal: 'The source code should not be empty' ].
 	compiler := self compiler
 		            source: sourceCode;
-		            "compatibility: permit undeclared if no requestor"
-		            permitUndeclared: false;
-		            permitFaulty: false.
+		            strict.
 	method := compiler compileOrFail.
 	methodInstaller install: method into: self compiler: compiler.
 	^ method selector

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -143,13 +143,13 @@ OCASTSemanticAnalyzer >> checkReservedName: aVariableNode as: aVariable [
 	kind := aVariable isArgumentVariable
 		ifTrue: [ 'a parameter' ]
 		ifFalse: [ 'a temporary variable' ].
-	aVariableNode addError: name, ' is a reserved word and cannot be used as ', kind, ' name'
+	aVariableNode addNotice: (OCReservedVariableNotice new messageText: name, ' is a reserved word and cannot be used as ', kind, ' name')
 ]
 
 { #category : 'error handling' }
 OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 
-	aNode addWarning: 'Name already defined'
+	aNode addNotice: (OCShadowingNotice new messageText: 'Name already defined')
 ]
 
 { #category : 'error handling' }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -89,11 +89,13 @@ OCASTSemanticAnalyzer >> declareTemporaryNode: aVariableNode [
 OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable [
 	| name var shadowing |
 	name := aVariableNode name.
+	self checkReservedName: aVariableNode as: anOCTempVariable.
 	"check if another variable with same name is visible"
 	shadowing := scope lookupVar: name.
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
-	(shadowing isNotNil and: [ shadowing allowsShadowing not]) ifTrue: [self shadowing: shadowing withVariable: aVariableNode].
+	(shadowing isNotNil and: [ shadowing allowsShadowing not and: [ shadowing isPseudoVariable not ] ])
+		ifTrue: [ self shadowing: shadowing withVariable: aVariableNode ].
 	^ var
 ]
 
@@ -129,6 +131,19 @@ OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
 { #category : 'initialization' }
 OCASTSemanticAnalyzer >> scope: aSemScope [
 	scope := aSemScope
+]
+
+{ #category : 'error handling' }
+OCASTSemanticAnalyzer >> checkReservedName: aVariableNode as: aVariable [
+
+	| name kind |
+	self compilationContext isScripting ifTrue: [ ^ self ].
+	name := aVariableNode name.
+	(Symbol reservedLiterals includes: name) ifFalse: [ ^ self ].
+	kind := aVariable isArgumentVariable
+		ifTrue: [ 'a parameter' ]
+		ifFalse: [ 'a temporary variable' ].
+	aVariableNode addError: name, ' is a reserved word and cannot be used as ', kind, ' name'
 ]
 
 { #category : 'error handling' }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -53,6 +53,19 @@ OCASTSemanticAnalyzer >> blockCounter [
 	^blockCounter ifNil: [0]
 ]
 
+{ #category : 'error handling' }
+OCASTSemanticAnalyzer >> checkReservedName: aVariableNode as: aVariable [
+
+	| name kind |
+	self compilationContext isScripting ifTrue: [ ^ self ].
+	name := aVariableNode name.
+	(Symbol reservedLiterals includes: name) ifFalse: [ ^ self ].
+	kind := aVariable isArgumentVariable
+		ifTrue: [ 'a parameter' ]
+		ifFalse: [ 'a temporary variable' ].
+	aVariableNode addNotice: (OCReservedVariableNotice new messageText: name, ' is a reserved word and cannot be used as ', kind, ' name')
+]
+
 { #category : 'accessing' }
 OCASTSemanticAnalyzer >> compilationContext [
 	^ compilationContext
@@ -131,19 +144,6 @@ OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
 { #category : 'initialization' }
 OCASTSemanticAnalyzer >> scope: aSemScope [
 	scope := aSemScope
-]
-
-{ #category : 'error handling' }
-OCASTSemanticAnalyzer >> checkReservedName: aVariableNode as: aVariable [
-
-	| name kind |
-	self compilationContext isScripting ifTrue: [ ^ self ].
-	name := aVariableNode name.
-	(Symbol reservedLiterals includes: name) ifFalse: [ ^ self ].
-	kind := aVariable isArgumentVariable
-		ifTrue: [ 'a parameter' ]
-		ifFalse: [ 'a temporary variable' ].
-	aVariableNode addNotice: (OCReservedVariableNotice new messageText: name, ' is a reserved word and cannot be used as ', kind, ' name')
 ]
 
 { #category : 'error handling' }

--- a/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
@@ -14,8 +14,7 @@ Class {
 { #category : 'testing' }
 OCReservedVariableNotice >> isErrorOn: anOpalCompiler [ 
 
-	| permitShadowing permitFaulty |
-	permitShadowing := anOpalCompiler permitShadowing ifNil: [ false ].
-	permitFaulty := anOpalCompiler permitFaulty ifNil: [ false ].
-	^ permitShadowing not and: [ permitFaulty not ]
+	anOpalCompiler permitShadowing ifNil: [ ^ false ].
+	anOpalCompiler permitFaulty ifNil: [ ^ false ].
+	^ anOpalCompiler permitShadowing not and: [ anOpalCompiler permitFaulty not ]
 ]

--- a/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
@@ -5,7 +5,7 @@ I am an a warning by default. I become an error when the compiler is in strict m
 "
 Class {
 	#name : 'OCReservedVariableNotice',
-	#superclass : 'OCErrorNotice',
+	#superclass : 'OCWarningNotice',
 	#category : 'OpalCompiler-Core-FrontEnd',
 	#package : 'OpalCompiler-Core',
 	#tag : 'FrontEnd'

--- a/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
@@ -1,7 +1,7 @@
 "
 I am a notice raised when a reserved word (e.g. self, super, thisContext) is used as a parameter or temporary variable name.
 
-I am an error by default, and I become a warning when the compiler permits shadowing or faults.
+I am an a warning by default. I become an error when the compiler is in strict mode.
 "
 Class {
 	#name : 'OCReservedVariableNotice',

--- a/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
@@ -1,0 +1,21 @@
+"
+I am a notice raised when a reserved word (e.g. self, super, thisContext) is used as a parameter or temporary variable name.
+
+I am an error by default, and I become a warning when the compiler permits shadowing or faults.
+"
+Class {
+	#name : 'OCReservedVariableNotice',
+	#superclass : 'OCErrorNotice',
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
+}
+
+{ #category : 'testing' }
+OCReservedVariableNotice >> isErrorOn: anOpalCompiler [ 
+
+	| permitShadowing permitFaulty |
+	permitShadowing := anOpalCompiler permitShadowing ifNil: [ false ].
+	permitFaulty := anOpalCompiler permitFaulty ifNil: [ false ].
+	^ permitShadowing not and: [ permitFaulty not ]
+]

--- a/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCReservedVariableNotice.class.st
@@ -12,9 +12,7 @@ Class {
 }
 
 { #category : 'testing' }
-OCReservedVariableNotice >> isErrorOn: anOpalCompiler [ 
+OCReservedVariableNotice >> isErrorOn: anOpalCompiler [
 
-	anOpalCompiler permitShadowing ifNil: [ ^ false ].
-	anOpalCompiler permitFaulty ifNil: [ ^ false ].
-	^ anOpalCompiler permitShadowing not and: [ anOpalCompiler permitFaulty not ]
+	^ anOpalCompiler isStrict
 ]

--- a/src/OpalCompiler-Core/OCShadowingNotice.class.st
+++ b/src/OpalCompiler-Core/OCShadowingNotice.class.st
@@ -14,7 +14,5 @@ Class {
 { #category : 'testing' }
 OCShadowingNotice >> isErrorOn: anOpalCompiler [
 
-	anOpalCompiler permitFaulty ifNil: [ ^ false ].
-	anOpalCompiler permitShadowing ifNil: [ ^ false ].
-	^ anOpalCompiler permitShadowing not and: [ anOpalCompiler permitFaulty not ]
+	^ anOpalCompiler isStrict
 ]

--- a/src/OpalCompiler-Core/OCShadowingNotice.class.st
+++ b/src/OpalCompiler-Core/OCShadowingNotice.class.st
@@ -14,7 +14,7 @@ Class {
 { #category : 'testing' }
 OCShadowingNotice >> isErrorOn: anOpalCompiler [
 
-	| permitFaulty |
-	permitFaulty := anOpalCompiler permitFaulty ifNil: [ false ].
-	^ (anOpalCompiler permitShadowing == false) and: [ permitFaulty not ]
+	anOpalCompiler permitFaulty ifNil: [ ^ false ].
+	anOpalCompiler permitShadowing ifNil: [ ^ false ].
+	^ anOpalCompiler permitShadowing not and: [ anOpalCompiler permitFaulty not ]
 ]

--- a/src/OpalCompiler-Core/OCShadowingNotice.class.st
+++ b/src/OpalCompiler-Core/OCShadowingNotice.class.st
@@ -1,0 +1,20 @@
+"
+I am a notice raised when a variable (argument or temporary) shadows another variable that was already visible (e.g. a global, an instance variable or an outer temporary).
+
+I am a warning by default, and I become an error when the compiler explicitly forbids shadowing (`permitShadowing: false`).
+"
+Class {
+	#name : 'OCShadowingNotice',
+	#superclass : 'OCWarningNotice',
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
+}
+
+{ #category : 'testing' }
+OCShadowingNotice >> isErrorOn: anOpalCompiler [
+
+	| permitFaulty |
+	permitFaulty := anOpalCompiler permitFaulty ifNil: [ false ].
+	^ (anOpalCompiler permitShadowing == false) and: [ permitFaulty not ]
+]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -623,18 +623,6 @@ OpalCompiler >> permitFaulty: aBoolean [
 ]
 
 { #category : 'public access' }
-OpalCompiler >> permitUndeclared [
-
-	^ permitUndeclared
-]
-
-{ #category : 'public access' }
-OpalCompiler >> permitUndeclared: aBoolean [
-
-	permitUndeclared := aBoolean
-]
-
-{ #category : 'public access' }
 OpalCompiler >> permitShadowing [
 
 	^ permitShadowing
@@ -647,13 +635,15 @@ OpalCompiler >> permitShadowing: aBoolean [
 ]
 
 { #category : 'public access' }
-OpalCompiler >> strict [
-	"Set all permit flags to false, so any fault (syntax, undeclared variable, shadowing) is an error"
+OpalCompiler >> permitUndeclared [
 
-	self permitFaulty: false.
-	self permitUndeclared: false.
-	self permitShadowing: false.
-	^ self
+	^ permitUndeclared
+]
+
+{ #category : 'public access' }
+OpalCompiler >> permitUndeclared: aBoolean [
+
+	permitUndeclared := aBoolean
 ]
 
 { #category : 'accessing' }
@@ -748,4 +738,14 @@ OpalCompiler >> source: aString [
 OpalCompiler >> storeSourcesAsProperty: aBoolean [ 
 	
 	compilationContext storeSourcesAsProperty: aBoolean
+]
+
+{ #category : 'public access' }
+OpalCompiler >> strict [
+	"Set all permit flags to false, so any fault (syntax, undeclared variable, shadowing) is an error"
+
+	self permitFaulty: false.
+	self permitUndeclared: false.
+	self permitShadowing: false.
+	^ self
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -475,6 +475,10 @@ OpalCompiler >> generateMethod [
 ]
 
 { #category : 'actions' }
+OpalCompiler >> initialize [ 
+]
+
+{ #category : 'actions' }
 OpalCompiler >> install [
 	"Compile and install a method in a class"
 
@@ -508,6 +512,12 @@ OpalCompiler >> isScripting [
 OpalCompiler >> isScripting: aBoolean [
 
 	self compilationContext isScripting: aBoolean
+]
+
+{ #category : 'public access' }
+OpalCompiler >> isStrict [
+
+	^ permitFaulty not and: [ permitUndeclared not and: [ permitShadowing not ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -753,7 +753,15 @@ OpalCompiler >> storeSourcesAsProperty: aBoolean [
 { #category : 'public access' }
 OpalCompiler >> strict [
 
-	self permitFaulty: false.
-	self permitUndeclared: false.
-	self permitShadowing: false
+	self strict: true
+]
+
+{ #category : 'public access' }
+OpalCompiler >> strict: aBoolean [
+
+	"self strict: true should set permitFaulty:, permitUndeclared:, and permitShadowing: to false"
+
+	self permitFaulty: aBoolean not.
+	self permitUndeclared: aBoolean not.
+	self permitShadowing: aBoolean not
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -475,10 +475,6 @@ OpalCompiler >> generateMethod [
 ]
 
 { #category : 'actions' }
-OpalCompiler >> initialize [ 
-]
-
-{ #category : 'actions' }
 OpalCompiler >> install [
 	"Compile and install a method in a class"
 
@@ -516,6 +512,10 @@ OpalCompiler >> isScripting: aBoolean [
 
 { #category : 'public access' }
 OpalCompiler >> isStrict [
+
+	permitShadowing ifNil: [ ^ false ].
+	permitFaulty ifNil: [ ^ false ].
+	permitUndeclared ifNil: [ ^ false ].
 
 	^ permitFaulty not and: [ permitUndeclared not and: [ permitShadowing not ] ]
 ]
@@ -752,10 +752,8 @@ OpalCompiler >> storeSourcesAsProperty: aBoolean [
 
 { #category : 'public access' }
 OpalCompiler >> strict [
-	"Set all permit flags to false, so any fault (syntax, undeclared variable, shadowing) is an error"
 
 	self permitFaulty: false.
 	self permitUndeclared: false.
-	self permitShadowing: false.
-	^ self
+	self permitShadowing: false
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -474,6 +474,13 @@ OpalCompiler >> generateMethod [
 	^ method
 ]
 
+{ #category : 'initialization' }
+OpalCompiler >> initialize [
+
+	super initialize.
+	permitShadowing := true
+]
+
 { #category : 'actions' }
 OpalCompiler >> install [
 	"Compile and install a method in a class"
@@ -513,7 +520,6 @@ OpalCompiler >> isScripting: aBoolean [
 { #category : 'public access' }
 OpalCompiler >> isStrict [
 
-	permitShadowing ifNil: [ ^ false ].
 	permitFaulty ifNil: [ ^ false ].
 	permitUndeclared ifNil: [ ^ false ].
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -35,6 +35,7 @@ Class {
 		'compilationContextClass',
 		'permitFaulty',
 		'permitUndeclared',
+		'permitShadowing',
 		'logged',
 		'changeStamp',
 		'protocol',
@@ -631,6 +632,28 @@ OpalCompiler >> permitUndeclared [
 OpalCompiler >> permitUndeclared: aBoolean [
 
 	permitUndeclared := aBoolean
+]
+
+{ #category : 'public access' }
+OpalCompiler >> permitShadowing [
+
+	^ permitShadowing
+]
+
+{ #category : 'public access' }
+OpalCompiler >> permitShadowing: aBoolean [
+
+	permitShadowing := aBoolean
+]
+
+{ #category : 'public access' }
+OpalCompiler >> strict [
+	"Set all permit flags to false, so any fault (syntax, undeclared variable, shadowing) is an error"
+
+	self permitFaulty: false.
+	self permitUndeclared: false.
+	self permitShadowing: false.
+	^ self
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Tests/OCCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/OCCodeSnippet.extension.st
@@ -21,7 +21,7 @@ OCCodeSnippet >> doSemanticAnalysisOnError: aBlock [
 	^ [
 		  OpalCompiler new
 			  isScripting: isScripting;
-			  permitFaulty: false;
+			  strict;
 			  source: self source;
 			  newParse ]
 		  on: OCCompilationError

--- a/src/OpalCompiler-Tests/OCCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/OCCodeSnippet.extension.st
@@ -21,7 +21,7 @@ OCCodeSnippet >> doSemanticAnalysisOnError: aBlock [
 	^ [
 		  OpalCompiler new
 			  isScripting: isScripting;
-			  strict;
+			  permitFaulty: false;
 			  source: self source;
 			  newParse ]
 		  on: OCCompilationError

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -138,6 +138,81 @@ OCCompilerTest >> testDoItTempCanShadowReservedWord [
 		equals: 42
 ]
 
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordAllowedInFaultyMode [
+
+	| method |
+	method := OpalCompiler new
+		          source: 'foo: self ^ self + 1';
+		          permitFaulty: true;
+		          compileOrFail.
+	self assert: method isCompiledMethod
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordAllowedWithPermitShadowing [
+
+	| method |
+	method := OpalCompiler new
+		          source: 'foo: self ^ self + 1';
+		          permitShadowing: true;
+		          compileOrFail.
+	self assert: method isCompiledMethod.
+	self
+		assert: (method ast allNotices anySatisfy: [ :n |
+				 n messageText = 'self is a reserved word and cannot be used as a parameter name' ])
+]
+
+{ #category : 'tests - flags' }
+OCCompilerTest >> testStrictSetsAllPermits [
+
+	| compiler |
+	compiler := OpalCompiler new strict.
+	self deny: compiler permitFaulty.
+	self deny: compiler permitUndeclared.
+	self deny: compiler permitShadowing
+]
+
+{ #category : 'tests - shadowing' }
+OCCompilerTest >> testGeneralShadowingErrorsUnderStrict [
+
+	self
+		should: [
+			OpalCompiler new
+				source: 'method: a [ :a | |a| ]';
+				class: MockForCompilation;
+				strict;
+				compileOrFail ]
+		raise: OCCompilationError
+]
+
+{ #category : 'tests - shadowing' }
+OCCompilerTest >> testGeneralShadowingErrorsWithPermitShadowingFalse [
+
+	self
+		should: [
+			OpalCompiler new
+				source: 'method: a [ :a | |a| ]';
+				class: MockForCompilation;
+				permitShadowing: false;
+				compileOrFail ]
+		raise: OCCompilationError
+]
+
+{ #category : 'tests - shadowing' }
+OCCompilerTest >> testGeneralShadowingWarnsByDefault [
+
+	| compiler compilationResult notices |
+	compiler := OpalCompiler new
+		            source: 'method: a [ :a | |a| ]';
+		            class: MockForCompilation.
+	compilationResult := compiler doCompile.
+	self deny: compilationResult isError.
+	notices := compiler ast allNotices select: [ :n | n messageText = 'Name already defined' ].
+	self assert: notices isNotEmpty.
+	self assert: (notices allSatisfy: [ :n | n isWarning ])
+]
+
 { #category : 'tests' }
 OCCompilerTest >> testErrorOrders [
 

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -203,8 +203,14 @@ OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 OCCompilerTest >> testInBlockArgumentReservedWordsShadowing [
 
 	Symbol reservedLiterals do: [ :thePseudoVar |
-			text := 'temp [:' , thePseudoVar asString , ' | ]'.
-			self compileWithFailBlock: [ :result | self assert: result isError ] ]
+		self
+			should: [
+				OpalCompiler new
+					source: 'temp [:' , thePseudoVar asString , ' | ]';
+					class: MockForCompilation;
+					strict;
+					compileOrFail ]
+			raise: OCCompilationError ]
 ]
 
 { #category : 'tests - shadowing' }
@@ -247,8 +253,14 @@ OCCompilerTest >> testInstanceVariableShadowing [
 OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
 
 	Symbol reservedLiterals do: [ :name |
-			text := 'method: ' , name , ' ^ ' , name.
-			self compileWithFailBlock: [ :result | self assert: result isError ] ]
+		self
+			should: [
+				OpalCompiler new
+					source: 'method: ' , name , ' ^ ' , name;
+					class: MockForCompilation;
+					strict;
+					compileOrFail ]
+			raise: OCCompilationError ]
 ]
 
 { #category : 'tests - reserved variables' }
@@ -287,8 +299,14 @@ OCCompilerTest >> testNoShadowing [
 OCCompilerTest >> testPseudoVariableShadowing [
 
 	Symbol reservedLiterals do: [ :thePseudoVar |
-			text := 'method |' , thePseudoVar asString , '| ^' , thePseudoVar asString.
-			self compileWithFailBlock: [ :result | self assert: result isError ] ]
+		self
+			should: [
+				OpalCompiler new
+					source: 'method |' , thePseudoVar asString , '| ^' , thePseudoVar asString;
+					class: MockForCompilation;
+					strict;
+					compileOrFail ]
+			raise: OCCompilationError ]
 ]
 
 { #category : 'tests - reserved variables' }

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -104,6 +104,40 @@ OCCompilerTest >> testAssignmentOfGlobalVarBinding [
 		with: [ :err | self assert: (err messageText beginsWith: 'Compilation failed with following errors:') ]
 ]
 
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method ^ [ :', name, ' | ', name, ' ]';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testBlockTempCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method ^ [ | ', name, ' | ', name, ' ]';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testDoItTempCanShadowReservedWord [
+
+	self
+		assert: (OpalEvaluator new evaluate: '| self | self := 42. ^ self')
+		equals: 42
+]
+
 { #category : 'tests' }
 OCCompilerTest >> testErrorOrders [
 
@@ -129,10 +163,12 @@ OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 
 { #category : 'tests - shadowing' }
 OCCompilerTest >> testInBlockArgumentPseudoVariableShadowing [
-	self initializeErrorMessage.
-	text := 'temp [:thisProcess | ]'.
 
-	self compileWithFailBlock: [ ^ self fail ]
+	| pseudoVariables |
+	pseudoVariables := #( #self #thisProcess #thisContext #super ).
+	pseudoVariables do: [ :thePseudoVar |
+			text := 'temp [:' , thePseudoVar asString , ' | ]'.
+			self compileWithFailBlock: [ :result | self assert: result isError ] ]
 ]
 
 { #category : 'tests - shadowing' }
@@ -171,6 +207,27 @@ OCCompilerTest >> testInstanceVariableShadowing [
 	self compileWithFailBlock: [ ^ self fail ]
 ]
 
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+			text := 'method: ' , name , ' ^ ' , name.
+			self compileWithFailBlock: [ :result | self assert: result isError ] ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testMethodTempCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method: x | ', name, ' | ', name, ' := 33';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
 { #category : 'literals' }
 OCCompilerTest >> testNegativeZero [
 	self
@@ -193,70 +250,11 @@ OCCompilerTest >> testNoShadowing [
 { #category : 'tests - shadowing' }
 OCCompilerTest >> testPseudoVariableShadowing [
 
-	self initializeErrorMessage.
-	text := 'var1 |thisContext| ^thisContext'.
-
-	self compileWithFailBlock: [ ^ self fail ]
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
-
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
-		self
-			should: [
-				OpalCompiler new
-					source: 'method ^ [ :', name, ' | ', name, ' ]';
-					permitFaulty: false;
-					compileOrFail ]
-			raise: OCCompilationError ]
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testBlockTempCannotBeReservedWord [
-
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
-		self
-			should: [
-				OpalCompiler new
-					source: 'method ^ [ | ', name, ' | ', name, ' ]';
-					permitFaulty: false;
-					compileOrFail ]
-			raise: OCCompilationError ]
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testDoItTempCanShadowReservedWord [
-
-	self
-		assert: (OpalEvaluator new evaluate: '| self | self := 42. ^ self')
-		equals: 42
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
-
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
-		self
-			should: [
-				OpalCompiler new
-					source: 'method: ', name, ' ^ ', name;
-					permitFaulty: false;
-					compileOrFail ]
-			raise: OCCompilationError ]
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testMethodTempCannotBeReservedWord [
-
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
-		self
-			should: [
-				OpalCompiler new
-					source: 'method: x | ', name, ' | ', name, ' := 33';
-					permitFaulty: false;
-					compileOrFail ]
-			raise: OCCompilationError ]
+	| pseudoVariables |
+	pseudoVariables := #( #self #thisProcess #thisContext #super ).
+	pseudoVariables do: [ :thePseudoVar |
+			text := 'method |' , thePseudoVar asString , '| ^' , thePseudoVar asString.
+			self compileWithFailBlock: [ :result | self assert: result isError ] ]
 ]
 
 { #category : 'tests - reserved variables' }
@@ -278,14 +276,12 @@ OCCompilerTest >> testReservedWordErrorMessage [
 OCCompilerTest >> testReservedWordErrorMessageForTemp [
 
 	| error |
-	text := 'var1 |thisContext| ^thisContext'.
+	text := 'method |thisContext| ^ thisContext'.
 	self
 		compileWithFailBlock: [ :result |
-			self assert: result ast allNotices size equals: 1.
 			error := result ast allNotices first.
-			self assert: error messageText equals: 'thisContext is a reserved word and cannot be used as a temporary variable name'.
-			self assert: error position equals: 7.
-			^ nil ].
+			self assert: error messageText equals: 'thisContext is a reserved word and cannot be used as a temporary variable name'. 
+			^ self ].
 	self fail
 ]
 

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -179,7 +179,8 @@ OCCompilerTest >> testGeneralShadowingWarnsByDefault [
 	| compiler compilationResult notices |
 	compiler := OpalCompiler new
 		            source: 'method: a [ :a | |a| ]';
-		            class: MockForCompilation.
+		            class: MockForCompilation;
+						permitShadowing: true.
 	compilationResult := compiler doCompile.
 	self deny: compilationResult isError.
 	notices := compiler ast allNotices select: [ :n | n messageText = 'Name already defined' ].
@@ -365,6 +366,7 @@ OCCompilerTest >> testSiblingBlocksInstanceVariableShadowing [
 	OpalCompiler new
 		source: 'temp [:temp | ].[:temp | |var1|]';
 		class: MockForCompilation;
+		permitShadowing: true;
 		compileOrFail
 ]
 

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -319,29 +319,29 @@ OCCompilerTest >> testReservedWordAllowedWithPermitShadowing [
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testReservedWordErrorMessage [
 
-	| error |
+	| compiler result error |
 	text := 'foo: self ^ self + 1'.
-	self
-		compileWithFailBlock: [ :result |
-			self assert: result ast allNotices size equals: 1.
-			error := result ast allNotices first.
-			self assert: error messageText equals: 'self is a reserved word and cannot be used as a parameter name'.
-			self assert: error position equals: 6.
-			^ nil ].
-	self fail
+	compiler := MockForCompilation compiler
+		            source: text;
+		            strict.
+	result := compiler doCompile.
+	error := result ast allNotices first.
+	
+	self assert: error messageText equals: 'self is a reserved word and cannot be used as a parameter name'
 ]
 
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testReservedWordErrorMessageForTemp [
 
-	| error |
+	| error compiler result |
 	text := 'method |self| ^ self'.
-	self
-		compileWithFailBlock: [ :result |
-			error := result ast allNotices first.
-			self assert: error messageText equals: 'self is a reserved word and cannot be used as a temporary variable name'. 
-			^ self ].
-	self fail
+	compiler := MockForCompilation compiler
+		            source: text;
+		            strict.
+	result := compiler doCompile.
+	error := result ast allNotices first.
+	
+	self assert: error messageText equals: 'self is a reserved word and cannot be used as a temporary variable name'
 ]
 
 { #category : 'literals' }

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -107,7 +107,7 @@ OCCompilerTest >> testAssignmentOfGlobalVarBinding [
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
 
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
+	Symbol reservedLiterals do: [ :name |
 		self
 			should: [
 				OpalCompiler new
@@ -120,7 +120,7 @@ OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testBlockTempCannotBeReservedWord [
 
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
+	Symbol reservedLiterals do: [ :name |
 		self
 			should: [
 				OpalCompiler new
@@ -162,11 +162,9 @@ OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 ]
 
 { #category : 'tests - shadowing' }
-OCCompilerTest >> testInBlockArgumentPseudoVariableShadowing [
+OCCompilerTest >> testInBlockArgumentReservedWordsShadowing [
 
-	| pseudoVariables |
-	pseudoVariables := #( #self #thisProcess #thisContext #super ).
-	pseudoVariables do: [ :thePseudoVar |
+	Symbol reservedLiterals do: [ :thePseudoVar |
 			text := 'temp [:' , thePseudoVar asString , ' | ]'.
 			self compileWithFailBlock: [ :result | self assert: result isError ] ]
 ]
@@ -210,7 +208,7 @@ OCCompilerTest >> testInstanceVariableShadowing [
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
 
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
+	Symbol reservedLiterals do: [ :name |
 			text := 'method: ' , name , ' ^ ' , name.
 			self compileWithFailBlock: [ :result | self assert: result isError ] ]
 ]
@@ -218,7 +216,7 @@ OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
 { #category : 'tests - reserved variables' }
 OCCompilerTest >> testMethodTempCannotBeReservedWord [
 
-	#( #self #super #thisContext #thisProcess ) do: [ :name |
+	Symbol reservedLiterals do: [ :name |
 		self
 			should: [
 				OpalCompiler new
@@ -250,9 +248,7 @@ OCCompilerTest >> testNoShadowing [
 { #category : 'tests - shadowing' }
 OCCompilerTest >> testPseudoVariableShadowing [
 
-	| pseudoVariables |
-	pseudoVariables := #( #self #thisProcess #thisContext #super ).
-	pseudoVariables do: [ :thePseudoVar |
+	Symbol reservedLiterals do: [ :thePseudoVar |
 			text := 'method |' , thePseudoVar asString , '| ^' , thePseudoVar asString.
 			self compileWithFailBlock: [ :result | self assert: result isError ] ]
 ]
@@ -276,11 +272,11 @@ OCCompilerTest >> testReservedWordErrorMessage [
 OCCompilerTest >> testReservedWordErrorMessageForTemp [
 
 	| error |
-	text := 'method |thisContext| ^ thisContext'.
+	text := 'method |self| ^ self'.
 	self
 		compileWithFailBlock: [ :result |
 			error := result ast allNotices first.
-			self assert: error messageText equals: 'thisContext is a reserved word and cannot be used as a temporary variable name'. 
+			self assert: error messageText equals: 'self is a reserved word and cannot be used as a temporary variable name'. 
 			^ self ].
 	self fail
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -26,9 +26,7 @@ OCCompilerTest >> compileWithFailBlock: aBlock [
 	| result compiler |
 	compiler := MockForCompilation compiler
 		            source: text;
-		            "compatibility: permit undeclared if no requestor"
-		            permitUndeclared: false;
-		            permitFaulty: false.
+		            strict.
 	result := compiler doCompile.
 	result isError ifTrue: [ aBlock cull: result ]
 ]
@@ -112,7 +110,7 @@ OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
 			should: [
 				OpalCompiler new
 					source: 'method ^ [ :', name, ' | ', name, ' ]';
-					permitFaulty: false;
+					strict;
 					compileOrFail ]
 			raise: OCCompilationError ]
 ]
@@ -125,7 +123,7 @@ OCCompilerTest >> testBlockTempCannotBeReservedWord [
 			should: [
 				OpalCompiler new
 					source: 'method ^ [ | ', name, ' | ', name, ' ]';
-					permitFaulty: false;
+					strict;
 					compileOrFail ]
 			raise: OCCompilationError ]
 ]
@@ -138,39 +136,15 @@ OCCompilerTest >> testDoItTempCanShadowReservedWord [
 		equals: 42
 ]
 
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testReservedWordAllowedInFaultyMode [
+{ #category : 'tests' }
+OCCompilerTest >> testErrorOrders [
 
-	| method |
-	method := OpalCompiler new
-		          source: 'foo: self ^ self + 1';
-		          permitFaulty: true;
-		          compileOrFail.
-	self assert: method isCompiledMethod
-]
-
-{ #category : 'tests - reserved variables' }
-OCCompilerTest >> testReservedWordAllowedWithPermitShadowing [
-
-	| method |
-	method := OpalCompiler new
-		          source: 'foo: self ^ self + 1';
-		          permitShadowing: true;
-		          compileOrFail.
-	self assert: method isCompiledMethod.
+	| ast notices |
+	ast := OpalCompiler new parse: 'foo | b | ^ a + ¿. 5 "what'.
+	notices := ast allNotices sorted collect: [ :e | e position asString , ':' , e messageText ] as: Array.
 	self
-		assert: (method ast allNotices anySatisfy: [ :n |
-				 n messageText = 'self is a reserved word and cannot be used as a parameter name' ])
-]
-
-{ #category : 'tests - flags' }
-OCCompilerTest >> testStrictSetsAllPermits [
-
-	| compiler |
-	compiler := OpalCompiler new strict.
-	self deny: compiler permitFaulty.
-	self deny: compiler permitUndeclared.
-	self deny: compiler permitShadowing
+		assertCollection: notices
+		equals: #( '17:Unknown character' '27:Unmatched " in comment.' '13:Undeclared variable named a in foo' '20:Unreachable statement' '7:Unused variable' )
 ]
 
 { #category : 'tests - shadowing' }
@@ -211,17 +185,6 @@ OCCompilerTest >> testGeneralShadowingWarnsByDefault [
 	notices := compiler ast allNotices select: [ :n | n messageText = 'Name already defined' ].
 	self assert: notices isNotEmpty.
 	self assert: (notices allSatisfy: [ :n | n isWarning ])
-]
-
-{ #category : 'tests' }
-OCCompilerTest >> testErrorOrders [
-
-	| ast notices |
-	ast := OpalCompiler new parse: 'foo | b | ^ a + ¿. 5 "what'.
-	notices := ast allNotices sorted collect: [ :e | e position asString , ':' , e messageText ] as: Array.
-	self
-		assertCollection: notices
-		equals: #( '17:Unknown character' '27:Unmatched " in comment.' '13:Undeclared variable named a in foo' '20:Unreachable statement' '7:Unused variable' )
 ]
 
 { #category : 'tests - shadowing' }
@@ -296,7 +259,7 @@ OCCompilerTest >> testMethodTempCannotBeReservedWord [
 			should: [
 				OpalCompiler new
 					source: 'method: x | ', name, ' | ', name, ' := 33';
-					permitFaulty: false;
+					strict;
 					compileOrFail ]
 			raise: OCCompilationError ]
 ]
@@ -326,6 +289,31 @@ OCCompilerTest >> testPseudoVariableShadowing [
 	Symbol reservedLiterals do: [ :thePseudoVar |
 			text := 'method |' , thePseudoVar asString , '| ^' , thePseudoVar asString.
 			self compileWithFailBlock: [ :result | self assert: result isError ] ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordAllowedInFaultyMode [
+
+	| method |
+	method := OpalCompiler new
+		          source: 'foo: self ^ self + 1';
+		          permitFaulty: true;
+		          compileOrFail.
+	self assert: method isCompiledMethod
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordAllowedWithPermitShadowing [
+
+	| method |
+	method := OpalCompiler new
+		          source: 'foo: self ^ self + 1';
+		          permitShadowing: true;
+		          compileOrFail.
+	self assert: method isCompiledMethod.
+	self
+		assert: (method ast allNotices anySatisfy: [ :n |
+				 n messageText = 'self is a reserved word and cannot be used as a parameter name' ])
 ]
 
 { #category : 'tests - reserved variables' }
@@ -389,6 +377,16 @@ OCCompilerTest >> testSiblingBlocksTempShadowing [
 		source: 'temp [:temp | ]. [:temp | ]';
 		class: MockForCompilation;
 		compileOrFail
+]
+
+{ #category : 'tests - flags' }
+OCCompilerTest >> testStrictSetsAllPermits [
+
+	| compiler |
+	compiler := OpalCompiler new strict.
+	self deny: compiler permitFaulty.
+	self deny: compiler permitUndeclared.
+	self deny: compiler permitShadowing
 ]
 
 { #category : 'tests' }

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -25,8 +25,7 @@ OCCompilerTest >> compileWithFailBlock: aBlock [
 
 	| result compiler |
 	compiler := MockForCompilation compiler
-		            source: text;
-		            strict.
+		            source: text.
 	result := compiler doCompile.
 	result isError ifTrue: [ aBlock cull: result ]
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -132,11 +132,7 @@ OCCompilerTest >> testInBlockArgumentPseudoVariableShadowing [
 	self initializeErrorMessage.
 	text := 'temp [:thisProcess | ]'.
 
-	self compile.
-
-	self assert: errorMessage equals: nil.
-	self assert: errorLocation equals: nil.
-	self assert: errorSource equals: nil
+	self compileWithFailBlock: [ ^ self fail ]
 ]
 
 { #category : 'tests - shadowing' }
@@ -200,11 +196,97 @@ OCCompilerTest >> testPseudoVariableShadowing [
 	self initializeErrorMessage.
 	text := 'var1 |thisContext| ^thisContext'.
 
-	self compile.
+	self compileWithFailBlock: [ ^ self fail ]
+]
 
-	self assert: errorMessage equals: nil.
-	self assert: errorLocation equals: nil.
-	self assert: errorSource equals: nil
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testBlockArgumentCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method ^ [ :', name, ' | ', name, ' ]';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testBlockTempCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method ^ [ | ', name, ' | ', name, ' ]';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testDoItTempCanShadowReservedWord [
+
+	self
+		assert: (OpalEvaluator new evaluate: '| self | self := 42. ^ self')
+		equals: 42
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testMethodArgumentCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method: ', name, ' ^ ', name;
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testMethodTempCannotBeReservedWord [
+
+	#( #self #super #thisContext #thisProcess ) do: [ :name |
+		self
+			should: [
+				OpalCompiler new
+					source: 'method: x | ', name, ' | ', name, ' := 33';
+					permitFaulty: false;
+					compileOrFail ]
+			raise: OCCompilationError ]
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordErrorMessage [
+
+	| error |
+	text := 'foo: self ^ self + 1'.
+	self
+		compileWithFailBlock: [ :result |
+			self assert: result ast allNotices size equals: 1.
+			error := result ast allNotices first.
+			self assert: error messageText equals: 'self is a reserved word and cannot be used as a parameter name'.
+			self assert: error position equals: 6.
+			^ nil ].
+	self fail
+]
+
+{ #category : 'tests - reserved variables' }
+OCCompilerTest >> testReservedWordErrorMessageForTemp [
+
+	| error |
+	text := 'var1 |thisContext| ^thisContext'.
+	self
+		compileWithFailBlock: [ :result |
+			self assert: result ast allNotices size equals: 1.
+			error := result ast allNotices first.
+			self assert: error messageText equals: 'thisContext is a reserved word and cannot be used as a temporary variable name'.
+			self assert: error position equals: 7.
+			^ nil ].
+	self fail
 ]
 
 { #category : 'literals' }

--- a/src/OpalCompiler-UI/OCInteractiveAPI.class.st
+++ b/src/OpalCompiler-UI/OCInteractiveAPI.class.st
@@ -110,8 +110,8 @@ OCInteractiveAPI >> compilerFor: behavior [
 
 	^ compiler ifNil: [
 			  compiler := behavior compiler
-				              permitUndeclared: self permitUndeclared;
-				              permitFaulty: self permitFaulty ]
+				              permitFaulty: self permitFaulty;
+				              permitUndeclared: self permitUndeclared ]
 ]
 
 { #category : 'initialization' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -487,7 +487,7 @@ RubSmalltalkEditor >> evaluate: source andDo: aBlock [
 			          requestor: self;
 			          context: ctxt;
 			          receiver: rcvr;
-			          permitFaulty: false;
+			          strict;
 			          evaluate ]
 		on: OCCodeError
 		do: [ :err | result := nil ].


### PR DESCRIPTION
- Introduced `strict` mode in `OpalCompiler` which sets the instance variables `permitFaulty, permitUndeclared, permitShadowing` to false. Added setters for those variables.
- Fixes #19895 by introducing the `OCReservedVariableNotice` which **only** produces an exception if the compiler is in strict mode. Now, reserved words (`self`, `super`, `false`)... can't be used as var names.
- Introduced the notice `OCShadowingNotice`. (Name already defined). It produces an exception only if the compiler is in strict mode.
- Tests
- Updated users from `compiler permitFaulty: false` to `compiler strict`

**Question**
What is the default behavior? of the compiler? strict? no strict? We implement the `initialize` method in Opal and we set `self strict: false`?

Currently, no behavior is defined.

*Experimenting with LLMs (Big Pickle). The commits with AI generated code are acknowledged with "made by Big Pickle."*