### PR TITLE
Expose new settings browser

### DIFF
--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -218,7 +218,7 @@ SDLOSXPharoMenu >> doCreatePharoMenu [
 { #category : 'menu options' }
 SDLOSXPharoMenu >> doPreferences [
 
-	UIManager default defer: [ SettingBrowser open ]
+	UIManager default defer: [ (StSettingsBrowser newApplication: StPharoApplication current) open ]
 ]
 
 { #category : 'menu options' }


### PR DESCRIPTION
Instead of the old one, when pressing Cmd+, on MacOS