### PR TITLE
Callsite fix - Overrid method

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyShowLocalImplementorsCommand.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyShowLocalImplementorsCommand.class.st
@@ -56,7 +56,7 @@ ClyShowLocalImplementorsCommand >> execute [
 	query := ClyMessageImplementorsQuery ofAny: selectors from: self createQueryScope.
 	scopedMethods := query execute.
 
-	(Smalltalk tools toolNamed: #messageList) browse: scopedMethods items
+	(Smalltalk tools toolNamed: #messageList) browse: scopedMethods items title: self defaultMenuItemName from: nil  
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
- The method browser was given no title when being called for overridden or overriding methods.
- Now the titles are well passed to the browser, using the `defaultMenuItemName` depending on the called command