### PR TITLE
Add #isSystemPackage to Package

### DIFF
--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -479,6 +479,13 @@ Package >> isPackage [
 ]
 
 { #category : 'testing' }
+Package >> isSystemPackage [
+	"I return true if I (the package) is a package from the basic Pharo image. It means that I was present in the Pharo image during its build."
+
+	^ SystemBuildInfo current systemPackagesIncludes: self
+]
+
+{ #category : 'testing' }
 Package >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
 	 2. Or test package contains '-Tests-' in middle.

--- a/src/System-Support-Tests/SystemBuildInfoTest.class.st
+++ b/src/System-Support-Tests/SystemBuildInfoTest.class.st
@@ -20,6 +20,15 @@ SystemBuildInfoTest >> testIsBuildFinished [
 ]
 
 { #category : 'tests' }
+SystemBuildInfoTest >> testIsSystemPackage [
+
+	| newPackage |
+	self assert: self class package isSystemPackage.
+	newPackage := self packageOrganizer ensurePackage: 'GeneratedPackageForTestsOfSystemBuildInfo'.
+	[ self deny: newPackage isSystemPackage ] ensure: [ newPackage ifNotNil: [ :package | package removeFromSystem ] ]
+]
+
+{ #category : 'tests' }
 SystemBuildInfoTest >> testSystemPackageNames [
 
 	| buildInfo newPackage |

--- a/src/System-Support/SystemBuildInfo.class.st
+++ b/src/System-Support/SystemBuildInfo.class.st
@@ -52,7 +52,7 @@ SystemBuildInfo >> systemPackages [
 	^ self packageOrganizer packages select: [ :package | self systemPackageNames includes: package name ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'testing' }
 SystemBuildInfo >> systemPackagesIncludes: aPackage [
 
 	^ self systemPackageNames includes: aPackage name

--- a/src/System-Support/SystemBuildInfo.class.st
+++ b/src/System-Support/SystemBuildInfo.class.st
@@ -51,3 +51,9 @@ SystemBuildInfo >> systemPackages [
 
 	^ self packageOrganizer packages select: [ :package | self systemPackageNames includes: package name ]
 ]
+
+{ #category : 'accessing' }
+SystemBuildInfo >> systemPackagesIncludes: aPackage [
+
+	^ self systemPackageNames includes: aPackage name
+]


### PR DESCRIPTION
To know if a package is from Pharo or from user installed projects. This could be useful to build tools hidding system packages

*done on my free time*