### PR TITLE
Fix #19900

### DIFF
--- a/src/PragmaCollector-Tests/PragmaCollectorTest.class.st
+++ b/src/PragmaCollector-Tests/PragmaCollectorTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'PragmaCollectorTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'collector'
+	],
+	#category : 'PragmaCollector-Tests',
+	#package : 'PragmaCollector-Tests'
+}
+
+{ #category : 'running' }
+PragmaCollectorTest >> setUp [
+
+	super setUp.
+	collector := PragmaCollector new
+]
+
+{ #category : 'tests' }
+PragmaCollectorTest >> testInstanceCreation [
+
+	self assert: collector announcer notNil.
+	self assert: collector isEmpty
+]
+
+{ #category : 'tests' }
+PragmaCollectorTest >> testRelease [
+
+	collector release.
+	self assert: collector announcer isNil.
+	self assert: collector isEmpty
+]

--- a/src/PragmaCollector-Tests/package.st
+++ b/src/PragmaCollector-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'PragmaCollector-Tests' }

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -274,7 +274,8 @@ PragmaCollector >> pragmas [
 { #category : 'querying' }
 PragmaCollector >> pragmasOfClass: aClass [
 	"return all handlers of class aClass"
-	^ self	select: [:prag | prag methodClass = aClass ]
+
+	^ self select: [:prag | prag methodClass = aClass ]
 ]
 
 { #category : 'enumerating' }
@@ -282,11 +283,11 @@ PragmaCollector >> reject: aBlock [
 	^ self collected reject: aBlock
 ]
 
-{ #category : 'dependents access' }
+{ #category : 'dependencies' }
 PragmaCollector >> release [
 
 	self noMoreNotifications.
-	self destroyAnnouncer.
+	announcer := nil.
 	collected := nil
 ]
 


### PR DESCRIPTION
Add a test to expose the bug and fix the bug.
Also replace a tab with a space in a message.
Move #release to the 'dependencies' protocol, consistent with the protocol of the method on the Object class.