### PR TITLE
fix: move class to correct package

### DIFF
--- a/src/General-Rules/ReNoPrintStringInPrintOnRule.class.st
+++ b/src/General-Rules/ReNoPrintStringInPrintOnRule.class.st
@@ -5,8 +5,8 @@ Using it inside a #printOn: will imply a useless creation of stream and its pass
 Class {
 	#name : 'ReNoPrintStringInPrintOnRule',
 	#superclass : 'ReAbstractRule',
-	#category : 'General-Rules-Tests-Optimization',
-	#package : 'General-Rules-Tests',
+	#category : 'General-Rules-Optimization',
+	#package : 'General-Rules',
 	#tag : 'Optimization'
 }
 


### PR DESCRIPTION
`ReNoPrintStringInPrintOnRule` seems to have inadvertently been placed in the 'General-Rules-Tests' package and clearly belongs in the non-test package.