### PR TITLE
Load the new test package as part of the general tests baseline.

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -44,6 +44,7 @@ BaselineOfGeneralTests >> baseline: spec [
 				package: 'Morphic-Tests';
 				package: 'Morphic-Widgets-FastTable-Tests';
 				package: 'NECompletion-Tests';
+				package: 'PragmaCollector-Tests';
 				package: 'Regex-Core-Tests';
 				package: 'Rubric-Tests';
 				package: 'ScriptingExtensions-Tests';


### PR DESCRIPTION
I forgot this change in the previous PR (#19949). The result was that the new test package was not loaded into the image.