### PR TITLE
Revert "Backport: First version of taskbar drag and drop"

### DIFF
--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -144,60 +144,6 @@ TaskbarMorphTest >> testIfTheTestedMethodIstheSameThatTheOneUsedInProd [
 	self assert: self theMethodInProdThatShouldBeTested bytecodes equals: (self class >> #updateOrderedTasksFrom:) bytecodes
 ]
 
-{ #category : 'tests - drag and drop' }
-TaskbarMorphTest >> testMoveNonExistentTaskIsNoOp [
-	| taskbarMorph task1 task2 unknownTask |
-	taskbarMorph := TaskbarMorph new.
-	task1 := self newTaskWithLabel: 'Task 1'.
-	task2 := self newTaskWithLabel: 'Task 2'.
-	unknownTask := self newTaskWithLabel: 'Unknown'.
-	taskbarMorph orderedTasks: { task1. task2 } asOrderedCollection.
-	taskbarMorph moveTask: unknownTask toIndex: 1.
-
-	self assert: taskbarMorph orderedTasks first equals: task1.
-	self assert: taskbarMorph orderedTasks second equals: task2
-]
-
-{ #category : 'tests - drag and drop' }
-TaskbarMorphTest >> testMoveTaskToIndexChangesOrder [
-	| taskbarMorph task1 task2 task3 |
-	taskbarMorph := TaskbarMorph new.
-	task1 := self newTaskWithLabel: 'Task 1'.
-	task2 := self newTaskWithLabel: 'Task 2'.
-	task3 := self newTaskWithLabel: 'Task 3'.
-	taskbarMorph orderedTasks: { task1. task2. task3 } asOrderedCollection.
-	taskbarMorph moveTask: task3 toIndex: 1.
-
-	self assert: taskbarMorph orderedTasks first equals: task3.
-	self assert: taskbarMorph orderedTasks second equals: task1.
-	self assert: taskbarMorph orderedTasks third equals: task2
-]
-
-{ #category : 'tests - drag and drop' }
-TaskbarMorphTest >> testMoveTaskToOutOfBoundsIndexClamps [
-	| taskbarMorph task1 task2 |
-	taskbarMorph := TaskbarMorph new.
-	task1 := self newTaskWithLabel: 'Task 1'.
-	task2 := self newTaskWithLabel: 'Task 2'.
-	taskbarMorph orderedTasks: { task1. task2 } asOrderedCollection.
-	taskbarMorph moveTask: task1 toIndex: 999.
-
-	self assert: taskbarMorph orderedTasks last equals: task1
-]
-
-{ #category : 'tests - drag and drop' }
-TaskbarMorphTest >> testMoveTaskToSameIndexIsNoOp [
-	| taskbarMorph task1 task2 |
-	taskbarMorph := TaskbarMorph new.
-	task1 := self newTaskWithLabel: 'Task 1'.
-	task2 := self newTaskWithLabel: 'Task 2'.
-	taskbarMorph orderedTasks: { task1. task2 } asOrderedCollection.
-	taskbarMorph moveTask: task1 toIndex: 1.
-
-	self assert: taskbarMorph orderedTasks first equals: task1.
-	self assert: taskbarMorph orderedTasks second equals: task2
-]
-
 { #category : 'tests' }
 TaskbarMorphTest >> testMoveTaskbarTaskLeftDoesNothingOnFirstTask [
 	| firstTask taskbarMorph |

--- a/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
@@ -35,13 +35,6 @@ TaskbarItemMorph >> buildLabelMorph [
 	^ self theme buttonLabelForText: self model taskbarLabel
 ]
 
-{ #category : 'event handling' }
-TaskbarItemMorph >> click: event [
-	"The user clicked (short press) on this button. Activate or minimize the window."
-
-	self performAction: event
-]
-
 { #category : 'style - border' }
 TaskbarItemMorph >> disabledBorderStyle [
 	"Return the disabled borderStyle of the receiver."
@@ -88,7 +81,6 @@ TaskbarItemMorph >> initializeFor: aTaskbar [
 		hResizing: #rigid;
 		vResizing: #rigid;
 		useSquareCorners;
-		dropEnabled: true;
 		getMenuSelector: #taskbarButtonMenu:.
 		
 	"The following code works like this:
@@ -103,36 +95,6 @@ TaskbarItemMorph >> initializeFor: aTaskbar [
 			(self model isCollapsed
 				ifTrue: [ self theme taskbarItemLabelColorForCollapsed: self ]
 				ifFalse: [ self theme taskbarItemLabelColorForExpanded: self ])
-]
-
-{ #category : 'event handling' }
-TaskbarItemMorph >> mouseDown: event [
-	"Set up click-or-drag handling. A short click activates the window;
-	a drag beyond the threshold initiates task reordering."
-
-	event yellowButtonPressed ifTrue: [ ^ super mouseDown: event ].
-	event hand
-		waitForClicksOrDrag: self
-		event: event
-		selectors: #( click: doubleClick: doubleClickTimeout: startDrag: )
-		threshold: 5
-]
-
-{ #category : 'event handling' }
-TaskbarItemMorph >> mouseEnterDragging: event [
-	"The hand is dragging a morph over us. Show a drop indicator bar."
-
-	| taskbar taskIndex |
-	(event hand hasSubmorphs and: [ self dropEnabled ]) ifFalse: [ ^ super mouseEnterDragging: event ].
-
-	taskbar := self owner.
-
-	taskIndex := (taskbar submorphIndexOf: self) ifNil: [ ^ self ]. "In case we close the task really close to the time we move it?"
-
-	"We check that the x position of the morph is before or after half my width to know which index to use."
-	taskbar showDropIndicatorAfterIndex: (event position x - self fullBounds left < (self width / 2)
-			 ifTrue: [ taskIndex - 1 ]
-			 ifFalse: [ taskIndex ]) 
 ]
 
 { #category : 'style - border' }
@@ -231,21 +193,6 @@ TaskbarItemMorph >> selectedPressedFillStyle [
 	"Return the selected pressed fillStyle of the receiver."
 
 	^ self theme taskbarItemSelectedPressedFillStyleFor: self
-]
-
-{ #category : 'drag and drop' }
-TaskbarItemMorph >> startDrag: event [
-	"Initiate a drag operation. Create a TransferMorph carrying the TaskbarTask."
-
-	| taskbar task transferMorph |
-	taskbar := self owner ifNil: [ ^ self ].
-	task := taskbar taskOf: self model.
-	task ifNil: [ ^ self ].
-	transferMorph := self model transferFor: task from: self.
-	transferMorph align: transferMorph center with: event position.
-	event hand
-		grabMorph: transferMorph;
-		releaseMouseFocus: self
 ]
 
 { #category : 'menu' }

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -7,10 +7,7 @@ Class {
 	#superclass : 'Morph',
 	#instVars : [
 		'tasks',
-		'orderedTasks',
-		'dropIndicator',
-		'dropTargetIndex',
-		'lastDraggedTask'
+		'orderedTasks'
 	],
 	#classVars : [
 		'MaximumButtons',
@@ -140,21 +137,6 @@ TaskbarMorph >> displayExtentChanged [
 	self updateBounds
 ]
 
-{ #category : 'drag and drop' }
-TaskbarMorph >> dropIndicatorIndexForX: xPosition [
-	"Answer the submorph index before which to place the drop indicator,
-	based on mouseX compared to button positions. Ignores y-position."
-
-	| buttons |
-	buttons := self submorphs reject: [ :morph | morph = dropIndicator ].
-
-	buttons ifEmpty: [ ^ 1 ].
-
-	buttons doWithIndex: [ :button :index | xPosition < button center x ifTrue: [ ^ index ] ].
-
-	^ buttons size + 1
-]
-
 { #category : 'private - accessing' }
 TaskbarMorph >> edgeToAdhereTo [
 	"Must implement. Answer #bottom."
@@ -185,7 +167,6 @@ TaskbarMorph >> initialize [
 	self
 		initializeLayout;
 		initializeAppearance;
-		dropEnabled: true;
 		tasks: #();
 		orderedTasks: OrderedCollection new
 ]
@@ -296,30 +277,6 @@ TaskbarMorph >> move: task withOffset: offset [
 	^ self updateTaskButtons
 ]
 
-{ #category : 'taskbar' }
-TaskbarMorph >> moveTask: aTask toIndex: targetIndex [
-	"Move aTask to the given index in orderedTasks. Used by drag-and-drop."
-
-	| currentIndex newOrderedTasks adjustedIndex |
-	currentIndex := self orderedTasks indexOf: aTask.
-
-	(currentIndex = 0 or: [ currentIndex = targetIndex ]) ifTrue: [ ^ self ].
-
-	newOrderedTasks := self orderedTasks copy.
-
-	newOrderedTasks removeAt: currentIndex.
-
-	adjustedIndex := targetIndex > currentIndex
-		                 ifTrue: [ targetIndex - 1 ]
-		                 ifFalse: [ targetIndex ].
-
-	newOrderedTasks add: aTask beforeIndex: (adjustedIndex clampBetween: 1 and: newOrderedTasks size + 1).
-
-	self
-		orderedTasks: newOrderedTasks;
-		updateTaskButtons
-]
-
 { #category : 'accessing' }
 TaskbarMorph >> orderedTasks [
 	"Answer the value of orderedTasks"
@@ -355,15 +312,6 @@ TaskbarMorph >> rejectsEvent: anEvent [
 	^ super rejectsEvent: anEvent
 ]
 
-{ #category : 'drag and drop' }
-TaskbarMorph >> removeDropIndicator [
-	"Remove the drop indicator bar."
-
-	dropIndicator ifNotNil: [ :ind | ind delete ].
-	dropIndicator := nil.
-	dropTargetIndex := nil
-]
-
 { #category : 'taskbar' }
 TaskbarMorph >> removeFromWorld [
 	"Delete the receiver from its world after restoring minimized tasks.
@@ -380,57 +328,9 @@ TaskbarMorph >> removeFromWorld [
 	mins do: [ :t | t morph minimize ]
 ]
 
-{ #category : 'drag and drop' }
-TaskbarMorph >> showDropIndicatorAfterIndex: anInteger [
-	"Show a thin vertical bar after the button at the given submorph index."
-
-	| buttonHeight |
-	self removeDropIndicator.
-	self submorphs ifEmpty: [ ^ self ].
-	buttonHeight := self submorphs first height.
-	dropIndicator := Morph new
-		                 color: (self theme taskbarItemLabelColorForExpanded: self);
-		                 extent: 4 @ buttonHeight;
-		                 yourself.
-	dropTargetIndex := anInteger + 1.
-	self addMorph: dropIndicator asElementNumber: dropTargetIndex
-]
-
 { #category : 'setting' }
 TaskbarMorph >> showWindowPreview [
 	^ self class showWindowPreview
-]
-
-{ #category : 'stepping and presenter' }
-TaskbarMorph >> step [
-	"If the hand is dragging a TaskbarTask, update the drop indicator.	When the drag ends, perform the move. We do not do it by overriding a drop event handling of the taskbar because we want to still apply the moving of the task if it's in the world above the bar."
-
-	| hand isDragging task indicatorIndex |
-	hand := self world activeHand ifNil: [ ^ self ].
-	isDragging := hand submorphs anySatisfy: [ :submorph |
-			              (submorph passenger isKindOf: TaskbarTask)
-				              ifTrue: [
-						              task := submorph passenger.
-						              true ]
-				              ifFalse: [ false ] ].
-	isDragging ifFalse: [
-			| targetIndex |
-			targetIndex := dropTargetIndex.
-			self removeDropIndicator.
-			(lastDraggedTask isNotNil and: [ targetIndex isNotNil ]) ifTrue: [ self moveTask: lastDraggedTask toIndex: targetIndex ].
-			lastDraggedTask := nil.
-			^ self ].
-
-	self submorphs ifEmpty: [ ^ self ].
-	lastDraggedTask := task.
-	indicatorIndex := self dropIndicatorIndexForX: hand cursorPoint x.
-	indicatorIndex = dropTargetIndex ifTrue: [ ^ self ].
-	self showDropIndicatorAfterIndex: indicatorIndex - 1
-]
-
-{ #category : 'stepping and presenter' }
-TaskbarMorph >> stepTime [
-	^ 50
 ]
 
 { #category : 'taskbar' }
@@ -504,7 +404,7 @@ TaskbarMorph >> updateTaskButtons [
 	"Make buttons for the ordered tasks."
 
 	| oldButtons size |
-	oldButtons := self submorphs reject: [ :morph | morph = dropIndicator ].
+	oldButtons := self submorphs copy.
 	self removeAllMorphs.
 	self defer: [ oldButtons do: [ :b | b model: nil ] ]. "release dependency after event handling"
 

--- a/src/Morphic-Widgets-Taskbar/TaskbarTask.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarTask.class.st
@@ -44,11 +44,6 @@ TaskbarTask >> activate [
 		ifTrue: [self morph restoreAndActivate]
 ]
 
-{ #category : 'drag and drop' }
-TaskbarTask >> asDraggableMorph [
-	^ StringMorph contents: self label
-]
-
 { #category : 'user-interface' }
 TaskbarTask >> buttonClickedForTaskList: aTasklist [
 	"Notify the tasklist."


### PR DESCRIPTION
Reverts pharo-project/pharo#19955

Because it is failing when dragging windows

<img width="1465" height="761" alt="Image" src="https://github.com/user-attachments/assets/802d916a-860a-4363-9da1-acbd0bce43d0" />