### PR TITLE
Fix #19962: Sanitize fileout file names, fix typo in Fileouter, and register missing tests

### DIFF
--- a/src/BaselineOfCompiler/BaselineOfCompiler.class.st
+++ b/src/BaselineOfCompiler/BaselineOfCompiler.class.st
@@ -51,6 +51,7 @@ BaselineOfCompiler >> baseline: spec [
 				package: 'ClassDefinitionPrinters';
 
 				package: 'CodeExport';
+				package: 'CodeExport-Tests' with: [ spec requires: #( 'CodeExport' ) ];
 				package: 'CodeImport';
 				package: 'CodeImport-Commands';
 				package: 'CodeImport-Tests' with: [ spec requires: #( 'AST-Core-Tests' ) ];
@@ -76,5 +77,5 @@ BaselineOfCompiler >> baseline: spec [
 					'CodeExport'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'. 'OpalCompiler-Core'. 'ParseTreeRewriter'. 'Deprecation' };
 				group: 'Tests'
 				with: { 'Kernel-Extended-Tests'. 'Kernel-Tests-WithCompiler'.
-					'AST-Core-Tests'. 'OpalCompiler-Tests'. 'DebugInfo-Tests'. 'CodeImport-Tests' } ]
+					'AST-Core-Tests'. 'OpalCompiler-Tests'. 'DebugInfo-Tests'. 'CodeImport-Tests'. 'CodeExport-Tests' } ]
 ]

--- a/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
+++ b/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
@@ -32,6 +32,8 @@ BaselineOfSystemCommands >> baseline: spec [
 						#( 'Commander' #'SystemCommands-RefactoringSupport' ) ];
 			package: #'SystemCommands-MethodCommands-Tests'
 			with: [ spec requires: #( #'SystemCommands-MethodCommands' ) ];
+			package: #'SystemCommands-ClassCommands-Tests'
+			with: [ spec requires: #( #'SystemCommands-ClassCommands' ) ];
 			package: #'SystemCommands-PackageCommands'
 			with: [ spec requires: #( 'Commander' ) ];
 			package: #'SystemCommands-PackageCommands-Tests'

--- a/src/CodeExport-Tests/FileNameSanitizerTest.class.st
+++ b/src/CodeExport-Tests/FileNameSanitizerTest.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : 'FileNameSanitizerTest',
+	#superclass : 'TestCase',
+	#category : 'CodeExport-Tests-Utilities',
+	#package : 'CodeExport-Tests',
+	#tag : 'Utilities'
+}
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeCleanName [
+	self assert: (FileNameSanitizer sanitize: 'MyClass') equals: 'MyClass'.
+	self assert: (FileNameSanitizer sanitize: 'Point-x') equals: 'Point-x'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeControlCharacters [
+	| raw |
+	raw := String with: $a with: Character null with: Character cr with: Character lf with: $b.
+	self assert: (FileNameSanitizer sanitize: raw) equals: 'a___b'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeEmptyAndWhitespace [
+	self assert: (FileNameSanitizer sanitize: '') equals: 'unnamed'.
+	self assert: (FileNameSanitizer sanitize: '   ') equals: 'unnamed'.
+	self assert: (FileNameSanitizer sanitize: '...') equals: 'unnamed'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeForbiddenCharacters [
+	| forbidden raw sanitized |
+	forbidden := { $\. $/. $:. $*. $?. $". $<. $>. $| }.
+	raw := String streamContents: [ :s |
+		s nextPutAll: 'foo'.
+		forbidden do: [ :c | s nextPut: c ].
+		s nextPutAll: 'bar' ].
+	sanitized := FileNameSanitizer sanitize: raw.
+	forbidden do: [ :c | self deny: (sanitized includes: c) ].
+	self assert: sanitized equals: 'foo_________bar'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeMethodSelector [
+	self assert: (FileNameSanitizer sanitize: 'Point-at:put:') equals: 'Point-at_put_'.
+	self assert: (FileNameSanitizer sanitize: 'Point-/') equals: 'Point-_'.
+	self assert: (FileNameSanitizer sanitize: 'Point-//') equals: 'Point-__'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeTrailingDotsAndSpaces [
+	self assert: (FileNameSanitizer sanitize: 'test.') equals: 'test'.
+	self assert: (FileNameSanitizer sanitize: 'test...  ') equals: 'test'.
+	self assert: (FileNameSanitizer sanitize: 'test. .st') equals: 'test.st'
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeWindowsReservedNames [
+	#('CON' 'prn' 'Aux' 'NUL' 'com1' 'COM9' 'lpt1' 'LPT9') do: [ :reserved |
+		| sanitized |
+		sanitized := FileNameSanitizer sanitize: reserved.
+		self assert: sanitized equals: '_' , reserved ]
+]
+
+{ #category : 'tests' }
+FileNameSanitizerTest >> testSanitizeWindowsReservedNamesWithExtension [
+	self assert: (FileNameSanitizer sanitize: 'CON.st') equals: '_CON.st'.
+	self assert: (FileNameSanitizer sanitize: 'aux.txt') equals: '_aux.txt'
+]

--- a/src/CodeExport-Tests/FileouterTest.class.st
+++ b/src/CodeExport-Tests/FileouterTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'FileouterTest',
+	#superclass : 'TestCase',
+	#category : 'CodeExport-Tests-Base',
+	#package : 'CodeExport-Tests',
+	#tag : 'Base'
+}
+
+{ #category : 'tests' }
+FileouterTest >> testFileoutClassOnStream [
+	| fileouter stream contents |
+	fileouter := Fileouter new.
+	fileouter addFullClass: Point.
+	stream := String new writeStream.
+	fileouter fileoutOnStream: stream.
+	contents := stream contents.
+
+	self assert: contents isNotEmpty.
+	self assert: (contents includesSubstring: 'Object subclass: #Point')
+]
+
+{ #category : 'tests' }
+FileouterTest >> testFileoutMethodOnStream [
+	| fileouter stream contents |
+	fileouter := Fileouter new.
+	fileouter addMethod: (Point >> #x).
+	stream := String new writeStream.
+	fileouter fileoutOnStream: stream.
+	contents := stream contents.
+
+	self assert: contents isNotEmpty.
+	self assert: (contents includesSubstring: 'Point methodsFor:').
+	self assert: (contents includesSubstring: 'x')
+]

--- a/src/CodeExport-Tests/package.st
+++ b/src/CodeExport-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'CodeExport-Tests' }

--- a/src/CodeExport/ChunkWriteStream.class.st
+++ b/src/CodeExport/ChunkWriteStream.class.st
@@ -11,8 +11,9 @@ Class {
 	#instVars : [
 		'flushChanges'
 	],
-	#category : 'CodeExport',
-	#package : 'CodeExport'
+	#category : 'CodeExport-Utilities',
+	#package : 'CodeExport',
+	#tag : 'Utilities'
 }
 
 { #category : 'writing' }

--- a/src/CodeExport/FileNameSanitizer.class.st
+++ b/src/CodeExport/FileNameSanitizer.class.st
@@ -1,0 +1,44 @@
+"
+I sanitize strings to be valid, cross-platform filenames across Windows, macOS, and Linux. I replace OS-forbidden characters, control characters, and trim trailing dots and whitespace. I also escape reserved device names on Windows (such as CON, PRN, AUX, NUL, COM1-9, LPT1-9).
+"
+Class {
+	#name : 'FileNameSanitizer',
+	#superclass : 'Object',
+	#category : 'CodeExport-Utilities',
+	#package : 'CodeExport',
+	#tag : 'Utilities'
+}
+
+{ #category : 'sanitizing' }
+FileNameSanitizer class >> sanitize: aString [
+	| forbidden reservedNames sanitized dotIndex base ext |
+	forbidden := { $\. $/. $:. $*. $?. $". $<. $>. $| }.
+	reservedNames := #( 'CON' 'PRN' 'AUX' 'NUL'
+		'COM1' 'COM2' 'COM3' 'COM4' 'COM5' 'COM6' 'COM7' 'COM8' 'COM9'
+		'LPT1' 'LPT2' 'LPT3' 'LPT4' 'LPT5' 'LPT6' 'LPT7' 'LPT8' 'LPT9' ).
+
+	sanitized := aString collect: [ :each |
+		(each asciiValue < 32 or: [ each asciiValue = 127 or: [ forbidden includes: each ] ])
+			ifTrue: [ $_ ]
+			ifFalse: [ each ] ].
+
+	sanitized := sanitized trimBoth.
+	sanitized ifEmpty: [ ^ 'unnamed' ].
+
+	dotIndex := sanitized findLast: [ :each | each = $. ].
+	(dotIndex > 1 and: [ dotIndex < sanitized size ])
+		ifTrue: [
+			base := sanitized copyFrom: 1 to: dotIndex - 1.
+			ext := sanitized copyFrom: dotIndex to: sanitized size ]
+		ifFalse: [
+			base := sanitized.
+			ext := '' ].
+
+	base := base trimRight: [ :each | each = $. or: [ each isSeparator ] ].
+	base ifEmpty: [ base := 'unnamed' ].
+
+	(reservedNames includes: base asUppercase)
+		ifTrue: [ base := '_' , base ].
+
+	^ base , ext
+]

--- a/src/SystemCommands-ClassCommands-Tests/SycCmFileOutClassCommandTest.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/SycCmFileOutClassCommandTest.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'SycCmFileOutClassCommandTest',
+	#superclass : 'TestCase',
+	#category : 'SystemCommands-ClassCommands-Tests-Tests',
+	#package : 'SystemCommands-ClassCommands-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+SycCmFileOutClassCommandTest >> testDefaultFileNameForMultipleClasses [
+	| cmd context |
+	cmd := SycCmFileOutClassCommand new.
+	context := SycMockClassContext new.
+	context selectedObjects: { Point . Rectangle }.
+	cmd context: context.
+	cmd prepareFullExecution.
+	self assert: cmd defaultFileName equals: 'classfileout'
+]
+
+{ #category : 'tests' }
+SycCmFileOutClassCommandTest >> testDefaultFileNameForSingleClass [
+	| cmd context |
+	cmd := SycCmFileOutClassCommand new.
+	context := SycMockClassContext new.
+	context selectedObjects: { Point }.
+	cmd context: context.
+	cmd prepareFullExecution.
+	self assert: cmd defaultFileName equals: 'Point'
+]

--- a/src/SystemCommands-ClassCommands-Tests/SycMockClassContext.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/SycMockClassContext.class.st
@@ -1,0 +1,23 @@
+"
+A mock of context for testing commands
+"
+Class {
+	#name : 'SycMockClassContext',
+	#superclass : 'Object',
+	#instVars : [
+		'selectedObjects'
+	],
+	#category : 'SystemCommands-ClassCommands-Tests-Tests',
+	#package : 'SystemCommands-ClassCommands-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'accessing' }
+SycMockClassContext >> selectedObjects [
+	^ selectedObjects ifNil: [ #() ]
+]
+
+{ #category : 'accessing' }
+SycMockClassContext >> selectedObjects: aCollection [
+	selectedObjects := aCollection
+]

--- a/src/SystemCommands-ClassCommands/SycCmFileOutClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmFileOutClassCommand.class.st
@@ -20,6 +20,13 @@ Class {
 }
 
 { #category : 'accessing' }
+SycCmFileOutClassCommand >> defaultFileName [
+	^ codeObjects size = 1
+		ifTrue: [ codeObjects first name ]
+		ifFalse: [ 'classfileout' ]
+]
+
+{ #category : 'accessing' }
 SycCmFileOutClassCommand >> description [
 
 	^ 'Requests to save a textual version of the selected class to a new file in chunk format and .st extension. Instance and class side methods are both saved'
@@ -27,15 +34,9 @@ SycCmFileOutClassCommand >> description [
 
 { #category : 'executing' }
 SycCmFileOutClassCommand >> executeRefactoring [
-
-	| filename |
-	filename := codeObjects size = 1
-		            ifTrue: [ codeObjects first name ]
-		            ifFalse: [ 'classfileout' ].
-
 	^ Fileouter
-		fileoutNamed: filename
-		cofigureWith: [ :fileouter | 
+		fileoutNamed: self defaultFileName
+		configureWith: [ :fileouter | 
 			codeObjects do: [ :each | fileouter addFullClass: each ] ]
 ]
 

--- a/src/SystemCommands-MethodCommands-Tests/SycConvertTempToinstVarCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycConvertTempToinstVarCommandTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SycConvertTempToinstVarCommandTest',
 	#superclass : 'TestCase',
-	#category : 'SystemCommands-MethodCommands-Tests',
-	#package : 'SystemCommands-MethodCommands-Tests'
+	#category : 'SystemCommands-MethodCommands-Tests-Tests',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'tests' }

--- a/src/SystemCommands-MethodCommands-Tests/SycFileOutMethodCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycFileOutMethodCommandTest.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : 'SycFileOutMethodCommandTest',
+	#superclass : 'TestCase',
+	#category : 'SystemCommands-MethodCommands-Tests-Tests',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+SycFileOutMethodCommandTest >> testDefaultFileNameForEmptyMethods [
+	| cmd context |
+	cmd := SycFileOutMethodCommand new.
+	context := SycMockMethodContext new.
+	context selectedMethods: #(  ).
+	cmd context: context.
+	self assert: cmd defaultFileName equals: 'methodsfileout'
+]
+
+{ #category : 'tests' }
+SycFileOutMethodCommandTest >> testDefaultFileNameForMultipleMethods [
+	| cmd context |
+	cmd := SycFileOutMethodCommand new.
+	context := SycMockMethodContext new.
+	context selectedMethods: { Point >> #x . Point >> #y }.
+	cmd context: context.
+	self assert: cmd defaultFileName equals: 'methodsfileout'
+]
+
+{ #category : 'tests' }
+SycFileOutMethodCommandTest >> testDefaultFileNameForSingleBinaryMethod [
+	| cmd context |
+	cmd := SycFileOutMethodCommand new.
+	context := SycMockMethodContext new.
+	context selectedMethods: { Point >> #+ }.
+	cmd context: context.
+	self assert: cmd defaultFileName equals: 'Point-+'
+]
+
+{ #category : 'tests' }
+SycFileOutMethodCommandTest >> testDefaultFileNameForSingleKeywordMethod [
+	| cmd context |
+	cmd := SycFileOutMethodCommand new.
+	context := SycMockMethodContext new.
+	context selectedMethods: { Point >> #setX:setY: }.
+	cmd context: context.
+	self assert: cmd defaultFileName equals: 'Point-setX:setY:'
+]
+
+{ #category : 'tests' }
+SycFileOutMethodCommandTest >> testDefaultFileNameForSingleUnaryMethod [
+	| cmd context |
+	cmd := SycFileOutMethodCommand new.
+	context := SycMockMethodContext new.
+	context selectedMethods: { Point >> #x }.
+	cmd context: context.
+	self assert: cmd defaultFileName equals: 'Point-x'
+]

--- a/src/SystemCommands-MethodCommands-Tests/SycInlineTempCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycInlineTempCommandTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SycInlineTempCommandTest',
 	#superclass : 'TestCase',
-	#category : 'SystemCommands-MethodCommands-Tests',
-	#package : 'SystemCommands-MethodCommands-Tests'
+	#category : 'SystemCommands-MethodCommands-Tests-Tests',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'tests' }

--- a/src/SystemCommands-MethodCommands-Tests/SycMockMethodContext.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycMockMethodContext.class.st
@@ -1,0 +1,23 @@
+"
+A mock of context for testing commands
+"
+Class {
+	#name : 'SycMockMethodContext',
+	#superclass : 'Object',
+	#instVars : [
+		'selectedMethods'
+	],
+	#category : 'SystemCommands-MethodCommands-Tests-TestData',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'TestData'
+}
+
+{ #category : 'accessing' }
+SycMockMethodContext >> selectedMethods [
+	^ selectedMethods ifNil: [ #() ]
+]
+
+{ #category : 'accessing' }
+SycMockMethodContext >> selectedMethods: aCollection [
+	selectedMethods := aCollection
+]

--- a/src/SystemCommands-MethodCommands-Tests/SycRenameArgOrTempCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycRenameArgOrTempCommandTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'SycRenameArgOrTempCommandTest',
 	#superclass : 'TestCase',
-	#category : 'SystemCommands-MethodCommands-Tests',
-	#package : 'SystemCommands-MethodCommands-Tests'
+	#category : 'SystemCommands-MethodCommands-Tests-Tests',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'tests' }

--- a/src/SystemCommands-MethodCommands-Tests/SycSourceCodeRefactoringCommandTest.class.st
+++ b/src/SystemCommands-MethodCommands-Tests/SycSourceCodeRefactoringCommandTest.class.st
@@ -6,8 +6,9 @@ Class {
 		'method',
 		'pc'
 	],
-	#category : 'SystemCommands-MethodCommands-Tests',
-	#package : 'SystemCommands-MethodCommands-Tests'
+	#category : 'SystemCommands-MethodCommands-Tests-Tests',
+	#package : 'SystemCommands-MethodCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'building suites' }

--- a/src/SystemCommands-MethodCommands/SycFileOutMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycFileOutMethodCommand.class.st
@@ -9,6 +9,16 @@ Class {
 }
 
 { #category : 'accessing' }
+SycFileOutMethodCommand >> defaultFileName [
+	| method |
+	^ self methods size = 1
+		ifTrue: [
+			method := self methods first.
+			method methodClass name , '-' , method selector ]
+		ifFalse: [ 'methodsfileout' ]
+]
+
+{ #category : 'accessing' }
 SycFileOutMethodCommand >> description [
 
 	^ 'Requests to save a textual version of the selected class to a new file in chunk format and .st extension. Instance and class side methods are both saved'
@@ -16,15 +26,9 @@ SycFileOutMethodCommand >> description [
 
 { #category : 'executing' }
 SycFileOutMethodCommand >> executeRefactoring [
-
-	| filename |
-	filename := self methods size = 1
-		            ifTrue: [ self methods first name ]
-		            ifFalse: [ 'methodsfileout' ].
-
 	^ Fileouter
-		fileoutNamed: filename
-		cofigureWith: [ :fileouter | 
+		fileoutNamed: self defaultFileName
+		configureWith: [ :fileouter | 
 			self methods do: [ :each | fileouter addMethod: each ] ]
 ]
 

--- a/src/SystemCommands-PackageCommands-Tests/SycAddNewPackageCommandTest.class.st
+++ b/src/SystemCommands-PackageCommands-Tests/SycAddNewPackageCommandTest.class.st
@@ -4,8 +4,9 @@ A SycAddNewPackageCommandTest is a test class for testing the behavior of SycAdd
 Class {
 	#name : 'SycAddNewPackageCommandTest',
 	#superclass : 'TestCase',
-	#category : 'SystemCommands-PackageCommands-Tests',
-	#package : 'SystemCommands-PackageCommands-Tests'
+	#category : 'SystemCommands-PackageCommands-Tests-Tests',
+	#package : 'SystemCommands-PackageCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'tests' }

--- a/src/SystemCommands-PackageCommands-Tests/SycFileOutPackageCommandTest.class.st
+++ b/src/SystemCommands-PackageCommands-Tests/SycFileOutPackageCommandTest.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'SycFileOutPackageCommandTest',
+	#superclass : 'TestCase',
+	#category : 'SystemCommands-PackageCommands-Tests-Tests',
+	#package : 'SystemCommands-PackageCommands-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+SycFileOutPackageCommandTest >> testDefaultFileNameForMultiplePackages [
+	| cmd pkg1 pkg2 |
+	cmd := SycFileOutPackageCommand new.
+	pkg1 := self packageOrganizer packageNamed: 'CodeExport'.
+	pkg2 := self packageOrganizer packageNamed: 'Kernel'.
+	cmd packages: { pkg1 . pkg2 }.
+	self assert: cmd defaultFileName equals: 'packagefileout'
+]
+
+{ #category : 'tests' }
+SycFileOutPackageCommandTest >> testDefaultFileNameForSinglePackage [
+	| cmd pkg |
+	cmd := SycFileOutPackageCommand new.
+	pkg := self packageOrganizer packageNamed: 'CodeExport'.
+	cmd packages: { pkg }.
+	self assert: cmd defaultFileName equals: 'CodeExport'
+]

--- a/src/SystemCommands-PackageCommands-Tests/SycRemoveNewPackageCommandTest.class.st
+++ b/src/SystemCommands-PackageCommands-Tests/SycRemoveNewPackageCommandTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'mockPackage'
 	],
-	#category : 'SystemCommands-PackageCommands-Tests',
-	#package : 'SystemCommands-PackageCommands-Tests'
+	#category : 'SystemCommands-PackageCommands-Tests-Tests',
+	#package : 'SystemCommands-PackageCommands-Tests',
+	#tag : 'Tests'
 }
 
 { #category : 'accessing' }

--- a/src/SystemCommands-PackageCommands/SycFileOutPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycFileOutPackageCommand.class.st
@@ -18,6 +18,13 @@ SycFileOutPackageCommand class >> fullBrowserMenuActivation [
 ]
 
 { #category : 'accessing' }
+SycFileOutPackageCommand >> defaultFileName [
+	^ packages size = 1
+		ifTrue: [ packages first name ]
+		ifFalse: [ 'packagefileout' ]
+]
+
+{ #category : 'accessing' }
 SycFileOutPackageCommand >> defaultMenuIconName [
 
 	^ #save
@@ -31,14 +38,8 @@ SycFileOutPackageCommand >> defaultMenuItemName [
 
 { #category : 'execution' }
 SycFileOutPackageCommand >> execute [
-
-	| filename |
-	filename := packages size = 1
-		            ifTrue: [ packages first name ]
-		            ifFalse: [ 'packagefileout' ].
-
 	^ Fileouter
-		fileoutNamed: filename
-		cofigureWith: [ :fileouter |
+		fileoutNamed: self defaultFileName
+		configureWith: [ :fileouter |
 			packages do: [ :each | fileouter addFullPackage: each ] ]
 ]

--- a/src/SystemCommands-SourceCodeCommands/Fileouter.extension.st
+++ b/src/SystemCommands-SourceCodeCommands/Fileouter.extension.st
@@ -2,25 +2,36 @@ Extension { #name : 'Fileouter' }
 
 { #category : '*SystemCommands-SourceCodeCommands' }
 Fileouter class >> fileoutNamed: filename cofigureWith: aBlock [
+	self
+		deprecated: 'Use #fileoutNamed:configureWith: instead'
+		transformWith: '`@rec fileoutNamed: `@arg1 cofigureWith: `@arg2'
+			-> '`@rec fileoutNamed: `@arg1 configureWith: `@arg2'.
+	^ self fileoutNamed: filename configureWith: aBlock
+]
 
-	| fileRef dialog ok |
+{ #category : '*SystemCommands-SourceCodeCommands' }
+Fileouter class >> fileoutNamed: filename configureWith: aBlock [
+	| fileRef dialog ok safeName suggestedName |
+	safeName := FileNameSanitizer sanitize: filename.
+	suggestedName := (safeName asLowercase endsWith: '.st')
+		ifTrue: [ safeName ]
+		ifFalse: [ safeName , '.st' ].
 	StSaveFilePresenter new
 		defaultFolder: FileLocator workingDirectory;
-		nameText: filename , '.st';
+		nameText: suggestedName;
 		okAction: [ :fileReference |
-				| fileouter |
-				fileRef := fileReference.
-				fileouter := self new.
-				aBlock value: fileouter.
-				fileouter fileoutOnFileReference: fileReference.
-
-				dialog := SpConfirmDialog new.
-				ok := dialog
-					      title: 'Do you want to browse natively the fileout?';
-					      message: 'Are you sure?';
-					      acceptLabel: 'Sure!';
-					      cancelLabel: 'No, forget it';
-					      openModal.
-				ok ifTrue: [ fileRef openInOSFileBrowser ] ];
+			| fileouter |
+			fileRef := fileReference.
+			fileouter := self new.
+			aBlock value: fileouter.
+			fileouter fileoutOnFileReference: fileReference.
+			dialog := SpConfirmDialog new.
+			ok := dialog
+				title: 'Do you want to browse natively the fileout?';
+				message: 'Are you sure?';
+				acceptLabel: 'Sure!';
+				cancelLabel: 'No, forget it';
+				openModal.
+			ok ifTrue: [ fileRef openInOSFileBrowser ] ];
 		openModal
 ]


### PR DESCRIPTION
Fixes #19962

- **Filename sanitization**: Introduced `FileNameSanitizer` in `CodeExport` (`Utilities` tag) to safely handle OS-reserved device names (e.g., `CON`, `PRN`), control characters, forbidden path characters (`/`, `\`, `:`, etc.), and trailing dots/whitespace across platforms.
- **Typo fix & deprecation**: Renamed `Fileouter class >> #fileoutNamed:cofigureWith:` to `#fileoutNamed:configureWith:`, leaving the old selector deprecated with transformation rules.
- **Commands**: Extracted and cleaned up `#defaultFileName` generation across `SycFileOutMethodCommand`, `SycCmFileOutClassCommand`, and `SycFileOutPackageCommand`.
- **Tests & Baselines**:
  - Created `CodeExport-Tests` containing tests for `FileNameSanitizer` and `Fileouter`; registered in `BaselineOfCompiler`.
  - Added unit tests for fileout commands using local mock contexts.
  - Registered the previously missing `SystemCommands-ClassCommands-Tests` package in `BaselineOfSystemCommands`.
- **Maintenance**: Added missing tags to untagged classes in `CodeExport` (`ChunkWriteStream`) and `SystemCommands-ClassCommands-Tests`.

Disclaimer: The code and the description above are AI-generated under my supervision, the code is checked by me, fileouts are working.